### PR TITLE
Sanitize Supabase content before rendering

### DIFF
--- a/static/js/loaders.js
+++ b/static/js/loaders.js
@@ -1,6 +1,15 @@
 (function () {
   const messages = window.__FACODI_I18N__ || {};
 
+  function escapeHTML(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function resolve(path) {
     if (!path) {
       return undefined;
@@ -41,21 +50,25 @@
     if (window.marked && typeof window.marked.parse === 'function') {
       return window.marked.parse(md);
     }
-    const escaped = md
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+    const escaped = escapeHTML(md);
     return '<p>' + escaped.replace(/\n{2,}/g, '</p><p>').replace(/\n/g, '<br />') + '</p>';
   }
 
   function toText(value, fallback = '—') {
+    const safeFallback = escapeHTML(fallback);
     if (Array.isArray(value)) {
-      return value.length ? value.join(', ') : fallback;
+      if (!value.length) {
+        return safeFallback;
+      }
+      return value
+        .map((item) => (item === null || item === undefined ? '' : escapeHTML(item)))
+        .filter((item) => item.length > 0)
+        .join(', ') || safeFallback;
     }
     if (value === null || value === undefined || value === '') {
-      return fallback;
+      return safeFallback;
     }
-    return value;
+    return escapeHTML(value);
   }
 
   function durationLabel(value) {
@@ -376,7 +389,7 @@
         throw topicContentError;
       }
 
-      const summaryHtml = topic.summary ? `<p class="fw-semibold">${topic.summary}</p>` : '';
+      const summaryHtml = topic.summary ? `<p class="fw-semibold">${escapeHTML(topic.summary)}</p>` : '';
       if (topicContent && topicContent.content_md) {
         contentEl.innerHTML = summaryHtml + renderMarkdown(topicContent.content_md);
       } else {


### PR DESCRIPTION
## Summary
- escape Supabase values before writing them into the DOM to avoid script injection
- reuse the same sanitizer in the Markdown fallback renderer and topic summaries

## Testing
- npm run lint:content

------
https://chatgpt.com/codex/tasks/task_e_68cf01918d308322bc30fb1a78d65519