### PR TITLE
Add initial docs, assets, and Supabase schema

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,259 @@
+# FACODI — Estrutura proposta do repositório `facodi-docs` e conteúdo dos arquivos de configuração
+
+> **Objetivo**: manter todo o conteúdo académico em Markdown, versionado e pronto para sincronização com o Supabase (Postgres). Este repositório é **só de conteúdo** + **configs de sincronização/validação**.
+
+---
+
+## 1) Estrutura de pastas (árvore)
+
+```bash
+facodi-docs/
+├─ README.md
+├─ .github/
+│ └─ workflows/
+│ ├─ validate-md.yml
+│ └─ sync-md-to-supabase.yml
+├─ config/
+│ ├─ _default/
+├─ scripts/
+├─ package.json
+├─ package-lock.json
+├─ content/
+│ ├─ _index.md
+│ └─ courses/
+│ └─ LESTI/
+│ └─ 2024-2025/
+│ ├─ index.md
+│ └─ uc/
+│ ├─ LESTI-ALG1/
+│ │ ├─ index.md
+│ │ └─ estruturas-de-dados.md
+│ └─ LESTI-BD1/
+│ └─ index.md
+├─ static/ (opcional: imagens anexas ao conteúdo)
+│ └─ courses/
+│ └─ ...
+└─ schemas/ (opcional: documentação de esquema e seeds)
+├─ README.md
+├─ mapping.md
+└─ examples/
+└─ frontmatter-samples.md
+```
+
+---
+
+## 2) Convenção de front‑matter (YAML) dos `.md`
+
+### 2.1 Curso (`content/courses/<curso>/<versao>/index.md`)
+
+```yaml
+---
+code: "LESTI"
+title: "Licenciatura em Engenharia de Sistemas e Tecnologias da Informação"
+degree: "bachelor" # bachelor|master|integrated_master|phd|other
+ects_total: 180
+duration_semesters: 6
+plan_version: "2024/2025"
+institution: "UAlg"
+school: "EST"
+language: "pt"
+summary: "Descrição do curso, objetivos e perfil de saída."
+seo:
+  title: "LESTI — UAlg"
+  description: "Plano curricular, UCs e trilhas de estudo"
+---
+
+Corpo do Markdown com apresentação do curso.
+```
+
+### 2.2 UC (`content/courses/<curso>/<versao>/uc/<uc_code>/index.md`)
+
+```yaml
+---
+code: "LESTI-ALG1"
+title: "Algoritmos e Estruturas de Dados I"
+description: "Introdução a algoritmos e estruturas de dados."
+ects: 6
+semester: 1
+language: "pt"
+prerequisites: ["LESTI-MAT1"]
+learning_outcomes:
+  - "Compreender complexidade de algoritmos"
+  - "Implementar estruturas básicas (listas, pilhas, filas)"
+youtube_playlists:
+  - id: "PL_abc123" # playlistId do YouTube
+    priority: 1
+  - id: "PL_def456"
+    priority: 2
+topics:
+  - slug: "estruturas-de-dados"
+  - slug: "analise-de-algoritmos"
+---
+
+Ementa detalhada, metodologia, bibliografia.
+```
+
+### 2.3 Tópico da UC (`content/courses/<curso>/<versao>/uc/<uc_code>/<topic>.md`)
+
+```yaml
+---
+slug: "estruturas-de-dados"
+title: "Estruturas de Dados"
+summary: "Conceitos e aplicações."
+youtube_playlists:
+  - id: "PL_topico_01"
+    priority: 1
+tags: ["estrutura", "listas", "pilhas"]
+---
+
+Conteúdo específico do tópico.
+```
+
+> **Nota**: o corpo Markdown de cada ficheiro será persistido no Postgres (coluna `content_md`) para renderização no portal.
+
+---
+
+### 3.3 `.gitignore`
+
+```gitignore
+node_modules/
+.DS_Store
+.env
+.env.local
+.cache/
+```
+
+### 3.9 `config/sync.config.json`
+
+```json
+{
+  "supabaseUrl": "${SUPABASE_URL}",
+  "supabaseAnonKey": "${SUPABASE_ANON_KEY}",
+  "schemas": {
+    "uc": {
+      "match": "content/courses/*/*/uc/*/index.md",
+      "mapFrontmatter": {
+        "code": "catalog.uc.code",
+        "title": "catalog.uc.name",
+        "description": "catalog.uc.description",
+        "ects": "catalog.uc.ects",
+        "semester": "catalog.uc.semester",
+        "language": "catalog.uc.language",
+        "prerequisites": "catalog.uc.prerequisites",
+        "learning_outcomes": "catalog.uc_learning_outcome[]",
+        "youtube_playlists": "mapping.uc_playlist[]",
+        "topics": "mapping.uc_topic[]"
+      },
+      "contentField": "catalog.uc_content.content_md"
+    },
+    "topic": {
+      "match": "content/courses/*/*/uc/*/*.md",
+      "mapFrontmatter": {
+        "slug": "subjects.topic.slug",
+        "title": "subjects.topic.name",
+        "tags": "subjects.topic_tag[]",
+        "youtube_playlists": "mapping.topic_playlist[]"
+      },
+      "contentField": "subjects.topic_content.content_md"
+    }
+  }
+}
+```
+
+> **Observação**: este arquivo mapeia *front‑matter* → colunas no Postgres e define onde o corpo do Markdown é persistido.
+
+### 3.10 `.github/workflows/validate-md.yml`
+
+```yaml
+name: Validate Markdown
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run validate
+```
+
+### 3.11 `.github/workflows/sync-md-to-supabase.yml`
+
+```yaml
+name: Sync MD → Supabase
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'content/**.md'
+      - 'config/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Run sync
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: npm run sync:md:db
+```
+
+### 3.12 `scripts/utils/supabase.ts`
+
+```ts
+import { createClient } from "@supabase/supabase-js";
+
+export const supabaseAdmin = () => {
+  const url = process.env.SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_KEY!;
+  return createClient(url, key, { auth: { persistSession: false } });
+};
+```
+
+---
+
+## 4) Boas práticas
+
+* **Single Source of Truth**: o `.md` é a fonte de verdade editorial; o DB reflete e indexa.
+* **PRs obrigatórios**: mudanças estruturais (novas UCs, playlists) passam por revisão via PR.
+* **Validação**: o CI bloqueia merges se `lint:md` ou mapeamentos obrigatórios faltarem (ex.: `code`, `plan_version`).
+* **Sincronização reversa**: toda ação editorial feita via portal (p.ex. aprovar playlist) deve abrir PR para manter o repositório fiel.
+* **i18n**: usar `config/i18n.json` para sinalizar idiomas; variações por idioma podem viver em caminhos paralelos (`content/en/...`).
+
+---
+
+## 5) Variáveis de ambiente (para CI/scripts)
+
+Crie um `.env.local` (não commitado) com:
+
+```
+SUPABASE_URL=...
+SUPABASE_ANON_KEY=...
+SUPABASE_SERVICE_KEY=...
+```
+
+No GitHub, configure **Actions Secrets** com as mesmas chaves.
+
+---
+
+## 6) Próximos passos
+
+1. Popular `content/` com os primeiros cursos/UCs.
+2. Implementar o `upsertUC` e o upsert de tópicos/playlists.
+3. Ligar o `youtube-refresh.ts` à Edge Function/cron.
+4. Activar os *workflows* e testar a sincronização ponta‑a‑ponta.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FACODI — Faculdade Comunitária Digital
 
-**FACODI** é uma plataforma EAD gratuita e open-source inspirada nos planos curriculares da Universidade do Algarve (UALG).  
+**FACODI** é uma plataforma EAD gratuita e open-source inspirada nos planos curriculares da Universidade do Algarve (UALG).
 Nosso objetivo é **democratizar o acesso ao ensino superior** por meio de trilhas de estudo organizadas em cursos, unidades curriculares e playlists do YouTube.
 
 🚀 Projeto mantido pela [Monynha Softwares](https://monynha.com).
@@ -18,34 +18,50 @@ Nosso objetivo é **democratizar o acesso ao ensino superior** por meio de trilh
 
 ---
 
-## 🏗️ Arquitetura
+<!-- ## 🏗️ Arquitetura
 
-- **Frontend**: [Next.js 14](https://nextjs.org) (App Router)  
-- **Banco de Dados**: [PostgreSQL + Supabase](https://supabase.com)  
-- **Docs**: Arquivos `.md` sincronizados com banco  
-- **Infra**: Deploy automatizado via [Coolify](https://coolify.io) em servidor Hetzner  
-- **Design**: UI baseada em [shadcn/ui](https://ui.shadcn.com) + Tailwind + tokens Monynha  
+- **Frontend**: [Next.js 14](https://nextjs.org) (App Router)
+- **Banco de Dados**: [PostgreSQL + Supabase](https://supabase.com)
+- **Docs**: Arquivos `.md` sincronizados com banco
+- **Infra**: Deploy automatizado via [Coolify](https://coolify.io) em servidor Hetzner
+- **Design**: UI baseada em [shadcn/ui](https://ui.shadcn.com) + Tailwind + tokens Monynha
 
----
+--- -->
 
 ## 📂 Estrutura do Repositório
 
 ```bash
-facodi.pt/
-├── apps/
-│   ├── web/        # Frontend Next.js (portal EAD)
-│   ├── cms/        # Payload CMS (admin de conteúdos)
-│   └── docs/       # Markdown acadêmico versionado
-├── supabase/
-│   ├── migrations/ # Schemas, RLS e seeds
-│   └── functions/  # Edge Functions
-├── packages/
-│   ├── ui/         # Componentes React compartilhados
-│   ├── i18n/       # Internacionalização
-│   ├── supabase/   # Cliente tipado do banco
-│   └── config/     # Tailwind, ESLint, etc.
-└── .github/
-    └── workflows/  # CI/CD com GitHub Actions
+facodi-docs/
+├─ README.md
+├─ .github/
+│ └─ workflows/
+│ ├─ validate-md.yml
+│ └─ sync-md-to-supabase.yml
+├─ config/
+│ ├─ _default/
+├─ scripts/
+├─ package.json
+├─ package-lock.json
+├─ content/
+│ ├─ _index.md
+│ └─ courses/
+│ └─ LESTI/
+│ └─ 2024-2025/
+│ ├─ index.md
+│ └─ uc/
+│ ├─ LESTI-ALG1/
+│ │ ├─ index.md
+│ │ └─ estruturas-de-dados.md
+│ └─ LESTI-BD1/
+│ └─ index.md
+├─ static/ (opcional: imagens anexas ao conteúdo)
+│ └─ courses/
+│ └─ ...
+└─ schemas/ (opcional: documentação de esquema e seeds)
+├─ README.md
+├─ mapping.md
+└─ examples/
+└─ frontmatter-samples.md
 ````
 
 ---

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600">
+  <defs>
+    <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFAC33" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#7C3AED" stop-opacity="0.7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="600" fill="url(#grad2)" />
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em"
+    font-family="Inter, sans-serif"
+    font-size="180"
+    font-weight="900"
+    fill="rgba(255,255,255,0.15)">
+    FACODI
+  </text>
+</svg>

--- a/assets/svgs/logo.svg
+++ b/assets/svgs/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FFAC33"/>
+      <stop offset="50%" stop-color="#0EA5E9"/>
+      <stop offset="100%" stop-color="#EC4899"/>
+    </linearGradient>
+  </defs>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em"
+    font-family="Inter, sans-serif"
+    font-size="72"
+    font-weight="700"
+    fill="url(#grad)">
+    FACODI
+  </text>
+</svg>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,1 @@
+project_id = "epozcdnlzgxivhehfcoi"

--- a/supabase/migrations/20250714090915-f247db9d-d3d0-412c-b176-ca92ad4b6976.sql
+++ b/supabase/migrations/20250714090915-f247db9d-d3d0-412c-b176-ca92ad4b6976.sql
@@ -1,0 +1,61 @@
+-- Criar tabela de perfis para usuários
+CREATE TABLE public.perfis (
+  id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
+  universidade_id UUID,
+  nome TEXT NOT NULL,
+  avatar_url TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Habilitar RLS
+ALTER TABLE public.perfis ENABLE ROW LEVEL SECURITY;
+
+-- Políticas RLS para perfis
+CREATE POLICY "Usuários podem ver todos os perfis" 
+ON public.perfis 
+FOR SELECT 
+USING (true);
+
+CREATE POLICY "Usuários podem inserir seu próprio perfil" 
+ON public.perfis 
+FOR INSERT 
+WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Usuários podem atualizar seu próprio perfil" 
+ON public.perfis 
+FOR UPDATE 
+USING (auth.uid() = id);
+
+-- Função para criar perfil automaticamente
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.perfis (id, nome)
+  VALUES (
+    NEW.id, 
+    COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.email)
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger para criar perfil automaticamente
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Função para atualizar timestamps
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger para atualizar timestamps
+CREATE TRIGGER update_perfis_updated_at
+  BEFORE UPDATE ON public.perfis
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20250720085227-5202529a-51ca-4361-b73b-d453a8ae77db.sql
+++ b/supabase/migrations/20250720085227-5202529a-51ca-4361-b73b-d453a8ae77db.sql
@@ -1,0 +1,327 @@
+
+-- Criar tabela de universidades
+CREATE TABLE public.universidades (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  nome TEXT NOT NULL,
+  sigla TEXT,
+  pais TEXT DEFAULT 'Portugal',
+  cidade TEXT,
+  website TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Criar tabela de cursos
+CREATE TABLE public.cursos (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  universidade_id UUID REFERENCES public.universidades(id) ON DELETE CASCADE,
+  nome TEXT NOT NULL,
+  descricao TEXT,
+  duracao_semestres INTEGER DEFAULT 8,
+  ects_total INTEGER DEFAULT 180,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Criar tabela de unidades curriculares
+CREATE TABLE public.unidades_curriculares (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  nome TEXT NOT NULL,
+  descricao TEXT,
+  ects INTEGER NOT NULL DEFAULT 6,
+  semestre INTEGER NOT NULL,
+  ano_curricular INTEGER DEFAULT 1,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Tabela de associação curso-unidades
+CREATE TABLE public.cursos_unidades (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  curso_id UUID REFERENCES public.cursos(id) ON DELETE CASCADE,
+  unidade_id UUID REFERENCES public.unidades_curriculares(id) ON DELETE CASCADE,
+  obrigatoria BOOLEAN DEFAULT true,
+  UNIQUE(curso_id, unidade_id)
+);
+
+-- Criar tabela de conteúdos
+CREATE TABLE public.conteudos (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  titulo TEXT NOT NULL,
+  descricao TEXT,
+  tipo TEXT CHECK (tipo IN ('video', 'artigo', 'exercicio', 'projeto', 'livro')) DEFAULT 'artigo',
+  url TEXT,
+  duracao_minutos INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Tabela de associação unidade-conteúdos
+CREATE TABLE public.unidades_conteudos (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  unidade_id UUID REFERENCES public.unidades_curriculares(id) ON DELETE CASCADE,
+  conteudo_id UUID REFERENCES public.conteudos(id) ON DELETE CASCADE,
+  ordem INTEGER DEFAULT 1,
+  UNIQUE(unidade_id, conteudo_id)
+);
+
+-- Criar tabela de tags
+CREATE TABLE public.tags (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  nome TEXT NOT NULL UNIQUE,
+  cor TEXT DEFAULT '#3B82F6',
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Tabela de associação conteúdo-tags
+CREATE TABLE public.conteudos_tags (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  conteudo_id UUID REFERENCES public.conteudos(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES public.tags(id) ON DELETE CASCADE,
+  UNIQUE(conteudo_id, tag_id)
+);
+
+-- Criar tabela de inscrições em cursos
+CREATE TABLE public.usuarios_cursos (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  curso_id UUID REFERENCES public.cursos(id) ON DELETE CASCADE,
+  data_inscricao TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  ativo BOOLEAN DEFAULT true,
+  UNIQUE(user_id, curso_id)
+);
+
+-- Criar tabela de progresso
+CREATE TABLE public.progresso (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  unidade_id UUID REFERENCES public.unidades_curriculares(id) ON DELETE CASCADE,
+  conteudo_id UUID REFERENCES public.conteudos(id) ON DELETE CASCADE,
+  concluido BOOLEAN DEFAULT false,
+  data_conclusao TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE(user_id, unidade_id, conteudo_id)
+);
+
+-- Criar tabela de comentários
+CREATE TABLE public.comentarios (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  unidade_id UUID REFERENCES public.unidades_curriculares(id) ON DELETE CASCADE,
+  conteudo_id UUID REFERENCES public.conteudos(id),
+  texto TEXT NOT NULL,
+  curtidas INTEGER DEFAULT 0,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Criar tabela de repositório
+CREATE TABLE public.repositorios (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  titulo TEXT NOT NULL,
+  descricao TEXT,
+  arquivo_url TEXT NOT NULL,
+  tipo_arquivo TEXT,
+  tamanho_kb INTEGER,
+  aprovado BOOLEAN DEFAULT false,
+  downloads INTEGER DEFAULT 0,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Habilitar RLS nas tabelas que precisam de segurança
+ALTER TABLE public.usuarios_cursos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.progresso ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.comentarios ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.repositorios ENABLE ROW LEVEL SECURITY;
+
+-- Políticas para usuarios_cursos
+CREATE POLICY "Usuários podem ver suas próprias inscrições" 
+ON public.usuarios_cursos 
+FOR SELECT 
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem se inscrever em cursos" 
+ON public.usuarios_cursos 
+FOR INSERT 
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem atualizar suas inscrições" 
+ON public.usuarios_cursos 
+FOR UPDATE 
+USING (auth.uid() = user_id);
+
+-- Políticas para progresso
+CREATE POLICY "Usuários podem ver seu próprio progresso" 
+ON public.progresso 
+FOR SELECT 
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem inserir seu próprio progresso" 
+ON public.progresso 
+FOR INSERT 
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem atualizar seu próprio progresso" 
+ON public.progresso 
+FOR UPDATE 
+USING (auth.uid() = user_id);
+
+-- Políticas para comentários
+CREATE POLICY "Todos podem ver comentários" 
+ON public.comentarios 
+FOR SELECT 
+USING (true);
+
+CREATE POLICY "Usuários podem inserir seus próprios comentários" 
+ON public.comentarios 
+FOR INSERT 
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem atualizar seus próprios comentários" 
+ON public.comentarios 
+FOR UPDATE 
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem deletar seus próprios comentários" 
+ON public.comentarios 
+FOR DELETE 
+USING (auth.uid() = user_id);
+
+-- Políticas para repositorios
+CREATE POLICY "Todos podem ver materiais aprovados" 
+ON public.repositorios 
+FOR SELECT 
+USING (aprovado = true OR auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem inserir seus próprios materiais" 
+ON public.repositorios 
+FOR INSERT 
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem atualizar seus próprios materiais" 
+ON public.repositorios 
+FOR UPDATE 
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Usuários podem deletar seus próprios materiais" 
+ON public.repositorios 
+FOR DELETE 
+USING (auth.uid() = user_id);
+
+-- Triggers para updated_at
+CREATE TRIGGER update_universidades_updated_at
+  BEFORE UPDATE ON public.universidades
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_cursos_updated_at
+  BEFORE UPDATE ON public.cursos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_unidades_curriculares_updated_at
+  BEFORE UPDATE ON public.unidades_curriculares
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_conteudos_updated_at
+  BEFORE UPDATE ON public.conteudos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_progresso_updated_at
+  BEFORE UPDATE ON public.progresso
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_comentarios_updated_at
+  BEFORE UPDATE ON public.comentarios
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_repositorios_updated_at
+  BEFORE UPDATE ON public.repositorios
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Inserir dados de exemplo da UAlg
+INSERT INTO public.universidades (nome, sigla, cidade, website)
+VALUES ('Universidade do Algarve', 'UAlg', 'Faro', 'https://www.ualg.pt')
+ON CONFLICT DO NOTHING;
+
+-- Inserir curso de Engenharia de Sistemas
+INSERT INTO public.cursos (universidade_id, nome, descricao, duracao_semestres, ects_total)
+SELECT id,
+  'Engenharia de Sistemas e Tecnologias Informáticas',
+  'Curso focado no desenvolvimento de sistemas de informação e tecnologias emergentes',
+  6,
+  180
+FROM public.universidades
+WHERE sigla = 'UAlg'
+ON CONFLICT DO NOTHING;
+
+-- Inserir tags populares
+INSERT INTO public.tags (nome, cor) VALUES
+  ('Programação', '#3B82F6'),
+  ('Sistemas Operativos', '#10B981'),
+  ('Bases de Dados', '#F59E0B'),
+  ('Redes', '#EF4444'),
+  ('Algoritmos', '#8B5CF6'),
+  ('Web Development', '#06B6D4'),
+  ('Inteligência Artificial', '#F97316'),
+  ('Cibersegurança', '#EC4899')
+ON CONFLICT (nome) DO NOTHING;
+
+-- Inserir unidades curriculares do 1º ano
+INSERT INTO public.unidades_curriculares (nome, descricao, ects, semestre, ano_curricular) VALUES
+  ('Programação I', 'Introdução à programação com Python', 6, 1, 1),
+  ('Matemática Discreta', 'Fundamentos matemáticos para informática', 6, 1, 1),
+  ('Introdução aos Sistemas de Informação', 'Conceitos básicos de sistemas de informação', 6, 1, 1),
+  ('Programação II', 'Programação orientada a objetos', 6, 2, 1),
+  ('Estruturas de Dados', 'Algoritmos e estruturas de dados fundamentais', 6, 2, 1),
+  ('Bases de Dados I', 'Modelação e consulta de bases de dados', 6, 2, 1)
+ON CONFLICT DO NOTHING;
+
+-- Associar unidades ao curso
+INSERT INTO public.cursos_unidades (curso_id, unidade_id, obrigatoria)
+SELECT c.id, u.id, true
+FROM public.cursos c, public.unidades_curriculares u
+WHERE c.nome = 'Engenharia de Sistemas e Tecnologias Informáticas'
+ON CONFLICT (curso_id, unidade_id) DO NOTHING;
+
+-- Inserir conteúdos de exemplo
+INSERT INTO public.conteudos (titulo, descricao, tipo, url, duracao_minutos) VALUES
+('Python para Iniciantes', 'Tutorial completo de Python', 'video', 'https://www.youtube.com/watch?v=example1', 120),
+('Algoritmos de Ordenação', 'Explicação dos principais algoritmos', 'artigo', 'https://example.com/algoritmos', 45),
+('Projeto: Sistema de Gestão', 'Desenvolvimento de um sistema simples', 'projeto', null, 300),
+('Exercícios de Programação', 'Lista de exercícios práticos', 'exercicio', null, 60)
+ON CONFLICT DO NOTHING;
+
+-- Associar conteúdos às unidades
+INSERT INTO public.unidades_conteudos (unidade_id, conteudo_id, ordem)
+SELECT u.id, c.id, 1
+FROM public.unidades_curriculares u, public.conteudos c
+WHERE u.nome = 'Programação I' AND c.titulo = 'Python para Iniciantes'
+ON CONFLICT (unidade_id, conteudo_id) DO NOTHING;
+
+INSERT INTO public.unidades_conteudos (unidade_id, conteudo_id, ordem)
+SELECT u.id, c.id, 2
+FROM public.unidades_curriculares u, public.conteudos c
+WHERE u.nome = 'Estruturas de Dados' AND c.titulo = 'Algoritmos de Ordenação'
+ON CONFLICT (unidade_id, conteudo_id) DO NOTHING;
+
+-- Associar tags aos conteúdos
+INSERT INTO public.conteudos_tags (conteudo_id, tag_id)
+SELECT c.id, t.id
+FROM public.conteudos c, public.tags t
+WHERE c.titulo = 'Python para Iniciantes' AND t.nome = 'Programação'
+ON CONFLICT (conteudo_id, tag_id) DO NOTHING;
+
+INSERT INTO public.conteudos_tags (conteudo_id, tag_id)
+SELECT c.id, t.id
+FROM public.conteudos c, public.tags t
+WHERE c.titulo = 'Algoritmos de Ordenação' AND t.nome = 'Algoritmos'
+ON CONFLICT (conteudo_id, tag_id) DO NOTHING;

--- a/supabase/migrations/20250801000000-ea65739e-828a-4b2e-a4c4-5961ebdd1d14.sql
+++ b/supabase/migrations/20250801000000-ea65739e-828a-4b2e-a4c4-5961ebdd1d14.sql
@@ -1,0 +1,160 @@
+-- PHASE 1: Fix Profile Creation and RLS
+
+-- Create a function to automatically create a profile when a user registers
+CREATE OR REPLACE FUNCTION public.create_new_user_profile()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO public.profiles (user_id, name, email)
+    VALUES (NEW.id, NEW.raw_user_meta_data->>'name' || NEW.email, NEW.email);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Create a trigger to call the function
+CREATE TRIGGER create_profile_for_new_user
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.create_new_user_profile();
+
+-- Fix RLS Policy for Profiles
+CREATE OR REPLACE FUNCTION public.is_profile_owner()
+RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN auth.uid() = (SELECT user_id FROM public.profiles WHERE id = current_setting('request.jwt.claims', true)::jsonb->>'profile_id');
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Implement RLS Policy
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Profiles are viewable by user" ON public.profiles;
+CREATE POLICY "Profiles are viewable by user" ON public.profiles
+    FOR ALL USING (public.is_profile_owner());
+
+-- PHASE 2: Implement Blog Comments System
+
+-- Create Blog Comments Table
+CREATE TABLE public.blog_comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    blog_post_id UUID REFERENCES public.blog_posts(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    content TEXT NOT NULL,
+    parent_comment_id UUID REFERENCES public.blog_comments(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.blog_comments ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Users can view comments" ON public.blog_comments FOR SELECT USING (true);
+CREATE POLICY "Authenticated users can insert comments" ON public.blog_comments 
+    FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "Users can update their own comments" ON public.blog_comments 
+    FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete their own comments" ON public.blog_comments 
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- PHASE 3: Normalize Tags System
+
+-- Enhance Tags Table
+ALTER TABLE public.tags ADD COLUMN description TEXT;
+ALTER TABLE public.tags ADD COLUMN category TEXT;
+
+-- Create a more robust repository_tags view
+CREATE OR REPLACE VIEW public.repository_tag_details AS
+SELECT 
+    rt.repository_id, 
+    r.name as repository_name,
+    rt.tag_id, 
+    t.name as tag_name,
+    t.slug as tag_slug,
+    t.category as tag_category
+FROM 
+    public.repository_tags rt
+JOIN 
+    public.repositories r ON rt.repository_id = r.id
+JOIN 
+    public.tags t ON rt.tag_id = t.id;
+
+-- Create a function to manage tags more efficiently
+CREATE OR REPLACE FUNCTION public.add_repository_tag(
+    p_repository_name TEXT, 
+    p_tag_name TEXT, 
+    p_tag_category TEXT DEFAULT NULL
+)
+RETURNS VOID AS $$
+DECLARE 
+    v_repository_id UUID;
+    v_tag_id INT;
+BEGIN
+    -- Find or create repository
+    SELECT id INTO v_repository_id FROM public.repositories WHERE name = p_repository_name;
+    
+    -- Find or create tag
+    INSERT INTO public.tags (name, slug, category)
+    VALUES (p_tag_name, lower(replace(p_tag_name, ' ', '-')), p_tag_category)
+    ON CONFLICT (name) DO UPDATE SET category = COALESCE(p_tag_category, tags.category)
+    RETURNING id INTO v_tag_id;
+    
+    -- Add repository tag if not exists
+    INSERT INTO public.repository_tags (repository_id, tag_id)
+    VALUES (v_repository_id, v_tag_id)
+    ON CONFLICT DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;
+
+-- PHASE 4: Improve Analytics Tracking
+
+-- Enhance Analytics Events
+ALTER TABLE public.analytics_events 
+ADD COLUMN session_id TEXT,
+ADD COLUMN page_url TEXT,
+ADD COLUMN browser TEXT,
+ADD COLUMN device_type TEXT;
+
+-- Create a function to log page views
+CREATE OR REPLACE FUNCTION public.log_page_view(
+    p_user_id UUID DEFAULT NULL,
+    p_page_url TEXT DEFAULT NULL,
+    p_browser TEXT DEFAULT NULL,
+    p_device_type TEXT DEFAULT NULL
+)
+RETURNS VOID AS $$
+BEGIN
+    INSERT INTO public.analytics_events (
+        user_id, 
+        event_type, 
+        payload,
+        page_url,
+        browser,
+        device_type
+    ) VALUES (
+        p_user_id,
+        'page_view',
+        jsonb_build_object(
+            'page_url', p_page_url,
+            'browser', p_browser,
+            'device_type', p_device_type
+        ),
+        p_page_url,
+        p_browser,
+        p_device_type
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- PHASE 5: SEO and Metadata Improvements
+
+-- Add SEO metadata to blog posts
+ALTER TABLE public.blog_posts 
+ADD COLUMN meta_description TEXT,
+ADD COLUMN keywords TEXT[],
+ADD COLUMN canonical_url TEXT;
+
+-- Add SEO metadata to solutions
+ALTER TABLE public.solutions 
+ADD COLUMN meta_description TEXT,
+ADD COLUMN keywords TEXT[],
+ADD COLUMN canonical_url TEXT;
+


### PR DESCRIPTION
Introduces repository structure and content plan in PLAN.md, updates README to reflect new docs-only repo, adds hero and logo SVG assets, and sets up Supabase config and migrations for user profiles, courses, units, content, tags, comments, repositories, and analytics. Includes RLS policies, triggers, and seed data for academic content management.