### PR TITLE
Add LESTI 2025/2026 curriculum content

### DIFF
--- a/content/pt/courses/LESTI/2025-2026/index.md
+++ b/content/pt/courses/LESTI/2025-2026/index.md
@@ -1,0 +1,29 @@
+---
+title: "Licenciatura em Engenharia de Sistemas e Tecnologias da Informação"
+code: "LESTI"
+degree: "bachelor"
+ects_total: 180
+duration_semesters: 6
+plan_version: "2025/2026"
+institution: "Universidade do Algarve"
+school: "Escola Superior de Tecnologia"
+language: "pt"
+summary: "Plano curricular renovado com foco em engenharia de software, ciência de dados e integração com a indústria."
+seo:
+  title: "LESTI — Plano 2025/2026"
+  description: "Plano curricular completo, unidades curriculares e tópicos de estudo."
+type: course
+layout: course
+---
+
+
+## Visão Geral
+
+A edição 2025/2026 da Licenciatura em Engenharia de Sistemas e Tecnologias da Informação (LESTI) fortalece o equilíbrio entre bases científicas, desenvolvimento de software e competências profissionais. O plano integra matemática avançada, programação, sistemas distribuídos e projetos em contexto real, preparando os estudantes para colaborar com equipas multidisciplinares e para continuarem estudos pós-graduados.
+
+## Destaques do Plano
+
+- Integração progressiva de práticas colaborativas, engenharia de software e ciência de dados.
+- Trilhas optativas em Eletrónica/Energia (EE), Ciências Informáticas (CI) e Qualidade e Acessibilidade (QAC) através de unidades optativas temáticas.
+- Projetos em empresa e trabalho final com ênfase em impacto real, documentação e apresentação profissional.
+- Conteúdos alinhados com referenciais internacionais e com a utilização de tecnologias abertas e plataformas cloud.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/ambiente-desenvolvimento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/ambiente-desenvolvimento.md
@@ -1,0 +1,19 @@
+---
+slug: "ambiente-desenvolvimento"
+title: "Ambiente de Desenvolvimento"
+summary: "Configuração de IDEs, ferramentas de execução e depuração de programas."
+youtube_playlists:
+  - id: "PL-TOPIC-ambiente-desenvolvimento"
+    priority: 1
+tags:
+  - "IDE"
+  - "ferramentas"
+  - "depuração"
+type: topic
+layout: topic
+---
+Configuração e uso de um ambiente de programação (IDE/editors) e ferramentas necessárias para
+escrever, executar e depurar códigos.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/estruturas-controle.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/estruturas-controle.md
@@ -1,0 +1,20 @@
+---
+slug: "estruturas-controle"
+title: "Estruturas de Controlo"
+summary: "Utilização de condicionais e laços para controlar o fluxo de execução."
+youtube_playlists:
+  - id: "PL-TOPIC-estruturas-controle"
+    priority: 1
+tags:
+  - "condicionais"
+  - "loops"
+  - "controle de fluxo"
+type: topic
+layout: topic
+---
+Uso de estruturas condicionais (if/else, switch/case) para guiar o fluxo do programa, e laços de
+repetição (for, while, do-while) para executar blocos de código múltiplas vezes consoante uma
+condição.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/estruturas-dados-simples.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/estruturas-dados-simples.md
@@ -1,0 +1,19 @@
+---
+slug: "estruturas-dados-simples"
+title: "Estruturas de Dados Simples"
+summary: "Listas, arrays e coleções básicas para armazenar conjuntos de dados."
+youtube_playlists:
+  - id: "PL-TOPIC-estruturas-dados-simples"
+    priority: 1
+tags:
+  - "arrays"
+  - "listas"
+  - "coleções"
+type: topic
+layout: topic
+---
+Introdução a estruturas como arrays (vetores, listas) para armazenar coleções de dados, operações de
+iteração e manipulação dessas estruturas.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/ficherios-excecoes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/ficherios-excecoes.md
@@ -1,0 +1,20 @@
+---
+slug: "ficherios-excecoes"
+title: "Ficheiros e Exceções"
+summary: "Leitura/escrita em ficheiros e tratamento de erros em tempo de execução."
+youtube_playlists:
+  - id: "PL-TOPIC-ficherios-excecoes"
+    priority: 1
+tags:
+  - "ficheiros"
+  - "exceções"
+  - "robustez"
+type: topic
+layout: topic
+---
+Leitura e escrita em arquivos do sistema (criação, abertura, fecho, leitura linha a linha, escrita)
+e tratamento de exceções/erros durante a execução do programa, garantindo robustez (ex.: usar blocos
+try/except).
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/fundamentos-programacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/fundamentos-programacao.md
@@ -1,0 +1,19 @@
+---
+slug: "fundamentos-programacao"
+title: "Fundamentos de Programação"
+summary: "Pensamento algorítmico e decomposição de problemas para implementação em código."
+youtube_playlists:
+  - id: "PL-TOPIC-fundamentos-programacao"
+    priority: 1
+tags:
+  - "algoritmos"
+  - "lógica"
+  - "pensamento computacional"
+type: topic
+layout: topic
+---
+Noções iniciais de programação, incluindo como traduzir problemas em algoritmos e compreender a
+importância de pensar logicamente para resolver tarefas computacionais.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/index.md
@@ -1,0 +1,44 @@
+---
+title: "Programação"
+code: "19411000"
+course_code: "LESTI"
+description: "Fundamentos de algoritmia e programação em Python com enfoque prático."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Construir algoritmos para resolver problemas simples usando pensamento computacional."
+  - "Implementar programas em Python utilizando estruturas de controlo, funções e coleções básicas."
+  - "Manipular ficheiros e tratar exceções garantindo robustez no código."
+youtube_playlists:
+  - id: "PL-19411000-aulas"
+    priority: 1
+  - id: "PL-19411000-laboratorios"
+    priority: 2
+topics:
+  - slug: "fundamentos-programacao"
+  - slug: "ambiente-desenvolvimento"
+  - slug: "variaveis-tipos"
+  - slug: "io-basico"
+  - slug: "estruturas-controle"
+  - slug: "modularizacao"
+  - slug: "estruturas-dados-simples"
+  - slug: "strings"
+  - slug: "ficherios-excecoes"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos básicos de programação, algoritmia e resolução de problemas.
+- Ambientes de desenvolvimento, edição, execução e depuração de programas.
+- Variáveis, tipos primitivos, entrada e saída padrão.
+- Estruturas condicionais, ciclos iterativos e boas práticas de controlo de fluxo.
+- Funções, procedimentos e noções de escopo.
+- Estruturas de dados básicas: listas, dicionários e tuplos.
+- Manipulação de strings, leitura e escrita em ficheiros, tratamento de exceções.
+
+## Metodologia
+
+A UC privilegia aulas laboratoriais hands-on com desafios incrementais e feedback contínuo através de plataformas de avaliação automática.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/io-basico.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/io-basico.md
@@ -1,0 +1,19 @@
+---
+slug: "io-basico"
+title: "Entrada e Saída Básica"
+summary: "Leitura de dados do utilizador e escrita formatada no ecrã."
+youtube_playlists:
+  - id: "PL-TOPIC-io-basico"
+    priority: 1
+tags:
+  - "input"
+  - "output"
+  - "formatação"
+type: topic
+layout: topic
+---
+Operações básicas de input/output – ler entradas do utilizador (ex.: teclado) e produzir saída
+formatada no ecrã, entendendo funções de leitura e escrita.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/modularizacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/modularizacao.md
@@ -1,0 +1,20 @@
+---
+slug: "modularizacao"
+title: "Modularização"
+summary: "Definição de funções e procedimentos com parâmetros, retorno e escopo."
+youtube_playlists:
+  - id: "PL-TOPIC-modularizacao"
+    priority: 1
+tags:
+  - "funções"
+  - "procedimentos"
+  - "escopo"
+type: topic
+layout: topic
+---
+Definição e chamada de funções/procedimentos para estruturar o código de forma modular, passando
+parâmetros por valor ou referência, obtendo retornos e compreendendo escopo de variáveis
+(local/global).
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/strings.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/strings.md
@@ -1,0 +1,19 @@
+---
+slug: "strings"
+title: "Strings"
+summary: "Manipulação de sequências de caracteres e uso de funções de texto."
+youtube_playlists:
+  - id: "PL-TOPIC-strings"
+    priority: 1
+tags:
+  - "texto"
+  - "caracteres"
+  - "manipulação"
+type: topic
+layout: topic
+---
+Manipulação de sequências de caracteres – operações comuns como concatenação, fatiamento (slicing),
+pesquisa de padrões e funções de biblioteca para processamento de texto.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411000/variaveis-tipos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411000/variaveis-tipos.md
@@ -1,0 +1,19 @@
+---
+slug: "variaveis-tipos"
+title: "Variáveis e Tipos"
+summary: "Declaração, atribuição e manipulação de tipos primitivos na memória."
+youtube_playlists:
+  - id: "PL-TOPIC-variaveis-tipos"
+    priority: 1
+tags:
+  - "variáveis"
+  - "tipos"
+  - "memória"
+type: topic
+layout: topic
+---
+Conceitos de variável, atribuição de valores, tipos de dados primitivos (números, caracteres,
+booleanos etc.) e como esses tipos são manipulados em memória.
+
+As aulas práticas utilizam Python e desafios incrementais, incentivando boas práticas de
+versionamento e testes desde o início da aprendizagem.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/controlo-de-versao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/controlo-de-versao.md
@@ -1,0 +1,19 @@
+---
+slug: "controlo-de-versao"
+title: "Controlo de Versão"
+summary: "Conceitos de repositórios, commits, branches e merges com Git."
+youtube_playlists:
+  - id: "PL-TOPIC-controlo-de-versao"
+    priority: 1
+tags:
+  - "Git"
+  - "versionamento"
+  - "branches"
+type: topic
+layout: topic
+---
+Conceitos de versionamento de código (repositórios, commits, branches, merges) com ferramentas como
+Git/GitHub, permitindo trabalho simultâneo de vários desenvolvedores.
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/documentacao-codigo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/documentacao-codigo.md
@@ -1,0 +1,19 @@
+---
+slug: "documentacao-codigo"
+title: "Documentação de Código"
+summary: "Boas práticas de código autocomentado e geração automática de documentação."
+youtube_playlists:
+  - id: "PL-TOPIC-documentacao-codigo"
+    priority: 1
+tags:
+  - "comentários"
+  - "Javadoc"
+  - "Sphinx"
+type: topic
+layout: topic
+---
+Especificação de boas práticas para escrever código autocomentado, uso de ferramentas para geração
+de documentação a partir do código-fonte (como Javadoc, Sphinx, etc.).
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/documentacao-colaborativa.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/documentacao-colaborativa.md
@@ -1,0 +1,20 @@
+---
+slug: "documentacao-colaborativa"
+title: "Documentação Colaborativa"
+summary: "Uso de wikis e markdown para manter documentação viva de projetos."
+youtube_playlists:
+  - id: "PL-TOPIC-documentacao-colaborativa"
+    priority: 1
+tags:
+  - "documentação"
+  - "wiki"
+  - "markdown"
+type: topic
+layout: topic
+---
+Criação e manutenção de documentação viva do projeto via wikis ou markdown dentro de repositórios,
+assegurando que informações sobre requisitos, arquitetura e uso do software estejam acessíveis e
+atualizadas.
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/gestao-de-projetos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/gestao-de-projetos.md
@@ -1,0 +1,19 @@
+---
+slug: "gestao-de-projetos"
+title: "Gestão de Projetos"
+summary: "Planeamento e acompanhamento de tarefas com ferramentas de gestão colaborativa."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-de-projetos"
+    priority: 1
+tags:
+  - "planeamento"
+  - "cronograma"
+  - "equipa"
+type: topic
+layout: topic
+---
+Utilização de software de gestão de projetos (como Trello, Jira ou similares) para organizar
+tarefas, cronogramas e recursos num projeto de desenvolvimento.
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/ides-colaborativos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/ides-colaborativos.md
@@ -1,0 +1,19 @@
+---
+slug: "ides-colaborativos"
+title: "IDEs Colaborativos"
+summary: "Configuração de ambientes de desenvolvimento que suportam trabalho em equipa."
+youtube_playlists:
+  - id: "PL-TOPIC-ides-colaborativos"
+    priority: 1
+tags:
+  - "IDE"
+  - "colaboração"
+  - "ferramentas"
+type: topic
+layout: topic
+---
+Configuração e uso de IDEs e plataformas de desenvolvimento que permitem colaboração em tempo real
+ou facilitam o trabalho em equipa (p.ex., Visual Studio Code com Live Share).
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/index.md
@@ -1,0 +1,40 @@
+---
+title: "Ambientes de Desenvolvimento Colaborativo"
+code: "19411001"
+course_code: "LESTI"
+description: "Ferramentas e práticas colaborativas para planeamento, versionamento e documentação de software."
+ects: 5
+semester: 2
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Configurar fluxos de trabalho colaborativos com sistemas de gestão de projetos e controlo de versões."
+  - "Documentar código e processos de desenvolvimento utilizando wikis e padrões de escrita técnica."
+  - "Monitorizar progresso de projetos através de issues, boards e métricas de equipa."
+youtube_playlists:
+  - id: "PL-19411001-aulas"
+    priority: 1
+  - id: "PL-19411001-oficinas"
+    priority: 2
+topics:
+  - slug: "gestao-de-projetos"
+  - slug: "ides-colaborativos"
+  - slug: "controlo-de-versao"
+  - slug: "documentacao-colaborativa"
+  - slug: "documentacao-codigo"
+  - slug: "rastreamento-issues"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Sistemas de gestão de projetos e acompanhamento de tarefas.
+- Plataformas colaborativas e IDEs com suporte a programação em equipa.
+- Conceitos de repositórios Git, branching, merges e workflows distribuídos.
+- Uso de wikis e documentação viva para projetos de software.
+- Boas práticas de documentação de código e geração automática de referências.
+- Sistemas de issue tracking e métricas de acompanhamento.
+
+## Metodologia
+
+A UC é orientada por projetos curtos onde as equipas configuram ferramentas reais, definem convenções e executam sprints simulados com reuniões de acompanhamento.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411001/rastreamento-issues.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411001/rastreamento-issues.md
@@ -1,0 +1,19 @@
+---
+slug: "rastreamento-issues"
+title: "Rastreamento de Issues"
+summary: "Registo e acompanhamento do ciclo de vida de bugs e tarefas."
+youtube_playlists:
+  - id: "PL-TOPIC-rastreamento-issues"
+    priority: 1
+tags:
+  - "issues"
+  - "bugs"
+  - "prioridades"
+type: topic
+layout: topic
+---
+Uso de sistemas de issue tracking para registro de bugs, pedidos de funcionalidades e acompanhamento
+do ciclo de vida de cada issue até resolução, atribuindo responsáveis e prioridades.
+
+Cada equipa organiza sprints simuladas, partilha documentação viva e acompanha métricas reais para
+criar hábitos profissionais de trabalho colaborativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411002/calculo-diferencial.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411002/calculo-diferencial.md
@@ -1,0 +1,19 @@
+---
+slug: "calculo-diferencial"
+title: "Cálculo Diferencial"
+summary: "Limites, continuidade, derivadas e aplicações em otimização e séries de Taylor."
+youtube_playlists:
+  - id: "PL-TOPIC-calculo-diferencial"
+    priority: 1
+tags:
+  - "derivadas"
+  - "limites"
+  - "Taylor"
+type: topic
+layout: topic
+---
+Limites e continuidade de funções reais; cálculo de derivadas e diferenciais; utilização do
+polinómio de Taylor para aproximação de funções; análise de extremos (otimização).
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411002/calculo-integral.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411002/calculo-integral.md
@@ -1,0 +1,19 @@
+---
+slug: "calculo-integral"
+title: "Cálculo Integral"
+summary: "Primitivas, integrais definidos e aplicações a áreas, comprimentos e volumes."
+youtube_playlists:
+  - id: "PL-TOPIC-calculo-integral"
+    priority: 1
+tags:
+  - "integrais"
+  - "áreas"
+  - "volumes"
+type: topic
+layout: topic
+---
+Cálculo de primitivas e integrais definidas; aplicação da integração no cálculo de áreas de regiões
+planas, comprimentos de curvas e volumes de sólidos de revolução.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411002/funcoes-basicas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411002/funcoes-basicas.md
@@ -1,0 +1,19 @@
+---
+slug: "funcoes-basicas"
+title: "Funções Básicas"
+summary: "Estudo de funções reais elementares, composição, inversa, implícita e paramétrica."
+youtube_playlists:
+  - id: "PL-TOPIC-funcoes-basicas"
+    priority: 1
+tags:
+  - "funções"
+  - "transcendentes"
+  - "composição"
+type: topic
+layout: topic
+---
+Conceitos iniciais de funções de ℝ em ℝ, incluindo funções elementares e transcendentes, composição
+de funções, inversa, implícita e funções definidas parametricamente.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411002/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411002/index.md
@@ -1,0 +1,36 @@
+---
+title: "Análise Matemática I"
+code: "19411002"
+course_code: "LESTI"
+description: "Introdução ao cálculo diferencial e integral de funções reais de variável real."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Compreender propriedades dos números reais e interpretar limites e continuidade."
+  - "Calcular derivadas e integrais de funções elementares aplicando-as a problemas de otimização."
+  - "Utilizar séries de Taylor e integrais definidos em aplicações geométricas e físicas."
+youtube_playlists:
+  - id: "PL-19411002-aulas"
+    priority: 1
+  - id: "PL-19411002-exercicios"
+    priority: 2
+topics:
+  - slug: "numeros-reais"
+  - slug: "funcoes-basicas"
+  - slug: "calculo-diferencial"
+  - slug: "calculo-integral"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conjuntos numéricos, propriedades e intervalos nos reais.
+- Funções reais, funções elementares, composição, inversa, implícita e paramétrica.
+- Limites, continuidade, derivadas, diferenciais e polinómio de Taylor.
+- Primitivas, integrais definidos e aplicações em áreas, comprimentos e volumes de revolução.
+
+## Metodologia
+
+As aulas intercalam exposições teóricas com exercícios resolvidos em sala, apoiados por ferramentas digitais para visualização de gráficos e simulação de problemas físicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411002/numeros-reais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411002/numeros-reais.md
@@ -1,0 +1,19 @@
+---
+slug: "numeros-reais"
+title: "Números Reais"
+summary: "Revisão de conjuntos numéricos, propriedades básicas e intervalos limitados."
+youtube_playlists:
+  - id: "PL-TOPIC-numeros-reais"
+    priority: 1
+tags:
+  - "números"
+  - "intervalos"
+  - "propriedades"
+type: topic
+layout: topic
+---
+Revisão dos conjuntos numéricos (N, Z, Q, R), suas propriedades fundamentais, definição de
+intervalos e conceito de conjunto limitado.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/calculo-vetorial-e-produtos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/calculo-vetorial-e-produtos.md
@@ -1,0 +1,20 @@
+---
+slug: "calculo-vetorial-e-produtos"
+title: "Cálculo Vetorial e Produtos"
+summary: "Produto interno, ortogonalização e produtos externo e misto aplicados à geometria."
+youtube_playlists:
+  - id: "PL-TOPIC-calculo-vetorial-e-produtos"
+    priority: 1
+tags:
+  - "produto interno"
+  - "Gram-Schmidt"
+  - "geometria"
+type: topic
+layout: topic
+---
+Produto interno de vetores (conceito, propriedades, aplicações); ortogonalização de Gram-Schmidt;
+produto externo e misto (conceitos geométricos, propriedades, aplicações).
+
+Nas sessões de Álgebra Linear os exercícios combinam manipulação simbólica e interpretação
+geométrica, recorrendo a ferramentas como GeoGebra ou Octave para consolidar a intuição espacial em
+aplicações de engenharia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/espacos-vetoriais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/espacos-vetoriais.md
@@ -1,0 +1,20 @@
+---
+slug: "espacos-vetoriais"
+title: "Espaços Vetoriais"
+summary: "Conceitos fundamentais de espaços vetoriais, combinações lineares e independência de vetores."
+youtube_playlists:
+  - id: "PL-TOPIC-espacos-vetoriais"
+    priority: 1
+tags:
+  - "álgebra linear"
+  - "vetores"
+  - "bases"
+type: topic
+layout: topic
+---
+Definição de espaços vetoriais e conceitos de combinação linear, dependência e independência linear,
+incluindo propriedades fundamentais.
+
+Nas sessões de Álgebra Linear os exercícios combinam manipulação simbólica e interpretação
+geométrica, recorrendo a ferramentas como GeoGebra ou Octave para consolidar a intuição espacial em
+aplicações de engenharia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/geometria-analitica-basica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/geometria-analitica-basica.md
@@ -1,0 +1,20 @@
+---
+slug: "geometria-analitica-basica"
+title: "Geometria Analítica Básica"
+summary: "Equações de retas e planos, parâmetros diretores e posições relativas no espaço."
+youtube_playlists:
+  - id: "PL-TOPIC-geometria-analitica-basica"
+    priority: 1
+tags:
+  - "geometria"
+  - "retas"
+  - "planos"
+type: topic
+layout: topic
+---
+Equações da reta e do plano no espaço, parâmetros e cossenos diretores, e análise da posição
+relativa entre retas e planos.
+
+Nas sessões de Álgebra Linear os exercícios combinam manipulação simbólica e interpretação
+geométrica, recorrendo a ferramentas como GeoGebra ou Octave para consolidar a intuição espacial em
+aplicações de engenharia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/index.md
@@ -1,0 +1,38 @@
+---
+title: "Álgebra Linear e Geometria Analítica"
+code: "19411003"
+course_code: "LESTI"
+description: "Fundamentos de espaços vetoriais, matrizes e geometria analítica aplicados à engenharia."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Modelar problemas de engenharia utilizando estruturas de álgebra linear."
+  - "Calcular determinantes, inversas e transformações lineares em diferentes bases."
+  - "Aplicar ferramentas vetoriais para analisar retas e planos no espaço tridimensional."
+youtube_playlists:
+  - id: "PL-19411003-aulas"
+    priority: 1
+  - id: "PL-19411003-exercicios"
+    priority: 2
+topics:
+  - slug: "espacos-vetoriais"
+  - slug: "matrizes-e-operacoes"
+  - slug: "sistemas-lineares-e-vetores-proprios"
+  - slug: "calculo-vetorial-e-produtos"
+  - slug: "geometria-analitica-basica"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Espaços vetoriais, combinações lineares, dependência e independência; subespaços geradores e bases.
+- Operações com matrizes, determinantes (Sarrus, Laplace), matrizes adjuntas, inversas, ortogonais e complexas.
+- Sistemas de equações lineares, regra de Cramer, mudança de base, valores e vetores próprios, diagonalização.
+- Produto interno, ortogonalização de Gram-Schmidt, produtos externo e misto; parâmetros e cossenos diretores.
+- Equações da reta e do plano, posições relativas de retas e planos no espaço tridimensional.
+
+## Metodologia
+
+A unidade combina aulas teóricas com resolução de exercícios guiados e trabalhos em pequenos grupos. Fichas digitais complementam o estudo autónomo e articulam aplicações computacionais com software matemático livre.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/matrizes-e-operacoes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/matrizes-e-operacoes.md
@@ -1,0 +1,20 @@
+---
+slug: "matrizes-e-operacoes"
+title: "Matrizes e Operações"
+summary: "Manipulação de matrizes, determinantes e propriedades associadas a inversas e ortogonalidade."
+youtube_playlists:
+  - id: "PL-TOPIC-matrizes-e-operacoes"
+    priority: 1
+tags:
+  - "matrizes"
+  - "determinantes"
+  - "transformações"
+type: topic
+layout: topic
+---
+Operações com matrizes (adição, multiplicação escalar e entre matrizes, transposição) e conceitos de
+determinantes (regra de Sarrus, Laplace), matriz adjunta, inversa, ortogonal e complexa.
+
+Nas sessões de Álgebra Linear os exercícios combinam manipulação simbólica e interpretação
+geométrica, recorrendo a ferramentas como GeoGebra ou Octave para consolidar a intuição espacial em
+aplicações de engenharia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411003/sistemas-lineares-e-vetores-proprios.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411003/sistemas-lineares-e-vetores-proprios.md
@@ -1,0 +1,20 @@
+---
+slug: "sistemas-lineares-e-vetores-proprios"
+title: "Sistemas Lineares e Vetores Próprios"
+summary: "Resolução de sistemas lineares, mudança de base e cálculo de autovalores e autovetores."
+youtube_playlists:
+  - id: "PL-TOPIC-sistemas-lineares-e-vetores-proprios"
+    priority: 1
+tags:
+  - "sistemas lineares"
+  - "autovalores"
+  - "diagonalização"
+type: topic
+layout: topic
+---
+Resolução de sistemas de equações lineares (regra de Cramer), mudança de base, cálculo de valores
+próprios e vetores próprios, e diagonalização de matrizes.
+
+Nas sessões de Álgebra Linear os exercícios combinam manipulação simbólica e interpretação
+geométrica, recorrendo a ferramentas como GeoGebra ou Octave para consolidar a intuição espacial em
+aplicações de engenharia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/cinematica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/cinematica.md
@@ -1,0 +1,19 @@
+---
+slug: "cinematica"
+title: "Cinemática"
+summary: "Descrição vetorial de posição, velocidade e aceleração em diferentes sistemas de coordenadas."
+youtube_playlists:
+  - id: "PL-TOPIC-cinematica"
+    priority: 1
+tags:
+  - "movimento"
+  - "velocidade"
+  - "aceleração"
+type: topic
+layout: topic
+---
+Descrição do movimento de um ponto material – vetores de posição, velocidade e aceleração;
+componentes retangulares e em coordenadas intrínsecas (tangencial/normal) do movimento.
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/dinamica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/dinamica.md
@@ -1,0 +1,19 @@
+---
+slug: "dinamica"
+title: "Dinâmica"
+summary: "Aplicação da 2ª Lei de Newton para equações de movimento e equilíbrio dinâmico."
+youtube_playlists:
+  - id: "PL-TOPIC-dinamica"
+    priority: 1
+tags:
+  - "segunda lei"
+  - "movimento"
+  - "força resultante"
+type: topic
+layout: topic
+---
+Aplicação da 2ª Lei de Newton para translação – formulação de equações diferenciais do movimento e
+análise de equilíbrio dinâmico (força resultante nula implica aceleração nula).
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/estatica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/estatica.md
@@ -1,0 +1,19 @@
+---
+slug: "estatica"
+title: "Estática"
+summary: "Equilíbrio de partículas e corpos rígidos, resultantes de forças e atrito."
+youtube_playlists:
+  - id: "PL-TOPIC-estatica"
+    priority: 1
+tags:
+  - "equilíbrio"
+  - "forças"
+  - "atrito"
+type: topic
+layout: topic
+---
+Equilíbrio de partículas e corpos rígidos sob forças – aplicação da 1ª Lei de Newton, resultante e
+momento de forças, atrito estático e cinético em superfícies.
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/forcas-distribuidas-inercia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/forcas-distribuidas-inercia.md
@@ -1,0 +1,19 @@
+---
+slug: "forcas-distribuidas-inercia"
+title: "Forças Distribuídas e Inércia"
+summary: "Cálculo de centros de massa e momentos de inércia com aplicações do teorema dos eixos paralelos."
+youtube_playlists:
+  - id: "PL-TOPIC-forcas-distribuidas-inercia"
+    priority: 1
+tags:
+  - "centro de massa"
+  - "momento de inércia"
+  - "eixos paralelos"
+type: topic
+layout: topic
+---
+Determinação de centros de massa de sistemas de partículas/corpos, cálculo de momentos de inércia e
+aplicação do teorema dos eixos paralelos para áreas e massas.
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/index.md
@@ -1,0 +1,42 @@
+---
+title: "Física"
+code: "19411004"
+course_code: "LESTI"
+description: "Mecânica clássica aplicada com enfoque em equilíbrio, movimento e energia."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Aplicar análise dimensional e unidades do SI na modelação de problemas físicos."
+  - "Resolver problemas de estática e dinâmica envolvendo forças, momentos e atrito."
+  - "Interpretar conservação de energia, oscilações e ondas em sistemas mecânicos simples."
+youtube_playlists:
+  - id: "PL-19411004-aulas"
+    priority: 1
+  - id: "PL-19411004-experiencias"
+    priority: 2
+topics:
+  - slug: "unidades-e-medidas"
+  - slug: "estatica"
+  - slug: "forcas-distribuidas-inercia"
+  - slug: "cinematica"
+  - slug: "dinamica"
+  - slug: "trabalho-e-energia"
+  - slug: "oscilacoes-ondas"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Sistema Internacional de Unidades, análise dimensional e tratamento de grandezas físicas.
+- Estática de pontos materiais e corpos rígidos, sistemas equivalentes de forças e condições de equilíbrio.
+- Forças distribuídas, centro de massa, momentos de inércia e teorema dos eixos paralelos.
+- Cinemática vetorial: posição, velocidade, aceleração em coordenadas cartesianas e intrínsecas.
+- Dinâmica translacional baseada na segunda lei de Newton e equilíbrio dinâmico.
+- Trabalho, energia cinética e potencial, conservação de energia mecânica.
+- Oscilações harmónicas simples, movimento circular uniforme e ondas mecânicas.
+
+## Metodologia
+
+A unidade privilegia experiências demonstrativas e resolução de problemas contextualizados em engenharia, promovendo o uso de ferramentas digitais para visualização de trajetórias e análise de dados experimentais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/oscilacoes-ondas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/oscilacoes-ondas.md
@@ -1,0 +1,20 @@
+---
+slug: "oscilacoes-ondas"
+title: "Oscilações e Ondas"
+summary: "Movimento harmónico simples, movimento circular uniforme e ondas mecânicas."
+youtube_playlists:
+  - id: "PL-TOPIC-oscilacoes-ondas"
+    priority: 1
+tags:
+  - "oscilações"
+  - "ondas"
+  - "MHS"
+type: topic
+layout: topic
+---
+Estudo do movimento harmônico simples (massa-mola, pêndulo) e movimento circular uniforme como caso
+especial; introdução às ondas mecânicas (características de ondas, propagação, frequência,
+amplitude).
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/trabalho-e-energia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/trabalho-e-energia.md
@@ -1,0 +1,19 @@
+---
+slug: "trabalho-e-energia"
+title: "Trabalho e Energia"
+summary: "Cálculo de trabalho, energia cinética e potencial e conservação da energia mecânica."
+youtube_playlists:
+  - id: "PL-TOPIC-trabalho-e-energia"
+    priority: 1
+tags:
+  - "trabalho"
+  - "energia"
+  - "conservação"
+type: topic
+layout: topic
+---
+Cálculo do trabalho realizado por forças, definição de energia cinética e potencial; conservação da
+energia mecânica em sistemas conservativos e análise energética de movimentos.
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411004/unidades-e-medidas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411004/unidades-e-medidas.md
@@ -1,0 +1,19 @@
+---
+slug: "unidades-e-medidas"
+title: "Unidades e Medidas"
+summary: "Uso do SI, análise dimensional e representação numérica com notação científica."
+youtube_playlists:
+  - id: "PL-TOPIC-unidades-e-medidas"
+    priority: 1
+tags:
+  - "SI"
+  - "análise dimensional"
+  - "notação científica"
+type: topic
+layout: topic
+---
+Uso do SI e análise dimensional para verificar consistência de equações físicas; representação
+numérica com notação científica e significância de dígitos.
+
+Problemas contextualizados em engenharia reforçam a ligação entre conceitos teóricos e a análise
+experimental de sistemas mecânicos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/fundamentos-computadores.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/fundamentos-computadores.md
@@ -1,0 +1,19 @@
+---
+slug: "fundamentos-computadores"
+title: "Fundamentos de Computadores"
+summary: "História da computação e estrutura dos sistemas digitais modernos."
+youtube_playlists:
+  - id: "PL-TOPIC-fundamentos-computadores"
+    priority: 1
+tags:
+  - "arquitetura"
+  - "história"
+  - "componentes"
+type: topic
+layout: topic
+---
+Visão histórica da computação e estrutura básica de computadores, incluindo componentes principais e
+organização interna.
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/hierarquia-memoria-io.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/hierarquia-memoria-io.md
@@ -1,0 +1,20 @@
+---
+slug: "hierarquia-memoria-io"
+title: "Hierarquia de Memória e I/O"
+summary: "Memória principal, cache, virtual e interfaces de entrada/saída."
+youtube_playlists:
+  - id: "PL-TOPIC-hierarquia-memoria-io"
+    priority: 1
+tags:
+  - "memória"
+  - "cache"
+  - "I/O"
+type: topic
+layout: topic
+---
+Organização da memória principal e cache, memória virtual e mapeamento de endereços; interfaces e
+sistemas de entrada/saída, incluindo comunicação do CPU com periféricos (introdução a barramentos,
+mapeamento de I/O, etc.).
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/index.md
@@ -1,0 +1,40 @@
+---
+title: "Arquitetura de Computadores"
+code: "19411005"
+course_code: "LESTI"
+description: "Estudo da organização interna de computadores, lógica digital e hierarquia de memória."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Identificar os componentes principais da arquitetura de um computador moderno."
+  - "Analisar circuitos combinatórios e sequenciais aplicados a unidades de processamento."
+  - "Avaliar técnicas de memória e interfaces de I/O em termos de desempenho e fiabilidade."
+youtube_playlists:
+  - id: "PL-19411005-aulas"
+    priority: 1
+  - id: "PL-19411005-labs"
+    priority: 2
+topics:
+  - slug: "fundamentos-computadores"
+  - slug: "representacao-digital"
+  - slug: "logica-combinatoria"
+  - slug: "sistemas-sequenciais"
+  - slug: "processador-e-isa"
+  - slug: "hierarquia-memoria-io"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Evolução histórica e estrutura de computadores; sistemas de numeração e aritmética binária/hexadecimal.
+- Álgebra Booleana, portas lógicas, descodificadores, multiplexadores e circuitos combinatórios.
+- Circuitos sequenciais: flip-flops, registos, memórias e controladores.
+- Organização do processador: ciclo de instrução, modos de endereçamento, ULA e unidade de controlo.
+- Arquitetura de instruções, chamadas, interrupções e suporte a sub-rotinas.
+- Hierarquia de memória, cache, memória virtual e interfaces de entrada/saída.
+
+## Metodologia
+
+As aulas combinam teoria com laboratórios de simulação de circuitos e atividades práticas com ferramentas de montagem de processadores didáticos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/logica-combinatoria.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/logica-combinatoria.md
@@ -1,0 +1,19 @@
+---
+slug: "logica-combinatoria"
+title: "Lógica Combinatória"
+summary: "Álgebra Booleana, portas lógicas e construção de circuitos combinatórios."
+youtube_playlists:
+  - id: "PL-TOPIC-logica-combinatoria"
+    priority: 1
+tags:
+  - "álgebra Booleana"
+  - "portas"
+  - "circuitos"
+type: topic
+layout: topic
+---
+Princípios da álgebra Booleana, portas lógicas fundamentais e implementação de circuitos
+combinatórios como descodificadores e multiplexadores.
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/processador-e-isa.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/processador-e-isa.md
@@ -1,0 +1,21 @@
+---
+slug: "processador-e-isa"
+title: "Processador e ISA"
+summary: "Ciclo de execução, modos de endereçamento e organização do conjunto de instruções."
+youtube_playlists:
+  - id: "PL-TOPIC-processador-e-isa"
+    priority: 1
+tags:
+  - "CPU"
+  - "ISA"
+  - "endereçamento"
+type: topic
+layout: topic
+---
+Estrutura interna do CPU, ciclo de busca–decodificação–execução, modos de endereçamento de
+instruções, organização de registradores e operações (ULA e controle); conjunto de instruções do
+processador (ISA), incluindo tipos de instruções e mecanismos de chamada de subrotinas e tratamento
+de interrupções.
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/representacao-digital.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/representacao-digital.md
@@ -1,0 +1,19 @@
+---
+slug: "representacao-digital"
+title: "Representação Digital"
+summary: "Sistemas de numeração binário e hexadecimal, conversões e codificações."
+youtube_playlists:
+  - id: "PL-TOPIC-representacao-digital"
+    priority: 1
+tags:
+  - "binário"
+  - "hexadecimal"
+  - "códigos"
+type: topic
+layout: topic
+---
+Sistemas de numeração (binário, hexadecimal), operações aritméticas nesses sistemas e códigos para
+representação de dados numéricos e caracteres (ASCII, etc.).
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411005/sistemas-sequenciais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411005/sistemas-sequenciais.md
@@ -1,0 +1,19 @@
+---
+slug: "sistemas-sequenciais"
+title: "Sistemas Sequenciais"
+summary: "Registos, memórias e controlo sequencial na organização de computadores."
+youtube_playlists:
+  - id: "PL-TOPIC-sistemas-sequenciais"
+    priority: 1
+tags:
+  - "flip-flops"
+  - "registos"
+  - "controle"
+type: topic
+layout: topic
+---
+Conceitos de circuitos sequenciais e armazenamento (flip-flops, registos, memórias) e noções de
+controle sequencial de operações dentro do computador.
+
+Os laboratórios recorrem a simuladores de circuitos e estudos de arquiteturas reais para conectar a
+teoria à forma como computadores executam instruções no dia a dia.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/associacoes-entre-classes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/associacoes-entre-classes.md
@@ -1,0 +1,21 @@
+---
+slug: "associacoes-entre-classes"
+title: "Associações entre Classes"
+summary: "Relacionamentos como associação, agregação e composição com implicações de ciclo de vida."
+youtube_playlists:
+  - id: "PL-TOPIC-associacoes-entre-classes"
+    priority: 1
+tags:
+  - "associações"
+  - "agregação"
+  - "composição"
+type: topic
+layout: topic
+---
+Diferentes formas de relacionamento entre objetos – associação simples (um objeto usa outro),
+agregação (relacionamento 'tem um' sem dependência forte), composição (um objeto compõe outro,
+dependência forte), entendendo implicações de ciclo de vida; qualidade de design via coesão e baixo
+acoplamento.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/classe-e-objeto.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/classe-e-objeto.md
@@ -1,0 +1,19 @@
+---
+slug: "classe-e-objeto"
+title: "Classe e Objeto"
+summary: "Definição de classes, objetos, atributos e métodos em sistemas OO."
+youtube_playlists:
+  - id: "PL-TOPIC-classe-e-objeto"
+    priority: 1
+tags:
+  - "classes"
+  - "objetos"
+  - "atributos"
+type: topic
+layout: topic
+---
+Conceitos de classe (definição de tipo de objeto) e objeto (instância concreta), atributos (estado)
+e métodos (comportamento); identidade do objeto e referência.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/desenho-oo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/desenho-oo.md
@@ -1,0 +1,20 @@
+---
+slug: "desenho-oo"
+title: "Desenho OO"
+summary: "Aplicação prática de análise e desenho orientados a objetos com UML e código."
+youtube_playlists:
+  - id: "PL-TOPIC-desenho-oo"
+    priority: 1
+tags:
+  - "UML"
+  - "design"
+  - "implementação"
+type: topic
+layout: topic
+---
+Aplicação prática dos conceitos OO no desenvolvimento de pequenos projetos, passando por etapas de
+análise e desenho OO (por exemplo, usando UML para representar classes e relações) e implementação
+em linguagem OO (como Java ou C#), mostrando benefícios de manutenção e extensibilidade.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/encapsulamento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/encapsulamento.md
@@ -1,0 +1,19 @@
+---
+slug: "encapsulamento"
+title: "Encapsulamento"
+summary: "Ocultação de informação e definição de interfaces públicas."
+youtube_playlists:
+  - id: "PL-TOPIC-encapsulamento"
+    priority: 1
+tags:
+  - "interfaces"
+  - "visibilidade"
+  - "estado"
+type: topic
+layout: topic
+---
+Ocultação da informação – manutenção de estados internos privados e exposição controlada via métodos
+públicos; definição de interfaces claras para uso de objetos.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/heranca-e-polimorfismo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/heranca-e-polimorfismo.md
@@ -1,0 +1,20 @@
+---
+slug: "heranca-e-polimorfismo"
+title: "Herança e Polimorfismo"
+summary: "Reutilização de código via herança e comportamentos especializados via polimorfismo."
+youtube_playlists:
+  - id: "PL-TOPIC-heranca-e-polimorfismo"
+    priority: 1
+tags:
+  - "herança"
+  - "polimorfismo"
+  - "reutilização"
+type: topic
+layout: topic
+---
+Mecanismo de herança de classes (classes derivadas estendendo classes base) para reutilizar e
+especializar código; polimorfismo de subtipo (objetos de subclasses sendo tratados como da classe
+base) e polimorfismo de sobrecarga; introdução a reflexão em sistemas OO.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/index.md
@@ -1,0 +1,41 @@
+---
+title: "Programação Orientada a Objetos"
+code: "19411006"
+course_code: "LESTI"
+description: "Paradigma orientado a objetos, modelação e implementação de classes, hierarquias e interfaces."
+ects: 5
+semester: 2
+language: "pt"
+prerequisites:
+  - "19411000"
+learning_outcomes:
+  - "Aplicar conceitos de encapsulamento, herança e polimorfismo na implementação de software."
+  - "Modelar sistemas com classes e relações coerentes, promovendo coesão e baixo acoplamento."
+  - "Projetar interfaces e contratos que separem especificação e implementação."
+youtube_playlists:
+  - id: "PL-19411006-aulas"
+    priority: 1
+  - id: "PL-19411006-labs"
+    priority: 2
+topics:
+  - slug: "paradigma-oo"
+  - slug: "classe-e-objeto"
+  - slug: "encapsulamento"
+  - slug: "heranca-e-polimorfismo"
+  - slug: "associacoes-entre-classes"
+  - slug: "desenho-oo"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Evolução do paradigma OO e comparação com abordagens procedimentais.
+- Classes, objetos, identidade, atributos, métodos e mensagens.
+- Encapsulamento, interfaces e visibilidade de membros.
+- Herança, polimorfismo, sobrecarga e reflexão básica.
+- Relações entre classes: associação, agregação, composição e dependências.
+- Análise e desenho OO com apoio de UML e implementação em linguagem moderna.
+
+## Metodologia
+
+Projetos incrementais e code reviews guiados permitem aplicar princípios de design OO e refatorar código para melhorar legibilidade e extensibilidade.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411006/paradigma-oo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411006/paradigma-oo.md
@@ -1,0 +1,19 @@
+---
+slug: "paradigma-oo"
+title: "Paradigma Orientado a Objetos"
+summary: "Motivação histórica e benefícios da programação orientada a objetos."
+youtube_playlists:
+  - id: "PL-TOPIC-paradigma-oo"
+    priority: 1
+tags:
+  - "OO"
+  - "paradigmas"
+  - "abstração"
+type: topic
+layout: topic
+---
+Motivação e surgimento da Programação Orientada a Objetos, em contraste com paradigmas procedurais –
+por que o OO auxilia na modelagem de sistemas complexos através de abstração.
+
+Projetos incrementais e revisões de código destacam como boas abstrações facilitam evolução e
+manutenção de sistemas orientados a objetos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/desenvolvimento-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/desenvolvimento-web.md
@@ -1,0 +1,21 @@
+---
+slug: "desenvolvimento-web"
+title: "Desenvolvimento Web"
+summary: "Projeto integrador unindo frontend, backend e persistência para aplicações completas."
+youtube_playlists:
+  - id: "PL-TOPIC-desenvolvimento-web"
+    priority: 1
+tags:
+  - "fullstack"
+  - "projeto"
+  - "aplicação"
+type: topic
+layout: topic
+---
+Projeto final integrador aplicando tecnologias Web aprendidas: concepção de um sítio/aplicação Web
+com múltiplas páginas, estilo consistente, interatividade no cliente e lógica de negócio no
+servidor, possivelmente usando um mini-framework ou bibliotecas se aplicável, simulando um ambiente
+de desenvolvimento Web real.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/fundamentos-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/fundamentos-web.md
@@ -1,0 +1,19 @@
+---
+slug: "fundamentos-web"
+title: "Fundamentos da Web"
+summary: "História da Web, protocolo HTTP e modelo cliente-servidor."
+youtube_playlists:
+  - id: "PL-TOPIC-fundamentos-web"
+    priority: 1
+tags:
+  - "HTTP"
+  - "cliente-servidor"
+  - "história"
+type: topic
+layout: topic
+---
+História da Web e seus protocolos base (HTTP requisicoes/respostas), diferença entre Web estática e
+dinâmica; arquitetura cliente-servidor na Web.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/html-css-xml.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/html-css-xml.md
@@ -1,0 +1,20 @@
+---
+slug: "html-css-xml"
+title: "HTML, CSS e XML"
+summary: "Estruturação de conteúdo com HTML/XHTML, estilos com CSS e dados estruturados com XML."
+youtube_playlists:
+  - id: "PL-TOPIC-html-css-xml"
+    priority: 1
+tags:
+  - "HTML"
+  - "CSS"
+  - "XML"
+type: topic
+layout: topic
+---
+Estruturação de conteúdo com HTML/XHTML (elementos, atributos, formulários), estilização com CSS
+(seletores, propriedades de estilo, layout) e uso de XML como formato de dados estruturados para
+configurar/transportar informações.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/index.md
@@ -1,0 +1,41 @@
+---
+title: "Tecnologias Web"
+code: "19411007"
+course_code: "LESTI"
+description: "Desenvolvimento de aplicações Web integrando HTML, CSS, JavaScript e PHP."
+ects: 5
+semester: 2
+language: "pt"
+prerequisites:
+  - "19411000"
+learning_outcomes:
+  - "Construir páginas Web estruturadas e estilizadas com HTML, CSS e boas práticas de acessibilidade."
+  - "Programar interatividade no cliente com JavaScript e comunicação assíncrona."
+  - "Implementar scripts PHP para gerar conteúdo dinâmico e interagir com bases de dados."
+youtube_playlists:
+  - id: "PL-19411007-aulas"
+    priority: 1
+  - id: "PL-19411007-projetos"
+    priority: 2
+topics:
+  - slug: "fundamentos-web"
+  - slug: "html-css-xml"
+  - slug: "javascript"
+  - slug: "php-e-backend"
+  - slug: "integracao-frontend-backend"
+  - slug: "desenvolvimento-web"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Evolução da Web, protocolo HTTP e arquitetura cliente-servidor.
+- HTML/XHTML para estruturação de conteúdo e CSS para estilo e layout responsivo.
+- Programação em JavaScript no navegador, eventos, DOM e AJAX.
+- Programação em PHP, processamento de formulários, sessões e acesso a bases de dados.
+- Integração cliente-servidor com troca de dados em JSON/XML.
+- Projeto Web completo envolvendo frontend, backend e persistência.
+
+## Metodologia
+
+Laboratórios práticos orientados por desafios, culminando num projeto integrador que consolida os conceitos e promove revisão por pares.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/integracao-frontend-backend.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/integracao-frontend-backend.md
@@ -1,0 +1,21 @@
+---
+slug: "integracao-frontend-backend"
+title: "Integração Frontend-Backend"
+summary: "Troca de dados entre cliente e servidor usando formulários, APIs e JSON/XML."
+youtube_playlists:
+  - id: "PL-TOPIC-integracao-frontend-backend"
+    priority: 1
+tags:
+  - "APIs"
+  - "JSON"
+  - "integração"
+type: topic
+layout: topic
+---
+Construção de uma aplicação Web completa onde o frontend (HTML/CSS/JS) se comunica com o backend
+(PHP ou similar) via HTTP – por exemplo, formulário em HTML que envia dados para um script PHP, ou
+uso de fetch/AJAX do JS para API em PHP – garantindo a troca de dados (JSON/XML) e atualização
+dinâmica da interface.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/javascript.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/javascript.md
@@ -1,0 +1,19 @@
+---
+slug: "javascript"
+title: "JavaScript"
+summary: "Programação no cliente com manipulação do DOM, eventos e AJAX."
+youtube_playlists:
+  - id: "PL-TOPIC-javascript"
+    priority: 1
+tags:
+  - "DOM"
+  - "eventos"
+  - "AJAX"
+type: topic
+layout: topic
+---
+Programação do lado do cliente – manipulação do DOM, eventos do navegador, validação de formulários,
+introdução a AJAX (comunicação assíncrona) para enriquecer interatividade sem recarregar páginas.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411007/php-e-backend.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411007/php-e-backend.md
@@ -1,0 +1,20 @@
+---
+slug: "php-e-backend"
+title: "PHP e Backend"
+summary: "Geração dinâmica de páginas no servidor com PHP e acesso a bases de dados."
+youtube_playlists:
+  - id: "PL-TOPIC-php-e-backend"
+    priority: 1
+tags:
+  - "PHP"
+  - "servidor"
+  - "bases de dados"
+type: topic
+layout: topic
+---
+Programação do lado do servidor – sintaxe básica do PHP, tratamento de requisições HTTP (GET/POST),
+acesso a bases de dados para conteúdo dinâmico, geração de páginas HTML no servidor e gestão de
+sessões de utilizador.
+
+Os laboratórios integram HTML/CSS/JS e scripts no servidor, desenvolvendo aplicações completas que
+consideram acessibilidade e performance.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411008/calculo-multivariavel.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411008/calculo-multivariavel.md
@@ -1,0 +1,20 @@
+---
+slug: "calculo-multivariavel"
+title: "Cálculo Multivariável"
+summary: "Funções de várias variáveis, derivadas direcionais e operadores vetoriais."
+youtube_playlists:
+  - id: "PL-TOPIC-calculo-multivariavel"
+    priority: 1
+tags:
+  - "derivadas parciais"
+  - "gradiente"
+  - "rotacional"
+type: topic
+layout: topic
+---
+Conceitos topológicos básicos em várias variáveis (campos escalares/vetoriais, superfícies de
+nível), continuidade em ℝⁿ e cálculo de derivadas parciais e direcionais, incluindo aplicações do
+gradiente, divergência e rotacional.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411008/equacoes-diferenciais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411008/equacoes-diferenciais.md
@@ -1,0 +1,20 @@
+---
+slug: "equacoes-diferenciais"
+title: "Equações Diferenciais"
+summary: "Técnicas de resolução para EDOs de primeira ordem e equações lineares de ordem superior."
+youtube_playlists:
+  - id: "PL-TOPIC-equacoes-diferenciais"
+    priority: 1
+tags:
+  - "EDO"
+  - "coeficientes"
+  - "soluções"
+type: topic
+layout: topic
+---
+Resolução de equações diferenciais ordinárias – técnicas para EDOs de primeira ordem (separação de
+variáveis, fator integrante) e equações lineares de ordem superior com coeficientes constantes,
+incluindo uso do método dos coeficientes indeterminados para termos forçados.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411008/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411008/index.md
@@ -1,0 +1,36 @@
+---
+title: "Análise Matemática II"
+code: "19411008"
+course_code: "LESTI"
+description: "Cálculo diferencial e integral em várias variáveis e equações diferenciais ordinárias."
+ects: 7
+semester: 1
+language: "pt"
+prerequisites:
+  - "19411002"
+learning_outcomes:
+  - "Analisar funções de várias variáveis usando derivadas direcionais, gradiente, divergência e rotacional."
+  - "Resolver integrais múltiplos e integrais de linha aplicados a problemas geométricos e físicos."
+  - "Modelar fenómenos com equações diferenciais de primeira e de ordem superior aplicando técnicas clássicas."
+youtube_playlists:
+  - id: "PL-19411008-aulas"
+    priority: 1
+  - id: "PL-19411008-exercicios"
+    priority: 2
+topics:
+  - slug: "calculo-multivariavel"
+  - slug: "integral-multivariavel"
+  - slug: "equacoes-diferenciais"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos topológicos em \(\mathbb{R}^n\), campos escalares e vetoriais, limites e continuidade.
+- Derivadas direcionais e parciais, diferencial total, regra da cadeia, derivadas superiores, gradiente, divergência e rotacional.
+- Integrais duplos e triplos, mudanças de variáveis, cálculo de áreas, volumes e integrais de linha, teoremas de Green, Stokes e Divergência.
+- Equações diferenciais: separáveis, lineares, homogéneas, exatas, fator integrante e equações lineares de ordem superior com coeficientes constantes.
+
+## Metodologia
+
+A unidade aposta em sessões práticas com problemas modelados em software computacional, promovendo a ligação entre teoria matemática e aplicações em engenharia e física.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411008/integral-multivariavel.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411008/integral-multivariavel.md
@@ -1,0 +1,21 @@
+---
+slug: "integral-multivariavel"
+title: "Integral Multivariável"
+summary: "Integrais múltiplos, mudança de variáveis e teoremas de Green, Stokes e Gauss."
+youtube_playlists:
+  - id: "PL-TOPIC-integral-multivariavel"
+    priority: 1
+tags:
+  - "integrais múltiplos"
+  - "Green"
+  - "Stokes"
+type: topic
+layout: topic
+---
+Integração múltipla (dupla e tripla) em regiões do plano e do espaço, técnicas de mudança de
+variáveis e aplicação desses integrais para determinar áreas e volumes; integração de campos
+vetoriais (linhas e superfícies) e principais teoremas (Green, Stokes, Gauss) ligados a fluxos e
+circulação.
+
+Estes conteúdos sustentam a modelação de fenómenos físicos e o desenvolvimento de algoritmos
+numéricos presentes em disciplinas de engenharia e ciência de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/administracao-sistemas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/administracao-sistemas.md
@@ -1,0 +1,20 @@
+---
+slug: "administracao-sistemas"
+title: "Administração de Sistemas"
+summary: "Instalação, configuração e manutenção básica de sistemas Windows e Linux."
+youtube_playlists:
+  - id: "PL-TOPIC-administracao-sistemas"
+    priority: 1
+tags:
+  - "administração"
+  - "Windows"
+  - "Linux"
+type: topic
+layout: topic
+---
+Procedimentos práticos de instalação e configuração de sistemas Windows e Linux, gerenciamento de
+utilizadores e permissões, configuração de serviços básicos (partilha de ficheiros, impressoras,
+etc.), noções de servidores Windows (AD, políticas de grupo).
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/gestao-memoria.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/gestao-memoria.md
@@ -1,0 +1,19 @@
+---
+slug: "gestao-memoria"
+title: "Gestão de Memória"
+summary: "Partições, paginação, segmentação e memória virtual em sistemas operativos."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-memoria"
+    priority: 1
+tags:
+  - "memória"
+  - "paginação"
+  - "segmentação"
+type: topic
+layout: topic
+---
+Técnicas de gerenciamento de memória principal (partições fixas/dinâmicas, paginação, segmentação) e
+memória virtual (paginação por demanda, algoritmos de substituição de páginas).
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/index.md
@@ -1,0 +1,42 @@
+---
+title: "Sistemas Operativos"
+code: "19411009"
+course_code: "LESTI"
+description: "Princípios de funcionamento de sistemas operativos e administração básica de Windows e Linux."
+ects: 5
+semester: 1
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Explicar o papel do sistema operativo na gestão de recursos de hardware e software."
+  - "Configurar ambientes Windows e Linux, incluindo utilizadores, permissões e serviços básicos."
+  - "Automatizar tarefas administrativas simples com scripts em shell e PowerShell."
+youtube_playlists:
+  - id: "PL-19411009-aulas"
+    priority: 1
+  - id: "PL-19411009-labs"
+    priority: 2
+topics:
+  - slug: "so-conceitos-gerais"
+  - slug: "processos-e-threads"
+  - slug: "gestao-memoria"
+  - slug: "sistemas-arquivos-io"
+  - slug: "protecao-seguranca-so"
+  - slug: "administracao-sistemas"
+  - slug: "scripting-e-automacao"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Arquitetura de sistemas operativos, serviços do kernel e modelos de gestão de recursos.
+- Processos e threads, escalonamento, sincronização e deadlocks.
+- Gestão de memória principal e virtual, paginação e segmentação.
+- Sistemas de ficheiros, drivers e mecanismos de I/O.
+- Mecanismos de proteção, segurança e autenticação em sistemas multiutilizador.
+- Instalação, configuração e administração básica de Windows e Linux.
+- Automação com shell script e PowerShell aplicada a gestão de sistemas.
+
+## Metodologia
+
+A abordagem integra aulas teóricas com laboratórios em máquinas virtuais, promovendo exercícios de configuração passo-a-passo e elaboração de scripts reutilizáveis.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/processos-e-threads.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/processos-e-threads.md
@@ -1,0 +1,20 @@
+---
+slug: "processos-e-threads"
+title: "Processos e Threads"
+summary: "Ciclo de vida de processos, escalonamento, sincronização e deadlocks."
+youtube_playlists:
+  - id: "PL-TOPIC-processos-e-threads"
+    priority: 1
+tags:
+  - "processos"
+  - "threads"
+  - "concorrência"
+type: topic
+layout: topic
+---
+Conceito de processo e thread, ciclo de vida de processos, escalonamento (políticas de alocação de
+CPU), problemas de concorrência (regiões críticas, semáforos/locks) e situações de impasse
+(deadlocks) e suas estratégias de prevenção/detecção.
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/protecao-seguranca-so.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/protecao-seguranca-so.md
@@ -1,0 +1,20 @@
+---
+slug: "protecao-seguranca-so"
+title: "Proteção e Segurança em SO"
+summary: "Mecanismos de proteção, autenticação e permissões em ambientes multiutilizador."
+youtube_playlists:
+  - id: "PL-TOPIC-protecao-seguranca-so"
+    priority: 1
+tags:
+  - "proteção"
+  - "autenticação"
+  - "permissões"
+type: topic
+layout: topic
+---
+Mecanismos de proteção do sistema (modos de usuário vs núcleo, separação de espaços de
+endereçamento), conceitos de segurança (autenticação de usuários, permissões de acesso a ficheiros,
+firewall básica) em ambiente multiutilizador.
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/scripting-e-automacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/scripting-e-automacao.md
@@ -1,0 +1,20 @@
+---
+slug: "scripting-e-automacao"
+title: "Scripting e Automação"
+summary: "Uso de scripts Bash e PowerShell para automatizar tarefas do sistema operativo."
+youtube_playlists:
+  - id: "PL-TOPIC-scripting-e-automacao"
+    priority: 1
+tags:
+  - "bash"
+  - "PowerShell"
+  - "automação"
+type: topic
+layout: topic
+---
+Utilização de linguagens de scripting (scripts Bash no Linux, PowerShell no Windows) para automação
+de tarefas administrativas e interação programática com o sistema operativo, incluindo escrita de
+pequenos scripts para gestão de ficheiros, processos ou configurações repetitivas.
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/sistemas-arquivos-io.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/sistemas-arquivos-io.md
@@ -1,0 +1,20 @@
+---
+slug: "sistemas-arquivos-io"
+title: "Sistemas de Ficheiros e I/O"
+summary: "Organização de ficheiros, chamadas de sistema e gerenciamento de dispositivos."
+youtube_playlists:
+  - id: "PL-TOPIC-sistemas-arquivos-io"
+    priority: 1
+tags:
+  - "sistema de ficheiros"
+  - "drivers"
+  - "I/O"
+type: topic
+layout: topic
+---
+Estrutura e funcionamento de sistemas de arquivos (organização em diretórios, FAT/NTFS/ext, etc.),
+chamadas de sistema para manipulação de ficheiros; gerenciamento de dispositivos de entrada/saída,
+drivers e noções de sistemas de I/O mapeado em memória vs. isolado.
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411009/so-conceitos-gerais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411009/so-conceitos-gerais.md
@@ -1,0 +1,20 @@
+---
+slug: "so-conceitos-gerais"
+title: "Conceitos Gerais de Sistemas Operativos"
+summary: "Serviços do sistema operativo e sua função como gestor de recursos."
+youtube_playlists:
+  - id: "PL-TOPIC-so-conceitos-gerais"
+    priority: 1
+tags:
+  - "sistema operativo"
+  - "kernel"
+  - "serviços"
+type: topic
+layout: topic
+---
+Estrutura e serviços de um sistema operativo, função do SO como gerenciador de recursos (CPU,
+memória, dispositivos) e arquitetura geral de sistemas operativos (camadas, núcleo kernel, modos de
+operação).
+
+Laboratórios em máquinas virtuais permitem experimentar configurações de Windows e Linux,
+automatizando tarefas e avaliando o impacto de cada decisão administrativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/controle-financeiro.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/controle-financeiro.md
@@ -1,0 +1,19 @@
+---
+slug: "controle-financeiro"
+title: "Controlo Financeiro"
+summary: "Noções de orçamento, análise de investimentos e indicadores financeiros."
+youtube_playlists:
+  - id: "PL-TOPIC-controle-financeiro"
+    priority: 1
+tags:
+  - "finanças"
+  - "orçamento"
+  - "investimentos"
+type: topic
+layout: topic
+---
+Noções de gestão financeira básica – controle orçamentário, análise de investimentos, indicadores
+financeiros – e sua relevância no processo decisório.
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/ferramentas-projetos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/ferramentas-projetos.md
@@ -1,0 +1,20 @@
+---
+slug: "ferramentas-projetos"
+title: "Ferramentas de Projetos"
+summary: "Uso de software e técnicas de planeamento como EAP e cronogramas."
+youtube_playlists:
+  - id: "PL-TOPIC-ferramentas-projetos"
+    priority: 1
+tags:
+  - "MS Project"
+  - "Gantt"
+  - "EAP"
+type: topic
+layout: topic
+---
+Utilização de software de gestão de projetos (ex.: MS Project, ferramentas ágeis) para acompanhar o
+progresso, e aplicação de técnicas como EAP (estrutura analítica do projeto), cronogramas Gantt,
+metodologias ágeis de sprints e retrospectivas.
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/fundamentos-gestao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/fundamentos-gestao.md
@@ -1,0 +1,19 @@
+---
+slug: "fundamentos-gestao"
+title: "Fundamentos de Gestão"
+summary: "Funções administrativas clássicas e principais teorias de gestão."
+youtube_playlists:
+  - id: "PL-TOPIC-fundamentos-gestao"
+    priority: 1
+tags:
+  - "gestão"
+  - "teorias"
+  - "funções"
+type: topic
+layout: topic
+---
+Introdução aos princípios de gestão de empresas, cobrindo funções administrativas (planejar,
+organizar, liderar, controlar) e principais teorias (clássica, comportamental, sistemas).
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/gestao-projetos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/gestao-projetos.md
@@ -1,0 +1,20 @@
+---
+slug: "gestao-projetos"
+title: "Gestão de Projetos"
+summary: "Ciclo de vida de projetos comparando abordagens tradicionais e ágeis."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-projetos"
+    priority: 1
+tags:
+  - "ciclo de vida"
+  - "Scrum"
+  - "PMBOK"
+type: topic
+layout: topic
+---
+Ciclo de vida de projetos – iniciação, planejamento (definição de escopo, cronograma, alocação de
+recursos, orçamento), execução, monitorização/controle (indicadores de desempenho, gestão de risco)
+e encerramento – comparando metodologias tradicionais (cascata) e metodologias ágeis (Scrum/Kanban).
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/index.md
@@ -1,0 +1,40 @@
+---
+title: "Gestão"
+code: "19411010"
+course_code: "LESTI"
+description: "Fundamentos de gestão organizacional e de projetos aplicados à engenharia informática."
+ects: 5
+semester: 2
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Explicar funções clássicas da gestão e interpretar estruturas organizacionais."
+  - "Elaborar análises estratégicas e planos de marketing alinhados a objetivos empresariais."
+  - "Planejar e controlar projetos combinando abordagens tradicionais e ágeis."
+youtube_playlists:
+  - id: "PL-19411010-aulas"
+    priority: 1
+  - id: "PL-19411010-casos"
+    priority: 2
+topics:
+  - slug: "fundamentos-gestao"
+  - slug: "planeamento-estrategico"
+  - slug: "organizacao-empresarial"
+  - slug: "controle-financeiro"
+  - slug: "gestao-projetos"
+  - slug: "ferramentas-projetos"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Teorias e funções da gestão: planeamento, organização, direção e controlo.
+- Processos de análise estratégica, marketing e definição de objetivos.
+- Estruturas organizacionais, comunicação interna e coordenação de equipas.
+- Noções de finanças empresariais: orçamento, investimentos e indicadores.
+- Gestão de projetos tradicionais versus abordagens ágeis.
+- Ferramentas digitais para planear, acompanhar e reportar projetos.
+
+## Metodologia
+
+Casos de estudo e simulações empresariais permitem aplicar conceitos a cenários reais, culminando num plano de projeto completo com indicadores de desempenho.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/organizacao-empresarial.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/organizacao-empresarial.md
@@ -1,0 +1,19 @@
+---
+slug: "organizacao-empresarial"
+title: "Organização Empresarial"
+summary: "Estruturas organizacionais, coordenação e comunicação interna."
+youtube_playlists:
+  - id: "PL-TOPIC-organizacao-empresarial"
+    priority: 1
+tags:
+  - "estruturas"
+  - "coordenação"
+  - "comunicação"
+type: topic
+layout: topic
+---
+Estruturas organizacionais (funcional, divisional, matricial), distribuição de tarefas e
+responsabilidades, mecanismos de coordenação e comunicação interna.
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411010/planeamento-estrategico.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411010/planeamento-estrategico.md
@@ -1,0 +1,19 @@
+---
+slug: "planeamento-estrategico"
+title: "Planeamento Estratégico"
+summary: "Análise de ambiente, definição de objetivos e estratégias de marketing."
+youtube_playlists:
+  - id: "PL-TOPIC-planeamento-estrategico"
+    priority: 1
+tags:
+  - "estratégia"
+  - "SWOT"
+  - "marketing"
+type: topic
+layout: topic
+---
+Processo de planejamento estratégico e marketing – análise de ambiente (SWOT), definição de
+objetivos e estratégias, e elaboração de planos de ação.
+
+Estudos de caso e simuladores empresariais ajudam a aplicar métricas financeiras, metodologias ágeis
+e técnicas de planeamento na tomada de decisão.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/complexidade.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/complexidade.md
@@ -1,0 +1,19 @@
+---
+slug: "complexidade"
+title: "Complexidade de Algoritmos"
+summary: "Notação Big-O e comparação de custos temporais e espaciais."
+youtube_playlists:
+  - id: "PL-TOPIC-complexidade"
+    priority: 1
+tags:
+  - "Big-O"
+  - "análise"
+  - "desempenho"
+type: topic
+layout: topic
+---
+Princípios de análise de algoritmos – contagem de operações, notação Big-O para classificar
+complexidade temporal e espacial, comparando eficiência de diferentes abordagens.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/estruturas-arvore.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/estruturas-arvore.md
@@ -1,0 +1,20 @@
+---
+slug: "estruturas-arvore"
+title: "Estruturas em Árvore"
+summary: "Árvores binárias de busca, travessias e balanceamento AVL."
+youtube_playlists:
+  - id: "PL-TOPIC-estruturas-arvore"
+    priority: 1
+tags:
+  - "BST"
+  - "traversal"
+  - "AVL"
+type: topic
+layout: topic
+---
+Uso de árvores binárias de busca para organização hierárquica de dados – inserção, remoção e busca
+em BST; travessias (pre-order, in-order, post-order) e suas finalidades; introdução a árvores AVL e
+balanceamento para manter eficiência.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/hash-e-grafo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/hash-e-grafo.md
@@ -1,0 +1,20 @@
+---
+slug: "hash-e-grafo"
+title: "Hash e Grafos"
+summary: "Tabelas de dispersão e representações de grafos com algoritmos básicos."
+youtube_playlists:
+  - id: "PL-TOPIC-hash-e-grafo"
+    priority: 1
+tags:
+  - "hash"
+  - "grafos"
+  - "BFS/DFS"
+type: topic
+layout: topic
+---
+Conceito de função de dispersão (hashing), implementação de tabelas de dispersão (tratamento de
+colisões) e conceito de grafo (nós e arestas), representação (listas de adjacência, matriz de
+adjacência) e algoritmos básicos (p. ex., BFS/DFS).
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/index.md
@@ -1,0 +1,42 @@
+---
+title: "Algoritmos e Estruturas de Dados"
+code: "19411011"
+course_code: "LESTI"
+description: "Análise de complexidade, estruturas de dados clássicas e aplicações em Java."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411006"
+learning_outcomes:
+  - "Avaliar a complexidade temporal e espacial de algoritmos em diferentes cenários."
+  - "Implementar estruturas de dados lineares, árvores e tabelas de dispersão garantindo eficiência."
+  - "Aplicar algoritmos de ordenação, pesquisa e grafos em problemas práticos."
+youtube_playlists:
+  - id: "PL-19411011-aulas"
+    priority: 1
+  - id: "PL-19411011-labs"
+    priority: 2
+topics:
+  - slug: "complexidade"
+  - slug: "ordenacao"
+  - slug: "pesquisa"
+  - slug: "pilhas-e-filas"
+  - slug: "estruturas-arvore"
+  - slug: "hash-e-grafo"
+  - slug: "projeto-algoritmos"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Revisão de POO em Java e recursos avançados da linguagem.
+- Notação Big-O e análise empírica de desempenho.
+- Algoritmos de ordenação: Bubble, Shell, Quick sort e comparações.
+- Pesquisa linear e binária; pilhas e filas (LIFO/FIFO).
+- Árvores binárias de busca, percursos e árvores AVL.
+- Tabelas de dispersão, grafos, BFS/DFS e aplicações práticas.
+
+## Metodologia
+
+Laboratórios semanais com desafios de programação e análise de desempenho, complementados por projetos que simulam casos reais de uso de estruturas de dados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/ordenacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/ordenacao.md
@@ -1,0 +1,19 @@
+---
+slug: "ordenacao"
+title: "Ordenação"
+summary: "Implementação e análise de algoritmos clássicos como Bubble, Shell e Quick sort."
+youtube_playlists:
+  - id: "PL-TOPIC-ordenacao"
+    priority: 1
+tags:
+  - "ordenar"
+  - "Quick Sort"
+  - "Shell Sort"
+type: topic
+layout: topic
+---
+Implementação e comparação de algoritmos de ordenação clássicos: Bubble Sort, Shell Sort e Quick
+Sort, entendendo os cenários ótimos/piores.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/pesquisa.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/pesquisa.md
@@ -1,0 +1,19 @@
+---
+slug: "pesquisa"
+title: "Pesquisa"
+summary: "Busca sequencial e binária em estruturas lineares ordenadas ou não."
+youtube_playlists:
+  - id: "PL-TOPIC-pesquisa"
+    priority: 1
+tags:
+  - "busca"
+  - "linear"
+  - "binária"
+type: topic
+layout: topic
+---
+Métodos de busca em coleções lineares – busca sequencial (linear) em arrays desordenados e busca
+binária em arrays ordenados, requisitos e análise de eficiência de cada método.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/pilhas-e-filas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/pilhas-e-filas.md
@@ -1,0 +1,20 @@
+---
+slug: "pilhas-e-filas"
+title: "Pilhas e Filas"
+summary: "Estruturas LIFO e FIFO para gerir coleções com ordens específicas."
+youtube_playlists:
+  - id: "PL-TOPIC-pilhas-e-filas"
+    priority: 1
+tags:
+  - "pilha"
+  - "fila"
+  - "LIFO/FIFO"
+type: topic
+layout: topic
+---
+Estruturas de dados lineares dinâmicas – pilha (push, pop, top) aplicadas, p.ex., em execução de
+chamadas de função ou algoritmos de undo; fila (enqueue, dequeue) aplicada em sistemas de espera;
+implementação usando listas ligadas ou arrays circulares.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411011/projeto-algoritmos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411011/projeto-algoritmos.md
@@ -1,0 +1,20 @@
+---
+slug: "projeto-algoritmos"
+title: "Projeto de Algoritmos"
+summary: "Integração de estruturas e algoritmos em aplicações práticas."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-algoritmos"
+    priority: 1
+tags:
+  - "projetos"
+  - "aplicações"
+  - "prática"
+type: topic
+layout: topic
+---
+Integração das estruturas e algoritmos em projetos práticos – e.g., simular fila de atendimento,
+usar pilha para converter expressões, aplicar BFS/DFS para encontrar caminhos curtos ou multiplicar
+matrizes esparsas eficientemente.
+
+Implementações em Java ou Python são acompanhadas de medições experimentais para comparar algoritmos
+e justificar escolhas de estruturas de dados em projetos reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/bd-distribuidas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/bd-distribuidas.md
@@ -1,0 +1,20 @@
+---
+slug: "bd-distribuidas"
+title: "Bases de Dados Distribuídas"
+summary: "Replicação, fragmentação e desafios de consistência entre múltiplos nós."
+youtube_playlists:
+  - id: "PL-TOPIC-bd-distribuidas"
+    priority: 1
+tags:
+  - "replicação"
+  - "fragmentação"
+  - "consistência"
+type: topic
+layout: topic
+---
+Conceitos básicos de distribuição de dados – replicação síncrona/assíncrona para redundância e alta
+disponibilidade; fragmentação horizontal/vertical; desafios de consistência e coordenação;
+integração de múltiplos SGBDs heterogêneos.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/desempenho-bd.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/desempenho-bd.md
@@ -1,0 +1,20 @@
+---
+slug: "desempenho-bd"
+title: "Desempenho de BD"
+summary: "Índices, otimização de consultas, particionamento e escalabilidade."
+youtube_playlists:
+  - id: "PL-TOPIC-desempenho-bd"
+    priority: 1
+tags:
+  - "performance"
+  - "índices"
+  - "escalabilidade"
+type: topic
+layout: topic
+---
+Discussão de fatores que afetam performance de BD – uso de índices, otimização de consultas pelo
+SGBD, particionamento de tabelas, dimensionamento vertical/horizontal; escalabilidade de sistemas de
+BD em cenários de alta carga.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/index.md
@@ -1,0 +1,43 @@
+---
+title: "Base de Dados I"
+code: "19411012"
+course_code: "LESTI"
+description: "Modelação relacional, SQL e introdução a bases de dados distribuídas e NoSQL."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411000"
+learning_outcomes:
+  - "Modelar esquemas relacionais normalizados a partir de requisitos de dados."
+  - "Escrever consultas SQL abrangendo DDL, DML, DCL e otimização básica."
+  - "Comparar arquiteturas relacionais e NoSQL identificando casos de utilização."
+youtube_playlists:
+  - id: "PL-19411012-aulas"
+    priority: 1
+  - id: "PL-19411012-labs"
+    priority: 2
+topics:
+  - slug: "sgbd-conceitos"
+  - slug: "transacoes"
+  - slug: "modelagem-e-normalizacao"
+  - slug: "sql-idioma"
+  - slug: "desempenho-bd"
+  - slug: "bd-distribuidas"
+  - slug: "no-sql"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Sistemas de gestão de bases de dados e arquitetura ANSI/SPARC.
+- Transações, propriedades ACID e controlo de concorrência.
+- Modelação relacional, formas normais e regras de Codd.
+- SQL completo (DDL, DML, DCL) e análise de planos de execução.
+- Estruturas de armazenamento, índices e otimização de consultas.
+- Bases de dados distribuídas, replicação, fragmentação e integração.
+- Introdução ao movimento NoSQL, categorias e teorema CAP.
+
+## Metodologia
+
+Laboratórios com SGBDs reais (PostgreSQL) e desafios de modelação culminam num mini-projeto de base de dados com relatórios de desempenho.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/modelagem-e-normalizacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/modelagem-e-normalizacao.md
@@ -1,0 +1,20 @@
+---
+slug: "modelagem-e-normalizacao"
+title: "Modelagem e Normalização"
+summary: "Transformação de modelos ER em esquemas relacionais e formas normais."
+youtube_playlists:
+  - id: "PL-TOPIC-modelagem-e-normalizacao"
+    priority: 1
+tags:
+  - "modelagem"
+  - "formas normais"
+  - "Codd"
+type: topic
+layout: topic
+---
+Modelagem relacional – transformar um modelo ER em esquema relacional; revisão das 1ª, 2ª, 3ª formas
+normais (e BCNF) para desenho de esquemas consistentes e minimização de redundâncias; entendimento
+das 12 regras de Codd que definem um sistema relacional completo.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/no-sql.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/no-sql.md
@@ -1,0 +1,20 @@
+---
+slug: "no-sql"
+title: "NoSQL"
+summary: "Histórico, categorias e teorema CAP aplicados a bases de dados não relacionais."
+youtube_playlists:
+  - id: "PL-TOPIC-no-sql"
+    priority: 1
+tags:
+  - "NoSQL"
+  - "CAP"
+  - "documentos"
+type: topic
+layout: topic
+---
+Introdução ao universo NoSQL – por que surgiram, explicação do teorema CAP; categorias de NoSQL
+(documentos, colunas, chaves-valor, grafos) e casos de uso; exemplo prático de documento JSON e
+comparativo com SQL.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/sgbd-conceitos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/sgbd-conceitos.md
@@ -1,0 +1,20 @@
+---
+slug: "sgbd-conceitos"
+title: "Conceitos de SGBD"
+summary: "Finalidade dos SGBDs, componentes e arquitetura ANSI/SPARC."
+youtube_playlists:
+  - id: "PL-TOPIC-sgbd-conceitos"
+    priority: 1
+tags:
+  - "SGBD"
+  - "arquitetura"
+  - "independência"
+type: topic
+layout: topic
+---
+Finalidade de um Sistema Gerenciador de Banco de Dados (SGBD) e seus componentes; diferenças entre
+gerir dados via SGBD vs. via arquivos planos; entendimento da arquitetura de 3 níveis (externo,
+conceitual, interno) e independência de dados.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/sql-idioma.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/sql-idioma.md
@@ -1,0 +1,20 @@
+---
+slug: "sql-idioma"
+title: "SQL"
+summary: "DDL, DML, DCL e interpretação de planos de execução."
+youtube_playlists:
+  - id: "PL-TOPIC-sql-idioma"
+    priority: 1
+tags:
+  - "SQL"
+  - "consultas"
+  - "índices"
+type: topic
+layout: topic
+---
+Domínio da sintaxe SQL para definição de esquemas, manipulação de dados e controle de acesso;
+compreensão de como consultas são interpretadas, otimizadas (uso de índices, plano de execução) e
+executadas no SGBD.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411012/transacoes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411012/transacoes.md
@@ -1,0 +1,19 @@
+---
+slug: "transacoes"
+title: "Transações"
+summary: "Propriedades ACID, controlo de concorrência e recuperação."
+youtube_playlists:
+  - id: "PL-TOPIC-transacoes"
+    priority: 1
+tags:
+  - "ACID"
+  - "concorrência"
+  - "recuperação"
+type: topic
+layout: topic
+---
+Conceito de transação de BD (sequência de operações atômicas), propriedades ACID, papel do controle
+de concorrência e recuperação para garantir integridade e isolamento.
+
+Laboratórios com PostgreSQL e ferramentas de profiling demonstram impactos de modelagem, índices e
+consultas no desempenho das aplicações.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/algoritmos-nao-supervisionados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/algoritmos-nao-supervisionados.md
@@ -1,0 +1,19 @@
+---
+slug: "algoritmos-nao-supervisionados"
+title: "Algoritmos Não Supervisionados"
+summary: "Clusterização, redução de dimensionalidade e deteção de anomalias."
+youtube_playlists:
+  - id: "PL-TOPIC-algoritmos-nao-supervisionados"
+    priority: 1
+tags:
+  - "clusterização"
+  - "PCA"
+  - "anomalias"
+type: topic
+layout: topic
+---
+Exploração de técnicas sem rótulos predefinidos – clusterização (k-means, DBSCAN), redução de
+dimensionalidade (PCA, autoencoders), e detecção de outliers/anomalias.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/algoritmos-supervisionados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/algoritmos-supervisionados.md
@@ -1,0 +1,19 @@
+---
+slug: "algoritmos-supervisionados"
+title: "Algoritmos Supervisionados"
+summary: "Estudo de k-NN, regressões, árvores, ensembles, SVM e redes neurais básicas."
+youtube_playlists:
+  - id: "PL-TOPIC-algoritmos-supervisionados"
+    priority: 1
+tags:
+  - "classificação"
+  - "regressão"
+  - "SVM"
+type: topic
+layout: topic
+---
+Estudo detalhado de algoritmos de classificação/regressão: funcionamento do k-NN, regressão linear e
+logística, árvores de decisão, ensembles, SVM e redes neurais artificiais básicas.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/aplicacoes-ml.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/aplicacoes-ml.md
@@ -1,0 +1,19 @@
+---
+slug: "aplicacoes-ml"
+title: "Aplicações de ML"
+summary: "Casos de uso como classificação de spam, previsão e reconhecimento de padrões."
+youtube_playlists:
+  - id: "PL-TOPIC-aplicacoes-ml"
+    priority: 1
+tags:
+  - "casos de uso"
+  - "previsão"
+  - "padrões"
+type: topic
+layout: topic
+---
+Discussão de casos de uso reais de ML – classificação de spam, previsão de valores, reconhecimento
+de dígitos, agrupamento de clientes – para contextualizar os algoritmos em cenários práticos.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/frameworks-ml.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/frameworks-ml.md
@@ -1,0 +1,20 @@
+---
+slug: "frameworks-ml"
+title: "Frameworks de ML"
+summary: "Uso de bibliotecas e plataformas para experimentação em machine learning."
+youtube_playlists:
+  - id: "PL-TOPIC-frameworks-ml"
+    priority: 1
+tags:
+  - "scikit-learn"
+  - "TensorFlow"
+  - "PyTorch"
+type: topic
+layout: topic
+---
+Familiarização com ferramentas populares para desenvolvimento de modelos de ML – bibliotecas Python
+(scikit-learn, TensorFlow/Keras, PyTorch) e plataformas visuais (WEKA, Google Colab, etc.),
+facilitando experimentação.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/index.md
@@ -1,0 +1,45 @@
+---
+title: "Aprendizagem Automática"
+code: "19411013"
+course_code: "LESTI"
+description: "Fundamentos de machine learning, algoritmos supervisionados e não supervisionados e avaliação de modelos."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411002"
+  - "19411012"
+learning_outcomes:
+  - "Distinguir paradigmas de aprendizagem e identificar problemas adequados a cada abordagem."
+  - "Preparar dados, selecionar atributos e treinar modelos supervisionados e não supervisionados."
+  - "Avaliar modelos com métricas apropriadas e ajustar hiperparâmetros utilizando pipelines automatizados."
+youtube_playlists:
+  - id: "PL-19411013-aulas"
+    priority: 1
+  - id: "PL-19411013-labs"
+    priority: 2
+topics:
+  - slug: "ml-fundamentos"
+  - slug: "frameworks-ml"
+  - slug: "algoritmos-supervisionados"
+  - slug: "algoritmos-nao-supervisionados"
+  - slug: "preparacao-dados"
+  - slug: "validacao-e-metricas"
+  - slug: "pipeline-ml"
+  - slug: "aplicacoes-ml"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos de machine learning, datasets de treino/teste, overfitting e underfitting.
+- Ferramentas e bibliotecas (scikit-learn, TensorFlow, plataformas AutoML).
+- Algoritmos supervisionados: k-NN, regressões, árvores, ensembles, SVM, redes neurais básicas.
+- Algoritmos não supervisionados: clusterização, redução de dimensionalidade e deteção de anomalias.
+- Engenharia de atributos e pipelines de processamento.
+- Validação cruzada, métricas de classificação/regressão, ajuste de hiperparâmetros.
+- Aplicações reais e discussões éticas sobre o uso de ML.
+
+## Metodologia
+
+Projetos guiados em notebooks permitem explorar diferentes algoritmos com datasets reais, culminando num mini-projeto com relatório analítico.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/ml-fundamentos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/ml-fundamentos.md
@@ -1,0 +1,19 @@
+---
+slug: "ml-fundamentos"
+title: "Fundamentos de Machine Learning"
+summary: "Paradigmas supervisionado, não supervisionado, overfitting e underfitting."
+youtube_playlists:
+  - id: "PL-TOPIC-ml-fundamentos"
+    priority: 1
+tags:
+  - "supervisionado"
+  - "não supervisionado"
+  - "overfitting"
+type: topic
+layout: topic
+---
+Conceitos básicos de Machine Learning, incluindo diferenças entre aprendizagem supervisionada, não
+supervisionada, e entendimento dos termos overfitting e underfitting.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/pipeline-ml.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/pipeline-ml.md
@@ -1,0 +1,20 @@
+---
+slug: "pipeline-ml"
+title: "Pipelines de ML"
+summary: "Construção de fluxos automatizados de pré-processamento, treino e avaliação."
+youtube_playlists:
+  - id: "PL-TOPIC-pipeline-ml"
+    priority: 1
+tags:
+  - "pipeline"
+  - "automação"
+  - "workflow"
+type: topic
+layout: topic
+---
+Montagem de um fluxo completo de Machine Learning: ingestão e limpeza de dados, transformação e
+seleção de características, treino do modelo, avaliação, ajuste e implementação de pipeline
+automatizado.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/preparacao-dados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/preparacao-dados.md
@@ -1,0 +1,19 @@
+---
+slug: "preparacao-dados"
+title: "Preparação de Dados"
+summary: "Normalização, codificação e engenharia de atributos para melhorar modelos."
+youtube_playlists:
+  - id: "PL-TOPIC-preparacao-dados"
+    priority: 1
+tags:
+  - "feature engineering"
+  - "normalização"
+  - "codificação"
+type: topic
+layout: topic
+---
+Técnicas de pré-processamento e feature engineering – normalização/escala de atributos, codificação
+de variáveis categóricas, seleção de atributos informativos e criação de novas variáveis derivadas.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411013/validacao-e-metricas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411013/validacao-e-metricas.md
@@ -1,0 +1,20 @@
+---
+slug: "validacao-e-metricas"
+title: "Validação e Métricas"
+summary: "Cross-validation, ajuste de hiperparâmetros e métricas de desempenho."
+youtube_playlists:
+  - id: "PL-TOPIC-validacao-e-metricas"
+    priority: 1
+tags:
+  - "cross-validation"
+  - "métricas"
+  - "hiperparâmetros"
+type: topic
+layout: topic
+---
+Procedimentos para avaliar modelos de forma confiável – separar dados de treino/validação/teste,
+usar cross-validation, ajustar hiperparâmetros via grid search e compreender métricas de
+classificação e regressão.
+
+Notebooks interativos com datasets reais permitem experimentar diferentes algoritmos, avaliar
+métricas e comunicar achados de forma ética e transparente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/enderecamento-e-roteamento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/enderecamento-e-roteamento.md
@@ -1,0 +1,19 @@
+---
+slug: "enderecamento-e-roteamento"
+title: "Endereçamento e Roteamento"
+summary: "IPv4/IPv6, subnetting, ARP, ICMP e roteamento básico."
+youtube_playlists:
+  - id: "PL-TOPIC-enderecamento-e-roteamento"
+    priority: 1
+tags:
+  - "IPv4"
+  - "subnetting"
+  - "roteamento"
+type: topic
+layout: topic
+---
+Estrutura de endereços IPv4/IPv6, máscaras de sub-rede, ARP, ICMP e configuração de roteamento
+estático entre redes pequenas.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/fisica-e-enlace.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/fisica-e-enlace.md
@@ -1,0 +1,19 @@
+---
+slug: "fisica-e-enlace"
+title: "Camadas Física e de Enlace"
+summary: "Sinalização, limite de Shannon, enquadramento e controle de erros/fluxo."
+youtube_playlists:
+  - id: "PL-TOPIC-fisica-e-enlace"
+    priority: 1
+tags:
+  - "modulação"
+  - "CRC"
+  - "ARQ"
+type: topic
+layout: topic
+---
+Camada física – sinalização de bits, modulação, largura de banda, limite de Shannon; camada de
+enlace – enquadramento, detecção/correção de erros (CRC), protocolos ARQ e controle de fluxo.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/index.md
@@ -1,0 +1,40 @@
+---
+title: "Redes de Computadores"
+code: "19411014"
+course_code: "LESTI"
+description: "Fundamentos de redes, camadas OSI/TCP-IP, protocolos e projeto de LANs."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411005"
+learning_outcomes:
+  - "Descrever as camadas de rede e os principais protocolos envolvidos na comunicação de dados."
+  - "Projetar e configurar redes locais cabladas e sem fios com endereçamento IPv4/IPv6."
+  - "Analisar protocolos de transporte e aplicação para suportar serviços distribuídos."
+youtube_playlists:
+  - id: "PL-19411014-aulas"
+    priority: 1
+  - id: "PL-19411014-labs"
+    priority: 2
+topics:
+  - slug: "principios-redes"
+  - slug: "fisica-e-enlace"
+  - slug: "redes-locais"
+  - slug: "enderecamento-e-roteamento"
+  - slug: "transporte-e-aplicacao"
+  - slug: "protocolos-servicos"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos fundamentais de redes, meios de transmissão e topologias.
+- Camadas física e de ligação: modulação, enquadramento, controlo de erros e fluxo.
+- Redes locais Ethernet e Wi-Fi, dimensionamento e configuração.
+- Endereçamento IPv4/IPv6, subnetting, ARP, ICMP e roteamento básico.
+- Camada de transporte (TCP/UDP) e protocolos de aplicação (HTTP, FTP, SMTP, DNS).
+
+## Metodologia
+
+Aulas laboratoriais com simuladores e equipamentos reais reforçam a compreensão dos protocolos e das configurações de rede, apoiadas por estudos de caso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/principios-redes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/principios-redes.md
@@ -1,0 +1,19 @@
+---
+slug: "principios-redes"
+title: "Princípios de Redes"
+summary: "Componentes de redes, meios de transmissão e modelos OSI/TCP-IP."
+youtube_playlists:
+  - id: "PL-TOPIC-principios-redes"
+    priority: 1
+tags:
+  - "OSI"
+  - "topologias"
+  - "meios"
+type: topic
+layout: topic
+---
+Entendimento dos componentes de uma rede de computadores – meio físico, topologias e importância de
+normas (OSI, IEEE) para interoperabilidade; introdução ao modelo OSI e ao modelo TCP/IP.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/protocolos-servicos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/protocolos-servicos.md
@@ -1,0 +1,19 @@
+---
+slug: "protocolos-servicos"
+title: "Protocolos e Serviços"
+summary: "HTTP, FTP, SMTP, DNS e outros protocolos de aplicação comuns."
+youtube_playlists:
+  - id: "PL-TOPIC-protocolos-servicos"
+    priority: 1
+tags:
+  - "HTTP"
+  - "SMTP"
+  - "DNS"
+type: topic
+layout: topic
+---
+Operação de protocolos da camada de aplicação: HTTP, SMTP/POP3/IMAP, FTP, DNS; como esses protocolos
+utilizam as camadas inferiores para oferecer serviços ao utilizador.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/redes-locais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/redes-locais.md
@@ -1,0 +1,19 @@
+---
+slug: "redes-locais"
+title: "Redes Locais"
+summary: "Ethernet, Wi-Fi, dimensionamento e configuração de LANs."
+youtube_playlists:
+  - id: "PL-TOPIC-redes-locais"
+    priority: 1
+tags:
+  - "Ethernet"
+  - "Wi-Fi"
+  - "VLAN"
+type: topic
+layout: topic
+---
+Funcionamento de redes Ethernet e Wi-Fi, configuração de LANs com switches e pontos de acesso,
+noções de VLAN e cálculo de recursos para projetos de rede.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411014/transporte-e-aplicacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411014/transporte-e-aplicacao.md
@@ -1,0 +1,19 @@
+---
+slug: "transporte-e-aplicacao"
+title: "Camadas de Transporte e Aplicação"
+summary: "TCP vs. UDP, controlo de congestionamento e portas de serviços."
+youtube_playlists:
+  - id: "PL-TOPIC-transporte-e-aplicacao"
+    priority: 1
+tags:
+  - "TCP"
+  - "UDP"
+  - "congestionamento"
+type: topic
+layout: topic
+---
+Mecanismos do TCP (handshake, janela deslizante, controle de congestionamento) versus UDP;
+identificação de aplicações via números de porta.
+
+Configurações em simuladores e equipamentos físicos evidenciam como escolhas de endereçamento e
+protocolos afetam disponibilidade e desempenho de serviços.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/computacao-grafica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/computacao-grafica.md
@@ -1,0 +1,20 @@
+---
+slug: "computacao-grafica"
+title: "Computação Gráfica"
+summary: "Pipeline gráfico, modelação 3D e renderização em ecrãs 2D."
+youtube_playlists:
+  - id: "PL-TOPIC-computacao-grafica"
+    priority: 1
+tags:
+  - "renderização"
+  - "modelagem"
+  - "OpenGL"
+type: topic
+layout: topic
+---
+Fundamentos de geração de gráficos por computador – pipeline gráfico básico, renderização de objetos
+3D em ecrã 2D, noções de modelagem geométrica (malhas de polígonos, curvas, texturas), e introdução
+a OpenGL ou bibliotecas gráficas similares.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/index.md
@@ -1,0 +1,42 @@
+---
+title: "Computação Visual"
+code: "19411015"
+course_code: "LESTI"
+description: "Conceitos de computação gráfica, processamento de imagem, visão computacional e realidade aumentada."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411011"
+  - "19411012"
+learning_outcomes:
+  - "Implementar pipelines básicos de computação gráfica e processamento de imagem."
+  - "Aplicar algoritmos de visão computacional para deteção e reconhecimento de objetos."
+  - "Integrar componentes visuais em protótipos interativos ou de realidade aumentada."
+youtube_playlists:
+  - id: "PL-19411015-aulas"
+    priority: 1
+  - id: "PL-19411015-labs"
+    priority: 2
+topics:
+  - slug: "computacao-grafica"
+  - slug: "processamento-imagem"
+  - slug: "visao-computacional"
+  - slug: "realidade-aumentada"
+  - slug: "interacao-3d"
+  - slug: "projeto-integrador-visual"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Introdução à computação gráfica e modelação de objetos 3D.
+- Processamento digital de imagens: filtros, deteção de contornos, morfologia.
+- Visão computacional: deteção e reconhecimento de objetos, faces e poses.
+- Fundamentos de realidade aumentada e integração com o mundo real.
+- Interação homem-máquina e dispositivos imersivos.
+- Projeto prático integrando gráficos, imagem e visão.
+
+## Metodologia
+
+Workshops práticos com Blender, OpenCV e MediaPipe conduzem ao desenvolvimento de um protótipo final demonstrado publicamente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/interacao-3d.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/interacao-3d.md
@@ -1,0 +1,19 @@
+---
+slug: "interacao-3d"
+title: "Interação 3D"
+summary: "Dispositivos e interfaces homem-máquina para experiências visuais imersivas."
+youtube_playlists:
+  - id: "PL-TOPIC-interacao-3d"
+    priority: 1
+tags:
+  - "VR"
+  - "interfaces"
+  - "dispositivos"
+type: topic
+layout: topic
+---
+Dispositivos de interação para aplicações visuais (monitores 3D, VR/AR, câmaras de profundidade) e
+design de interfaces homem-máquina centradas em elementos visuais.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/processamento-imagem.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/processamento-imagem.md
@@ -1,0 +1,20 @@
+---
+slug: "processamento-imagem"
+title: "Processamento de Imagem"
+summary: "Filtros, ajustes e deteção de bordas em imagens digitais."
+youtube_playlists:
+  - id: "PL-TOPIC-processamento-imagem"
+    priority: 1
+tags:
+  - "filtros"
+  - "bordas"
+  - "OpenCV"
+type: topic
+layout: topic
+---
+Técnicas para manipulação de imagens digitais 2D – ajustes de brilho/contraste, filtros espaciais
+(blur, sharpen), algoritmos de deteção de bordas (Sobel, Canny), morfologia matemática, geralmente
+usando bibliotecas como OpenCV.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/projeto-integrador-visual.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/projeto-integrador-visual.md
@@ -1,0 +1,20 @@
+---
+slug: "projeto-integrador-visual"
+title: "Projeto Integrador Visual"
+summary: "Desenvolvimento de protótipo que combina gráficos 3D, processamento de imagem e visão."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-integrador-visual"
+    priority: 1
+tags:
+  - "projeto"
+  - "Blender"
+  - "integração"
+type: topic
+layout: topic
+---
+Desenvolvimento de um projeto prático que combine computação gráfica, processamento de imagem e
+visão computacional – usando Blender para modelos, OpenCV/MediaPipe para análise de imagem e
+integração em programa interativo.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/realidade-aumentada.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/realidade-aumentada.md
@@ -1,0 +1,20 @@
+---
+slug: "realidade-aumentada"
+title: "Realidade Aumentada"
+summary: "Calibração de câmaras, rastreamento e sobreposição de objetos virtuais no mundo real."
+youtube_playlists:
+  - id: "PL-TOPIC-realidade-aumentada"
+    priority: 1
+tags:
+  - "AR"
+  - "rastreio"
+  - "calibração"
+type: topic
+layout: topic
+---
+Princípios de AR – calibração de câmera, rastreamento de marcadores ou características no mundo
+real, sobreposição de modelos virtuais em tempo real; exemplos de AR em dispositivos móveis ou
+óculos.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411015/visao-computacional.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411015/visao-computacional.md
@@ -1,0 +1,19 @@
+---
+slug: "visao-computacional"
+title: "Visão Computacional"
+summary: "Deteção e reconhecimento de padrões visuais em imagens e vídeo."
+youtube_playlists:
+  - id: "PL-TOPIC-visao-computacional"
+    priority: 1
+tags:
+  - "detecção"
+  - "reconhecimento"
+  - "MediaPipe"
+type: topic
+layout: topic
+---
+Elementos de visão computacional – deteção de características em imagens/vídeo (faces, objetos),
+reconhecimento de padrões visuais e estimação de pose corporal com ferramentas como MediaPipe.
+
+Workshops com Blender, OpenCV e MediaPipe resultam em protótipos interativos apresentados em mostras
+públicas do curso.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/analise-estruturada-vs-oo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/analise-estruturada-vs-oo.md
@@ -1,0 +1,19 @@
+---
+slug: "analise-estruturada-vs-oo"
+title: "Análise Estruturada vs OO"
+summary: "Comparação entre enfoques centrados em dados/fluxos e orientados a objetos."
+youtube_playlists:
+  - id: "PL-TOPIC-analise-estruturada-vs-oo"
+    priority: 1
+tags:
+  - "DFD"
+  - "OO"
+  - "modelagem"
+type: topic
+layout: topic
+---
+Contraste entre análise estruturada (fluxos de dados, DFDs) e análise orientada a objetos
+(identificação de classes e relacionamentos) e impacto nas etapas de design e implementação.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/ferramentas-case.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/ferramentas-case.md
@@ -1,0 +1,19 @@
+---
+slug: "ferramentas-case"
+title: "Ferramentas CASE"
+summary: "Uso de ferramentas para desenhar UML e gerar código esqueleto."
+youtube_playlists:
+  - id: "PL-TOPIC-ferramentas-case"
+    priority: 1
+tags:
+  - "CASE"
+  - "modelagem"
+  - "geração de código"
+type: topic
+layout: topic
+---
+Experimentação com ferramentas CASE para desenhar diagramas UML e gerar esboço de código, avaliando
+vantagens e limitações.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/gestao-projeto-sw.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/gestao-projeto-sw.md
@@ -1,0 +1,19 @@
+---
+slug: "gestao-projeto-sw"
+title: "Gestão de Projeto de Software"
+summary: "Aplicação de práticas tradicionais e ágeis, integração contínua e métricas."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-projeto-sw"
+    priority: 1
+tags:
+  - "Scrum"
+  - "WBS"
+  - "CI/CD"
+type: topic
+layout: topic
+---
+Práticas de gerenciamento aplicadas a projetos de software – WBS, cronogramas, gestão de backlog,
+reuniões ágeis e uso de integração contínua/entrega contínua.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/index.md
@@ -1,0 +1,43 @@
+---
+title: "Engenharia de Software"
+code: "19411016"
+course_code: "LESTI"
+description: "Processos de desenvolvimento, UML, ferramentas CASE e gestão de projetos de software."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411006"
+  - "19411001"
+learning_outcomes:
+  - "Comparar modelos de ciclo de vida e selecionar processos adequados ao contexto do projeto."
+  - "Modelar requisitos e arquitetura utilizando UML e ferramentas CASE."
+  - "Aplicar práticas de gestão de projetos e integração contínua alinhadas a métodos ágeis e tradicionais."
+youtube_playlists:
+  - id: "PL-19411016-aulas"
+    priority: 1
+  - id: "PL-19411016-oficinas"
+    priority: 2
+topics:
+  - slug: "processo-software"
+  - slug: "analise-estruturada-vs-oo"
+  - slug: "uml-casos-uso"
+  - slug: "uml-classes-sequencias"
+  - slug: "uml-estados-atividades"
+  - slug: "uml-componentes"
+  - slug: "ferramentas-case"
+  - slug: "gestao-projeto-sw"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Processos de software: cascata, incremental, espiral e ágil.
+- Análise estruturada versus orientada a objetos.
+- UML: casos de uso, diagramas de classes, sequência, estados, atividades, componentes e implantação.
+- Ferramentas CASE e geração de código.
+- Gestão de projetos de software: PMBOK vs Scrum, métricas, integração contínua.
+
+## Metodologia
+
+Projetos em equipa com iterações controladas, revisões de artefactos e integração contínua simulam o ciclo completo de desenvolvimento e entrega de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/processo-software.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/processo-software.md
@@ -1,0 +1,19 @@
+---
+slug: "processo-software"
+title: "Processo de Software"
+summary: "Modelos de ciclo de vida como cascata, incremental, espiral e ágil."
+youtube_playlists:
+  - id: "PL-TOPIC-processo-software"
+    priority: 1
+tags:
+  - "ciclo de vida"
+  - "ágil"
+  - "espiral"
+type: topic
+layout: topic
+---
+Importância de um processo definido – descrição de modelos clássicos (cascata, espiral, métodos
+ágeis) e entregáveis de cada fase.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-casos-uso.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-casos-uso.md
@@ -1,0 +1,19 @@
+---
+slug: "uml-casos-uso"
+title: "UML – Casos de Uso"
+summary: "Identificação de atores, cenários e relações include/extend."
+youtube_playlists:
+  - id: "PL-TOPIC-uml-casos-uso"
+    priority: 1
+tags:
+  - "UML"
+  - "casos de uso"
+  - "atores"
+type: topic
+layout: topic
+---
+Representação de requisitos funcionais através de casos de uso UML – atores, cenários, relação
+include/extend e elaboração de especificações textuais.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-classes-sequencias.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-classes-sequencias.md
@@ -1,0 +1,19 @@
+---
+slug: "uml-classes-sequencias"
+title: "UML – Classes e Sequências"
+summary: "Modelagem estrutural e temporal de interações entre objetos."
+youtube_playlists:
+  - id: "PL-TOPIC-uml-classes-sequencias"
+    priority: 1
+tags:
+  - "diagrama de classes"
+  - "sequência"
+  - "relacionamentos"
+type: topic
+layout: topic
+---
+Criação de diagramas de classes (atributos, métodos, relacionamentos) e diagramas de sequência
+mostrando interação temporal entre objetos.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-componentes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-componentes.md
@@ -1,0 +1,19 @@
+---
+slug: "uml-componentes"
+title: "UML – Componentes e Implantação"
+summary: "Arquitetura de alto nível com módulos de software e nós de hardware."
+youtube_playlists:
+  - id: "PL-TOPIC-uml-componentes"
+    priority: 1
+tags:
+  - "componentes"
+  - "implantação"
+  - "arquitetura"
+type: topic
+layout: topic
+---
+Representação da arquitetura com diagramas de componentes (módulos, interfaces) e de implantação
+(distribuição em nós de hardware).
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-estados-atividades.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411016/uml-estados-atividades.md
@@ -1,0 +1,19 @@
+---
+slug: "uml-estados-atividades"
+title: "UML – Estados e Atividades"
+summary: "Modelagem de comportamento interno e fluxos de trabalho."
+youtube_playlists:
+  - id: "PL-TOPIC-uml-estados-atividades"
+    priority: 1
+tags:
+  - "estados"
+  - "atividades"
+  - "fluxos"
+type: topic
+layout: topic
+---
+Uso de diagramas de estados para modelar comportamento de objetos e diagramas de atividades para
+representar fluxos com paralelismo e sincronização.
+
+Trabalhos em equipa produzem artefactos UML, pipelines de integração contínua e documentação
+alinhada a práticas profissionais de engenharia de software.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/backup-recuperacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/backup-recuperacao.md
@@ -1,0 +1,19 @@
+---
+slug: "backup-recuperacao"
+title: "Backup e Recuperação"
+summary: "Estratégias de backup completo/incremental e restauração após falhas."
+youtube_playlists:
+  - id: "PL-TOPIC-backup-recuperacao"
+    priority: 1
+tags:
+  - "backup"
+  - "restore"
+  - "logs"
+type: topic
+layout: topic
+---
+Importância de backups regulares; métodos (online/offline, completo/diferencial/incremental) e
+restauração em caso de falha utilizando logs de transação.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/catalogo-sistema.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/catalogo-sistema.md
@@ -1,0 +1,19 @@
+---
+slug: "catalogo-sistema"
+title: "Catálogo do Sistema"
+summary: "Metadados, dicionário de dados, views e programação armazenada."
+youtube_playlists:
+  - id: "PL-TOPIC-catalogo-sistema"
+    priority: 1
+tags:
+  - "metadados"
+  - "views"
+  - "triggers"
+type: topic
+layout: topic
+---
+Estrutura do dicionário de dados – tabelas de sistema que armazenam metadados; diferenças e usos de
+views, materialized views, tabelas externas; uso de triggers e lógica de negócio no BD.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/index.md
@@ -1,0 +1,45 @@
+---
+title: "Base de Dados II"
+code: "19411017"
+course_code: "LESTI"
+description: "Arquitetura interna de SGBDs, SQL avançado, tuning, segurança e replicação."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411012"
+learning_outcomes:
+  - "Configurar estruturas de storage, índices e particionamento para suportar grandes volumes de dados."
+  - "Desenvolver código SQL avançado, triggers e programação armazenada com foco em desempenho."
+  - "Implementar estratégias de backup, recuperação, replicação e segurança em SGBDs empresariais."
+youtube_playlists:
+  - id: "PL-19411017-aulas"
+    priority: 1
+  - id: "PL-19411017-labs"
+    priority: 2
+topics:
+  - slug: "storage-interno"
+  - slug: "catalogo-sistema"
+  - slug: "sql-avancado"
+  - slug: "tuning-bd"
+  - slug: "transacoes-concorrencia"
+  - slug: "backup-recuperacao"
+  - slug: "replicacao-distribuicao"
+  - slug: "seguranca-bd"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Estruturas de ficheiros, blocos de dados, buffers e uso de RAID.
+- Metadados, dicionário de dados, views, materialized views, triggers e programação armazenada.
+- SQL avançado, índices especializados e leitura de planos de execução.
+- Técnicas de tuning, particionamento e processamento paralelo.
+- Controlo de concorrência, isolamento, deadlocks e MVCC.
+- Estratégias de backup/restore e recuperação de desastres.
+- Replicação, sharding e arquitetura distribuída.
+- Segurança, gestão de permissões, auditoria e encriptação.
+
+## Metodologia
+
+Estudos de caso com SGBDs empresariais e laboratórios orientados a troubleshooting conduzem a um relatório técnico de otimização e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/replicacao-distribuicao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/replicacao-distribuicao.md
@@ -1,0 +1,19 @@
+---
+slug: "replicacao-distribuicao"
+title: "Replicação e Distribuição"
+summary: "Topologias de replicação e sharding para escalar bases de dados."
+youtube_playlists:
+  - id: "PL-TOPIC-replicacao-distribuicao"
+    priority: 1
+tags:
+  - "replicação"
+  - "sharding"
+  - "consistência"
+type: topic
+layout: topic
+---
+Visão geral de replicação de dados – mestre-escravo, multi-mestre, consistência eventual;
+particionamento horizontal em shards para escalar sistemas de alta carga.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/seguranca-bd.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/seguranca-bd.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-bd"
+title: "Segurança de Bases de Dados"
+summary: "Gestão de utilizadores, privilégios, encriptação e auditoria."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-bd"
+    priority: 1
+tags:
+  - "permissões"
+  - "encriptação"
+  - "auditoria"
+type: topic
+layout: topic
+---
+Criação e gestão de utilizadores no SGBD, atribuição de privilégios mínimos necessários, mecanismos
+de autenticação, encriptação e auditoria de operações.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/sql-avancado.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/sql-avancado.md
@@ -1,0 +1,19 @@
+---
+slug: "sql-avancado"
+title: "SQL Avançado"
+summary: "Consultas complexas, índices especializados e leitura de planos de execução."
+youtube_playlists:
+  - id: "PL-TOPIC-sql-avancado"
+    priority: 1
+tags:
+  - "CTE"
+  - "índices"
+  - "plano de execução"
+type: topic
+layout: topic
+---
+Consulta SQL de alta complexidade – junções múltiplas, subconsultas correlacionadas, CTEs; quando e
+como os índices ajudam (B-tree, bitmap); interpretação de planos de execução.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/storage-interno.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/storage-interno.md
@@ -1,0 +1,19 @@
+---
+slug: "storage-interno"
+title: "Storage Interno"
+summary: "Organização física de dados, buffers e uso de RAID em SGBDs."
+youtube_playlists:
+  - id: "PL-TOPIC-storage-interno"
+    priority: 1
+tags:
+  - "storage"
+  - "buffers"
+  - "RAID"
+type: topic
+layout: topic
+---
+Organização de como os SGBDs guardam dados no disco – páginas, extensões, gestão de buffers em
+memória, técnicas de RAID para redundância e performance.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/transacoes-concorrencia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/transacoes-concorrencia.md
@@ -1,0 +1,19 @@
+---
+slug: "transacoes-concorrencia"
+title: "Transações e Concorrência"
+summary: "Isolamento, locks, MVCC e gestão de deadlocks."
+youtube_playlists:
+  - id: "PL-TOPIC-transacoes-concorrencia"
+    priority: 1
+tags:
+  - "isolamento"
+  - "locks"
+  - "MVCC"
+type: topic
+layout: topic
+---
+Mecanismos de isolamento de transações – níveis (READ COMMITTED, REPEATABLE READ, SERIALIZABLE),
+implementações via bloqueios ou MVCC e tratamento de deadlocks.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411017/tuning-bd.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411017/tuning-bd.md
@@ -1,0 +1,19 @@
+---
+slug: "tuning-bd"
+title: "Tuning de BD"
+summary: "Particionamento, processamento paralelo e monitorização de desempenho."
+youtube_playlists:
+  - id: "PL-TOPIC-tuning-bd"
+    priority: 1
+tags:
+  - "otimização"
+  - "particionamento"
+  - "monitorização"
+type: topic
+layout: topic
+---
+Técnicas de otimização de BD – normalização vs desnormalização, particionamento de tabelas,
+configuração de paralelismo e monitorização de estatísticas para ajuste de parâmetros do servidor.
+
+Casos reais de tuning e administração de SGBDs são debatidos em aula, reforçando estratégias de
+disponibilidade e segurança empresarial.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/analise-dados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/analise-dados.md
@@ -1,0 +1,19 @@
+---
+slug: "analise-dados"
+title: "Análise de Dados"
+summary: "Estatística descritiva e visualização inicial com histogramas e boxplots."
+youtube_playlists:
+  - id: "PL-TOPIC-analise-dados"
+    priority: 1
+tags:
+  - "descritiva"
+  - "histograma"
+  - "boxplot"
+type: topic
+layout: topic
+---
+Técnicas para sumarizar um conjunto de dados – média, mediana, moda, variância e representações
+gráficas como histogramas e boxplots.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/conceitos-probabilidade.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/conceitos-probabilidade.md
@@ -1,0 +1,19 @@
+---
+slug: "conceitos-probabilidade"
+title: "Conceitos de Probabilidade"
+summary: "Axiomas de Kolmogorov, operações com eventos e teorema de Bayes."
+youtube_playlists:
+  - id: "PL-TOPIC-conceitos-probabilidade"
+    priority: 1
+tags:
+  - "axiomas"
+  - "eventos"
+  - "Bayes"
+type: topic
+layout: topic
+---
+Definição formal de probabilidade, operações com eventos (união, interseção, complemento) e
+aplicação do teorema de Bayes em problemas práticos.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/index.md
@@ -1,0 +1,41 @@
+---
+title: "Probabilidades e Estatística"
+code: "19411018"
+course_code: "LESTI"
+description: "Fundamentos de probabilidade, estatística descritiva, inferência e regressão linear."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411002"
+learning_outcomes:
+  - "Modelar eventos aleatórios usando distribuições discretas e contínuas relevantes."
+  - "Aplicar técnicas de análise descritiva, estimação e testes de hipóteses a conjuntos de dados."
+  - "Construir modelos de regressão linear e interpretar indicadores de correlação."
+youtube_playlists:
+  - id: "PL-19411018-aulas"
+    priority: 1
+  - id: "PL-19411018-exercicios"
+    priority: 2
+topics:
+  - slug: "conceitos-probabilidade"
+  - slug: "variaveis-aleatorias"
+  - slug: "analise-dados"
+  - slug: "inferencias-estatisticas"
+  - slug: "testagem-hipoteses"
+  - slug: "regressao-linear"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Eventos, axiomas de probabilidade, probabilidade condicional e teorema de Bayes.
+- Variáveis aleatórias discretas e contínuas, esperança e variância.
+- Estatística descritiva e representações gráficas.
+- Distribuições amostrais, intervalos de confiança e estimação.
+- Testes de hipóteses (z, t, qui-quadrado) e interpretação de p-valores.
+- Regressão linear, correlação e análise de resíduos.
+
+## Metodologia
+
+Aplicações computacionais com folhas de cálculo e Python reforçam a compreensão dos métodos estatísticos e suportam relatórios analíticos baseados em dados reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/inferencias-estatisticas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/inferencias-estatisticas.md
@@ -1,0 +1,19 @@
+---
+slug: "inferencias-estatisticas"
+title: "Inferências Estatísticas"
+summary: "Distribuições amostrais, intervalos de confiança e estimação."
+youtube_playlists:
+  - id: "PL-TOPIC-inferencias-estatisticas"
+    priority: 1
+tags:
+  - "intervalos"
+  - "estimação"
+  - "amostragem"
+type: topic
+layout: topic
+---
+Conceito de distribuição amostral, construção de intervalos de confiança para média e proporção,
+impacto do tamanho amostral na precisão.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/regressao-linear.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/regressao-linear.md
@@ -1,0 +1,19 @@
+---
+slug: "regressao-linear"
+title: "Regressão Linear"
+summary: "Modelos de regressão simples, coeficiente de correlação e análise de resíduos."
+youtube_playlists:
+  - id: "PL-TOPIC-regressao-linear"
+    priority: 1
+tags:
+  - "regressão"
+  - "correlação"
+  - "resíduos"
+type: topic
+layout: topic
+---
+Ajuste de reta aos dados via mínimos quadrados, interpretação de coeficientes, correlação e
+avaliação por resíduos.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/testagem-hipoteses.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/testagem-hipoteses.md
@@ -1,0 +1,19 @@
+---
+slug: "testagem-hipoteses"
+title: "Testagem de Hipóteses"
+summary: "Procedimentos de testes z, t e qui-quadrado, p-valores e erros."
+youtube_playlists:
+  - id: "PL-TOPIC-testagem-hipoteses"
+    priority: 1
+tags:
+  - "testes"
+  - "p-valor"
+  - "significância"
+type: topic
+layout: topic
+---
+Formulação de H0 e H1, escolha de testes (z, t, χ²), cálculo de estatísticas e p-valores,
+interpretação de erros tipo I e II.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411018/variaveis-aleatorias.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411018/variaveis-aleatorias.md
@@ -1,0 +1,19 @@
+---
+slug: "variaveis-aleatorias"
+title: "Variáveis Aleatórias"
+summary: "Distribuições discretas e contínuas, esperança e variância."
+youtube_playlists:
+  - id: "PL-TOPIC-variaveis-aleatorias"
+    priority: 1
+tags:
+  - "distribuições"
+  - "esperança"
+  - "variância"
+type: topic
+layout: topic
+---
+Caracterização de variáveis aleatórias discretas (binomial, Poisson) e contínuas (normal, uniforme);
+cálculo de esperança e variância.
+
+Aplicações em folhas de cálculo e Python permitem investigar dados reais e comunicar resultados
+estatísticos de forma clara.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/desenho-ui-ux-mobile.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/desenho-ui-ux-mobile.md
@@ -1,0 +1,19 @@
+---
+slug: "desenho-ui-ux-mobile"
+title: "Design UI/UX Mobile"
+summary: "Princípios de interfaces táteis, responsividade e acessibilidade."
+youtube_playlists:
+  - id: "PL-TOPIC-desenho-ui-ux-mobile"
+    priority: 1
+tags:
+  - "UI"
+  - "UX"
+  - "acessibilidade"
+type: topic
+layout: topic
+---
+Princípios de design para telas pequenas – utilização eficaz de espaço, tipografia legível,
+elementos adequados ao toque, adaptação a orientações e acessibilidade.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/flet-framework.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/flet-framework.md
@@ -1,0 +1,19 @@
+---
+slug: "flet-framework"
+title: "Framework Flet"
+summary: "Estrutura de apps Flet, widgets disponíveis e modelo cliente-servidor."
+youtube_playlists:
+  - id: "PL-TOPIC-flet-framework"
+    priority: 1
+tags:
+  - "Flet"
+  - "Python"
+  - "multiplataforma"
+type: topic
+layout: topic
+---
+Introdução prática ao Flet (Python) para construir GUI multiplataforma: estrutura de um app,
+controles disponíveis e modelo cliente-servidor interno.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/frameworks-nativos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/frameworks-nativos.md
@@ -1,0 +1,19 @@
+---
+slug: "frameworks-nativos"
+title: "Frameworks Nativos"
+summary: "Visão geral de Flutter, React Native ou Kotlin Multiplatform."
+youtube_playlists:
+  - id: "PL-TOPIC-frameworks-nativos"
+    priority: 1
+tags:
+  - "Flutter"
+  - "React Native"
+  - "Kotlin"
+type: topic
+layout: topic
+---
+Visão geral de frameworks nativos/multiplataforma – estrutura de projeto, linguagem (Dart ou
+JSX/JS), compilação para código nativo, uso de widgets e integração com serviços do dispositivo.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/index.md
@@ -1,0 +1,44 @@
+---
+title: "Computação Móvel"
+code: "19411019"
+course_code: "LESTI"
+description: "Desenvolvimento de aplicações móveis multiplataforma com Flet e frameworks nativas."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411007"
+learning_outcomes:
+  - "Identificar particularidades de hardware, UI/UX e ciclos de vida de aplicações móveis."
+  - "Construir interfaces responsivas e lidar com eventos e estado em Flet ou frameworks similares."
+  - "Integrar chamadas assíncronas, APIs Web e persistência local em aplicações multiplataforma."
+youtube_playlists:
+  - id: "PL-19411019-aulas"
+    priority: 1
+  - id: "PL-19411019-labs"
+    priority: 2
+topics:
+  - slug: "mobile-hardware"
+  - slug: "desenho-ui-ux-mobile"
+  - slug: "tipos-apps-mobile"
+  - slug: "flet-framework"
+  - slug: "widgets-e-eventos"
+  - slug: "programacao-assincrona"
+  - slug: "frameworks-nativos"
+  - slug: "projeto-mobile"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Características de dispositivos móveis, sensores, conectividade e restrições de energia.
+- Design de interfaces touch-friendly e acessíveis.
+- Tipos de aplicações: nativas, Web e híbridas.
+- Desenvolvimento com Flet: arquitetura, widgets, estado e navegação.
+- Eventos, gestão de estado e comunicação assíncrona.
+- Introdução a frameworks nativos (Flutter/React Native) e integração com serviços.
+- Projeto integrador envolvendo consumo de APIs e persistência local.
+
+## Metodologia
+
+Sprints curtas com prototipagem rápida e testes em emuladores e dispositivos reais suportam a entrega de uma aplicação completa com documentação técnica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/mobile-hardware.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/mobile-hardware.md
@@ -1,0 +1,19 @@
+---
+slug: "mobile-hardware"
+title: "Hardware Mobile"
+summary: "Características de smartphones/tablets, sensores e restrições de energia."
+youtube_playlists:
+  - id: "PL-TOPIC-mobile-hardware"
+    priority: 1
+tags:
+  - "smartphones"
+  - "sensores"
+  - "bateria"
+type: topic
+layout: topic
+---
+Limitações e capacidades de smartphones/tablets – CPU menos potente, consumo de bateria crítico,
+sensores disponíveis (GPS, câmera, acelerômetro) e implicações para programadores.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/programacao-assincrona.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/programacao-assincrona.md
@@ -1,0 +1,19 @@
+---
+slug: "programacao-assincrona"
+title: "Programação Assíncrona"
+summary: "Uso de chamadas assíncronas para acesso a rede sem bloquear a interface."
+youtube_playlists:
+  - id: "PL-TOPIC-programacao-assincrona"
+    priority: 1
+tags:
+  - "assíncrono"
+  - "await"
+  - "rede"
+type: topic
+layout: topic
+---
+Uso de chamadas assíncronas para acessar recursos de rede sem travar a UI (await/async,
+promises/futures) e atualização da interface após respostas.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/projeto-mobile.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/projeto-mobile.md
@@ -1,0 +1,19 @@
+---
+slug: "projeto-mobile"
+title: "Projeto Mobile"
+summary: "Desenvolvimento de app multiplataforma com interface, lógica e consumo de APIs."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-mobile"
+    priority: 1
+tags:
+  - "app"
+  - "API"
+  - "persistência"
+type: topic
+layout: topic
+---
+Concepção e implementação de aplicação móvel demonstrando caso real – design de interface,
+gerenciamento de estado, persistência e integração com serviço online.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/tipos-apps-mobile.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/tipos-apps-mobile.md
@@ -1,0 +1,19 @@
+---
+slug: "tipos-apps-mobile"
+title: "Tipos de Apps Mobile"
+summary: "Comparação entre apps nativas, web responsivas e híbridas."
+youtube_playlists:
+  - id: "PL-TOPIC-tipos-apps-mobile"
+    priority: 1
+tags:
+  - "nativas"
+  - "web"
+  - "híbridas"
+type: topic
+layout: topic
+---
+Comparar apps nativas (acesso total a APIs e melhor performance) vs. web responsivas (portabilidade
+via browser) vs. híbridas/multiplataforma (escreva uma vez, rode em vários sistemas).
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411019/widgets-e-eventos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411019/widgets-e-eventos.md
@@ -1,0 +1,19 @@
+---
+slug: "widgets-e-eventos"
+title: "Widgets e Eventos"
+summary: "Composição de layouts, tratamento de eventos e gestão de estado."
+youtube_playlists:
+  - id: "PL-TOPIC-widgets-e-eventos"
+    priority: 1
+tags:
+  - "widgets"
+  - "eventos"
+  - "estado"
+type: topic
+layout: topic
+---
+Programação de interfaces declarativas – definindo layouts e componentes, tratadores de eventos
+(cliques, entradas) e manipulação de estado reativo.
+
+Sprints curtas com protótipos executados em emuladores e dispositivos reais reforçam a importância
+de testes e feedback rápido no ecossistema móvel.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/analise-exploratoria.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/analise-exploratoria.md
@@ -1,0 +1,19 @@
+---
+slug: "analise-exploratoria"
+title: "Análise Exploratória"
+summary: "Estatísticas descritivas e gráficos iniciais para compreender padrões."
+youtube_playlists:
+  - id: "PL-TOPIC-analise-exploratoria"
+    priority: 1
+tags:
+  - "EDA"
+  - "histograma"
+  - "dispersão"
+type: topic
+layout: topic
+---
+Uso de estatísticas descritivas e gráficos simples (histogramas, dispersão) para identificar padrões
+ou anomalias iniciais.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/design-visualizacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/design-visualizacao.md
@@ -1,0 +1,19 @@
+---
+slug: "design-visualizacao"
+title: "Design de Visualização"
+summary: "Princípios de percepção visual, escolha de gráficos e boas práticas."
+youtube_playlists:
+  - id: "PL-TOPIC-design-visualizacao"
+    priority: 1
+tags:
+  - "percepção"
+  - "boas práticas"
+  - "tipos de gráfico"
+type: topic
+layout: topic
+---
+Princípios de percepção visual aplicados a gráficos – escolher tipos adequados, evitar distorções e
+aplicar melhores práticas de rótulos e legendas.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/ferramentas-visualizacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/ferramentas-visualizacao.md
@@ -1,0 +1,19 @@
+---
+slug: "ferramentas-visualizacao"
+title: "Ferramentas de Visualização"
+summary: "Uso de ferramentas como Tableau, Power BI ou bibliotecas Python/R."
+youtube_playlists:
+  - id: "PL-TOPIC-ferramentas-visualizacao"
+    priority: 1
+tags:
+  - "Tableau"
+  - "Power BI"
+  - "bibliotecas"
+type: topic
+layout: topic
+---
+Uso prático de ferramentas para criar gráficos e dashboards interativos, explorando recursos de
+interatividade e animação.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/index.md
@@ -1,0 +1,42 @@
+---
+title: "Análise de Dados e Visualização da Informação"
+code: "19411020"
+course_code: "LESTI"
+description: "Processos de análise exploratória, visualização eficaz e storytelling com dados."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411018"
+  - "19411013"
+learning_outcomes:
+  - "Preparar dados para análise exploratória identificando outliers e padrões relevantes."
+  - "Selecionar e construir visualizações adequadas que respeitem princípios de perceção."
+  - "Comunicar insights através de dashboards e narrativas orientadas por dados."
+youtube_playlists:
+  - id: "PL-19411020-aulas"
+    priority: 1
+  - id: "PL-19411020-labs"
+    priority: 2
+topics:
+  - slug: "pre-processamento-dados"
+  - slug: "analise-exploratoria"
+  - slug: "design-visualizacao"
+  - slug: "ferramentas-visualizacao"
+  - slug: "visualizacao-avancada"
+  - slug: "storytelling"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Limpeza de dados, tratamento de valores em falta e normalização.
+- Estatística descritiva e análise exploratória.
+- Princípios de design de visualização e boas práticas de comunicação visual.
+- Ferramentas de visualização (Tableau, Power BI, Python/R).
+- Visualização de dados complexos: séries temporais, mapas, dados multidimensionais.
+- Storytelling com dados e elaboração de dashboards interativos.
+
+## Metodologia
+
+Estúdios práticos com datasets abertos permitem aplicar técnicas de análise e construir narrativas visuais culminando numa apresentação pública.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/pre-processamento-dados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/pre-processamento-dados.md
@@ -1,0 +1,19 @@
+---
+slug: "pre-processamento-dados"
+title: "Pré-processamento de Dados"
+summary: "Limpeza, tratamento de valores faltantes e normalização para análise."
+youtube_playlists:
+  - id: "PL-TOPIC-pre-processamento-dados"
+    priority: 1
+tags:
+  - "limpeza"
+  - "outliers"
+  - "normalização"
+type: topic
+layout: topic
+---
+Técnicas para tratar dados brutos – lidar com valores faltantes, detecção de outliers e
+normalização/transformações para adequar dados à análise.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/storytelling.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/storytelling.md
@@ -1,0 +1,19 @@
+---
+slug: "storytelling"
+title: "Storytelling com Dados"
+summary: "Construção de narrativas, dashboards e comunicação de insights."
+youtube_playlists:
+  - id: "PL-TOPIC-storytelling"
+    priority: 1
+tags:
+  - "narrativa"
+  - "dashboards"
+  - "insights"
+type: topic
+layout: topic
+---
+Estruturação de uma narrativa com dados – selecionar visualizações relevantes, ordenar insights e
+adicionar contexto para conclusões claras.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411020/visualizacao-avancada.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411020/visualizacao-avancada.md
@@ -1,0 +1,19 @@
+---
+slug: "visualizacao-avancada"
+title: "Visualização Avançada"
+summary: "Representação de séries temporais, mapas, redes e dados multidimensionais."
+youtube_playlists:
+  - id: "PL-TOPIC-visualizacao-avancada"
+    priority: 1
+tags:
+  - "séries"
+  - "mapas"
+  - "redes"
+type: topic
+layout: topic
+---
+Representação de dados complexos – séries temporais com intervalos de confiança, mapas temáticos e
+gráficos de rede; técnicas de redução de dimensionalidade para visualização.
+
+Projetos incluem dashboards interativos e relatos visuais que traduzem dados complexos em
+recomendações estratégicas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/api-restful.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/api-restful.md
@@ -1,0 +1,19 @@
+---
+slug: "api-restful"
+title: "APIs RESTful"
+summary: "Design de endpoints, métodos HTTP e serialização de dados."
+youtube_playlists:
+  - id: "PL-TOPIC-api-restful"
+    priority: 1
+tags:
+  - "REST"
+  - "endpoints"
+  - "serialização"
+type: topic
+layout: topic
+---
+Projeto de APIs REST definindo recursos, métodos, códigos de resposta e serialização/validação de
+dados, integrando com bases de dados via ORMs ou queries diretas.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/arquitetura-webapp.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/arquitetura-webapp.md
@@ -1,0 +1,19 @@
+---
+slug: "arquitetura-webapp"
+title: "Arquitetura de Aplicações Web"
+summary: "Comparação entre renderização no servidor, SPAs e arquiteturas baseadas em serviços."
+youtube_playlists:
+  - id: "PL-TOPIC-arquitetura-webapp"
+    priority: 1
+tags:
+  - "SPA"
+  - "microserviços"
+  - "renderização"
+type: topic
+layout: topic
+---
+Diferenças entre renderização server-side, aplicações SPA e arquiteturas baseadas em
+serviços/microserviços, avaliando trade-offs de complexidade e desempenho.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/comunicacao-async.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/comunicacao-async.md
@@ -1,0 +1,19 @@
+---
+slug: "comunicacao-async"
+title: "Comunicação Assíncrona"
+summary: "Uso de AJAX, fetch, WebSockets e CORS no cliente."
+youtube_playlists:
+  - id: "PL-TOPIC-comunicacao-async"
+    priority: 1
+tags:
+  - "AJAX"
+  - "WebSocket"
+  - "CORS"
+type: topic
+layout: topic
+---
+Implementação de chamadas assíncronas do front-end para o back-end, tratamento de respostas e erros,
+configuração de CORS e uso de WebSockets para atualizações em tempo real.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/front-end-framework.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/front-end-framework.md
@@ -1,0 +1,19 @@
+---
+slug: "front-end-framework"
+title: "Framework Front-end"
+summary: "Componentização, roteamento e gestão de estado em frameworks modernos."
+youtube_playlists:
+  - id: "PL-TOPIC-front-end-framework"
+    priority: 1
+tags:
+  - "React"
+  - "componentes"
+  - "estado"
+type: topic
+layout: topic
+---
+Uso de frameworks JavaScript (React, Angular, Vue) para criar componentes reutilizáveis, gerir
+roteamento e manter estado global com bibliotecas apropriadas.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/index.md
@@ -1,0 +1,44 @@
+---
+title: "Desenvolvimento de Aplicações Web"
+code: "19411021"
+course_code: "LESTI"
+description: "Arquitetura moderna de aplicações Web, frameworks frontend/backend e segurança."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411007"
+  - "19411012"
+learning_outcomes:
+  - "Projetar arquiteturas Web em camadas, SPA ou baseadas em serviços."
+  - "Desenvolver frontends com frameworks modernos e gerir estado e roteamento."
+  - "Construir APIs back-end seguras integradas com bases de dados e serviços externos."
+youtube_playlists:
+  - id: "PL-19411021-aulas"
+    priority: 1
+  - id: "PL-19411021-projetos"
+    priority: 2
+topics:
+  - slug: "arquitetura-webapp"
+  - slug: "front-end-framework"
+  - slug: "api-restful"
+  - slug: "comunicacao-async"
+  - slug: "seguranca-web"
+  - slug: "performance-web"
+  - slug: "projeto-fullstack"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Arquiteturas Web monolíticas, em camadas e SPA.
+- Desenvolvimento frontend com frameworks (React/Angular/Vue).
+- APIs RESTful, serialização e integração com bases de dados.
+- Comunicação assíncrona, WebSockets e CORS.
+- Segurança Web: OWASP Top 10, autenticação, autorização e proteção de dados.
+- Otimização de performance e práticas de deploy.
+- Projeto fullstack integrando frontend, backend e base de dados.
+
+## Metodologia
+
+A UC é baseada em projeto incremental com revisões técnicas, testes automatizados e deploy contínuo para ambientes de staging.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/performance-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/performance-web.md
@@ -1,0 +1,19 @@
+---
+slug: "performance-web"
+title: "Performance Web"
+summary: "Minificação, caching, lazy loading e análise de desempenho."
+youtube_playlists:
+  - id: "PL-TOPIC-performance-web"
+    priority: 1
+tags:
+  - "otimização"
+  - "caching"
+  - "Lighthouse"
+type: topic
+layout: topic
+---
+Estratégias para melhorar carregamento e responsividade: minificação de ativos, uso de CDN, lazy
+loading, caching e monitorização com ferramentas como Lighthouse.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/projeto-fullstack.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/projeto-fullstack.md
@@ -1,0 +1,19 @@
+---
+slug: "projeto-fullstack"
+title: "Projeto Fullstack"
+summary: "Integração de frontend, backend e base de dados em aplicação completa."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-fullstack"
+    priority: 1
+tags:
+  - "fullstack"
+  - "deploy"
+  - "testes"
+type: topic
+layout: topic
+---
+Integração de todas as camadas – interface responsiva, lógica de negócio no servidor, persistência e
+testes, culminando em deploy em ambiente de produção.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411021/seguranca-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411021/seguranca-web.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-web"
+title: "Segurança Web"
+summary: "Mitigação de vulnerabilidades comuns como SQL Injection, XSS e CSRF."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-web"
+    priority: 1
+tags:
+  - "OWASP"
+  - "SQL Injection"
+  - "XSS"
+type: topic
+layout: topic
+---
+Melhores práticas de segurança em aplicações web – validação de entrada, uso de prepared statements,
+sanitização contra XSS, tokens anti-CSRF, HTTPS e armazenamento seguro de senhas.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/algoritmos-evolutivos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/algoritmos-evolutivos.md
@@ -1,0 +1,19 @@
+---
+slug: "algoritmos-evolutivos"
+title: "Algoritmos Evolutivos"
+summary: "Otimização inspirada na evolução com seleção, cruzamento e mutação."
+youtube_playlists:
+  - id: "PL-TOPIC-algoritmos-evolutivos"
+    priority: 1
+tags:
+  - "genéticos"
+  - "seleção"
+  - "mutação"
+type: topic
+layout: topic
+---
+Codificação de soluções como cromossomos, operadores genéticos (seleção, cruzamento, mutação) e
+aplicações em problemas de otimização difíceis.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/aprendizagem-ia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/aprendizagem-ia.md
@@ -1,0 +1,19 @@
+---
+slug: "aprendizagem-ia"
+title: "Aprendizagem em IA"
+summary: "Integração de técnicas de machine learning em agentes inteligentes."
+youtube_playlists:
+  - id: "PL-TOPIC-aprendizagem-ia"
+    priority: 1
+tags:
+  - "ML"
+  - "agentes"
+  - "reforço"
+type: topic
+layout: topic
+---
+Conexão entre IA clássica e aprendizagem de máquina – uso de métodos supervisionados, não
+supervisionados e por reforço em agentes inteligentes.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/busca-estados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/busca-estados.md
@@ -1,0 +1,19 @@
+---
+slug: "busca-estados"
+title: "Busca em Espaços de Estados"
+summary: "Busca cega e heurística (A*) para resolver problemas representados como grafos de estados."
+youtube_playlists:
+  - id: "PL-TOPIC-busca-estados"
+    priority: 1
+tags:
+  - "BFS"
+  - "DFS"
+  - "A*"
+type: topic
+layout: topic
+---
+Representação de problemas como estados e operadores; busca BFS/DFS e busca informada com
+heurísticas admissíveis (A*).
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/index.md
@@ -1,0 +1,44 @@
+---
+title: "Inteligência Artificial"
+code: "19411022"
+course_code: "LESTI"
+description: "Resolução de problemas com busca, lógica, planeamento, aprendizagem e algoritmos evolucionários."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411011"
+  - "19411013"
+learning_outcomes:
+  - "Modelar problemas como espaços de estados e aplicar algoritmos de busca informada."
+  - "Representar conhecimento em lógica proposicional/predicados e implementar mecanismos de inferência."
+  - "Desenvolver agentes inteligentes simples usando técnicas de IA simbólica e conexionista."
+youtube_playlists:
+  - id: "PL-19411022-aulas"
+    priority: 1
+  - id: "PL-19411022-labs"
+    priority: 2
+topics:
+  - slug: "busca-estados"
+  - slug: "logica-inferencia"
+  - slug: "planeamento"
+  - slug: "aprendizagem-ia"
+  - slug: "algoritmos-evolutivos"
+  - slug: "pln-e-outros"
+  - slug: "sistema-inteligente-proj"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Espaços de estados, busca cega e heurística (A*).
+- Representação de conhecimento, lógica proposicional e de predicados, encadeamento.
+- Planeamento automático e representação de ações.
+- Revisão de aprendizagem automática aplicada à IA.
+- Inteligência computacional: redes neurais simples e algoritmos genéticos.
+- Aplicações em PLN, visão e ética em IA.
+- Projeto final de agente ou sistema especialista.
+
+## Metodologia
+
+A UC combina seminários teóricos com laboratórios de implementação de agentes, finalizando com apresentação de um protótipo inteligente.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/logica-inferencia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/logica-inferencia.md
@@ -1,0 +1,19 @@
+---
+slug: "logica-inferencia"
+title: "Lógica e Inferência"
+summary: "Lógica proposicional/predicados e mecanismos de inferência como resolução."
+youtube_playlists:
+  - id: "PL-TOPIC-logica-inferencia"
+    priority: 1
+tags:
+  - "lógica"
+  - "inferência"
+  - "regras"
+type: topic
+layout: topic
+---
+Princípios da lógica proposicional e de predicados, método de resolução e encadeamento
+forward/backward para sistemas baseados em regras.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/planeamento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/planeamento.md
@@ -1,0 +1,19 @@
+---
+slug: "planeamento"
+title: "Planeamento Automático"
+summary: "Representação de ações, pré-condições e algoritmos de planeamento."
+youtube_playlists:
+  - id: "PL-TOPIC-planeamento"
+    priority: 1
+tags:
+  - "planeamento"
+  - "ações"
+  - "HTN"
+type: topic
+layout: topic
+---
+Algoritmos para planeamento automático, representação de ações com pré-condições/efeitos e noções de
+planeamento hierárquico.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/pln-e-outros.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/pln-e-outros.md
@@ -1,0 +1,19 @@
+---
+slug: "pln-e-outros"
+title: "PLN e Outras Áreas"
+summary: "Introdução a processamento de linguagem natural, visão e ética em IA."
+youtube_playlists:
+  - id: "PL-TOPIC-pln-e-outros"
+    priority: 1
+tags:
+  - "PLN"
+  - "visão"
+  - "ética"
+type: topic
+layout: topic
+---
+Desafios do processamento de linguagem natural, visão computacional e discussão ética sobre impacto
+da IA.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411022/sistema-inteligente-proj.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411022/sistema-inteligente-proj.md
@@ -1,0 +1,19 @@
+---
+slug: "sistema-inteligente-proj"
+title: "Projeto de Sistema Inteligente"
+summary: "Implementação de agente, sistema especialista ou aplicação inteligente simples."
+youtube_playlists:
+  - id: "PL-TOPIC-sistema-inteligente-proj"
+    priority: 1
+tags:
+  - "projeto"
+  - "agente"
+  - "IA aplicada"
+type: topic
+layout: topic
+---
+Desenvolvimento de protótipo que aplica técnicas de IA – por exemplo, agente de jogo, sistema
+especialista ou algoritmo evolutivo para otimização.
+
+Laboratórios combinam implementação de algoritmos clássicos com discussões sobre impacto ético e
+aplicações contemporâneas da IA.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-interpessoal.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-interpessoal.md
@@ -1,0 +1,20 @@
+---
+slug: "comunicacao-interpessoal"
+title: "Comunicação Interpessoal"
+summary: "Influência de estilos pessoais e componentes verbal/não verbal na interação."
+youtube_playlists:
+  - id: "PL-TOPIC-comunicacao-interpessoal"
+    priority: 1
+tags:
+  - "estilos"
+  - "não verbal"
+  - "barreiras"
+type: topic
+layout: topic
+---
+Dinâmica da comunicação face a face – como características individuais (introversão/extroversão,
+estilos de comunicação) afetam a transmissão da mensagem; distinção entre comunicação verbal e não-
+verbal e identificação de barreiras.
+
+Oficinas com role-playing e feedback estruturado ajudam os estudantes a adaptar mensagem, tom e
+linguagem corporal a diferentes públicos profissionais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-organizacional.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-organizacional.md
@@ -1,0 +1,20 @@
+---
+slug: "comunicacao-organizacional"
+title: "Comunicação Organizacional"
+summary: "Fluxos formais/informais, gestão de conflitos e liderança comunicativa."
+youtube_playlists:
+  - id: "PL-TOPIC-comunicacao-organizacional"
+    priority: 1
+tags:
+  - "fluxos"
+  - "liderança"
+  - "conflitos"
+type: topic
+layout: topic
+---
+Fluxos de comunicação dentro de empresas (vertical, horizontal); importância da comunicação clara na
+liderança e gestão de equipas; métodos para lidar com conflitos via comunicação eficaz (feedback
+construtivo, negociação).
+
+Oficinas com role-playing e feedback estruturado ajudam os estudantes a adaptar mensagem, tom e
+linguagem corporal a diferentes públicos profissionais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-pratica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/comunicacao-pratica.md
@@ -1,0 +1,21 @@
+---
+slug: "comunicacao-pratica"
+title: "Comunicação Prática"
+summary: "Produção de textos profissionais e apresentações orais, incluindo inglês técnico."
+youtube_playlists:
+  - id: "PL-TOPIC-comunicacao-pratica"
+    priority: 1
+tags:
+  - "escrita"
+  - "apresentações"
+  - "inglês técnico"
+type: topic
+layout: topic
+---
+Exercícios de elaboração de textos profissionais (currículo, relatório, e-mail formal) com clareza e
+correção; desenvolvimento de habilidades de falar em público – estruturação de apresentações, uso de
+recursos audiovisuais, linguagem adequada ao público; simulação de entrevistas e reuniões, inclusive
+em inglês técnico.
+
+Oficinas com role-playing e feedback estruturado ajudam os estudantes a adaptar mensagem, tom e
+linguagem corporal a diferentes públicos profissionais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/escuta-ativa.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/escuta-ativa.md
@@ -1,0 +1,20 @@
+---
+slug: "escuta-ativa"
+title: "Escuta Ativa"
+summary: "Técnicas para ouvir com atenção, reformular e superar obstáculos de receção."
+youtube_playlists:
+  - id: "PL-TOPIC-escuta-ativa"
+    priority: 1
+tags:
+  - "escuta"
+  - "feedback"
+  - "perguntas"
+type: topic
+layout: topic
+---
+Técnicas para melhorar a recepção da mensagem, incluindo prestar atenção, mostrar compreensão (ex.:
+reformular, fazer perguntas) e superar barreiras de escuta; conscientização de obstáculos comuns
+(distrações, julgamentos precipitados).
+
+Oficinas com role-playing e feedback estruturado ajudam os estudantes a adaptar mensagem, tom e
+linguagem corporal a diferentes públicos profissionais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/index.md
@@ -1,0 +1,38 @@
+---
+title: "Técnicas de Comunicação"
+code: "19411023"
+course_code: "LESTI"
+description: "Desenvolvimento de competências de comunicação interpessoal, escrita profissional e apresentações."
+ects: 3
+semester: 2
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Analisar contextos de comunicação identificando emissores, mensagens e canais adequados."
+  - "Aplicar técnicas de escuta ativa e comunicação não verbal para interações profissionais."
+  - "Produzir textos e apresentações alinhados a objetivos organizacionais, inclusive em inglês técnico."
+youtube_playlists:
+  - id: "PL-19411023-aulas"
+    priority: 1
+  - id: "PL-19411023-praticas"
+    priority: 2
+topics:
+  - slug: "teoria-comunicacao"
+  - slug: "comunicacao-interpessoal"
+  - slug: "escuta-ativa"
+  - slug: "comunicacao-organizacional"
+  - slug: "comunicacao-pratica"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Modelos do processo comunicacional e funções da comunicação.
+- Comunicação interpessoal, estilos individuais e barreiras.
+- Técnicas de escuta ativa, feedback e negociação.
+- Comunicação nas organizações, gestão de conflitos e liderança.
+- Prática de comunicação escrita e oral em contexto profissional.
+
+## Metodologia
+
+Oficinas presenciais com role-playing, exercícios de escrita e apresentações gravadas permitem feedback imediato e desenvolvimento contínuo das competências comunicativas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411023/teoria-comunicacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411023/teoria-comunicacao.md
@@ -1,0 +1,19 @@
+---
+slug: "teoria-comunicacao"
+title: "Teoria da Comunicação"
+summary: "Modelos emissores, mensagens e funções da comunicação em diferentes contextos."
+youtube_playlists:
+  - id: "PL-TOPIC-teoria-comunicacao"
+    priority: 1
+tags:
+  - "modelo"
+  - "funções"
+  - "mensagem"
+type: topic
+layout: topic
+---
+Entendimento do processo de comunicação (modelo emissor-mensagem-receptor) e das funções da
+comunicação (informar, persuadir, entreter), identificando elementos e códigos envolvidos.
+
+Oficinas com role-playing e feedback estruturado ajudam os estudantes a adaptar mensagem, tom e
+linguagem corporal a diferentes públicos profissionais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/arduino-e-atmega.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/arduino-e-atmega.md
@@ -1,0 +1,19 @@
+---
+slug: "arduino-e-atmega"
+title: "Arduino e ATmega"
+summary: "Arquitetura do ATmega328, GPIO, timers e comunicações em Arduino."
+youtube_playlists:
+  - id: "PL-TOPIC-arduino-e-atmega"
+    priority: 1
+tags:
+  - "Arduino"
+  - "ATmega"
+  - "GPIO"
+type: topic
+layout: topic
+---
+Visão geral da plataforma Arduino (hardware e IDE) e arquitetura do ATmega328 – conjuntos de
+instruções, GPIO, temporizadores, comunicação serial (UART/I2C/SPI), conversores AD.
+
+Sessões de bancada com placas Arduino e instrumentos de medição permitem validar conceitos de
+hardware em situações reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/arquitetura-cpu.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/arquitetura-cpu.md
@@ -1,0 +1,19 @@
+---
+slug: "arquitetura-cpu"
+title: "Arquitetura de CPU"
+summary: "Componentes internos, Von Neumann vs Harvard e RISC vs CISC."
+youtube_playlists:
+  - id: "PL-TOPIC-arquitetura-cpu"
+    priority: 1
+tags:
+  - "CPU"
+  - "Von Neumann"
+  - "RISC"
+type: topic
+layout: topic
+---
+Revisão das partes internas de um microprocessador (UC, ULA, registradores, barramentos internos) e
+estudo de arquiteturas típicas (Von Neumann vs Harvard, arquiteturas RISC vs CISC).
+
+Sessões de bancada com placas Arduino e instrumentos de medição permitem validar conceitos de
+hardware em situações reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/index.md
@@ -1,0 +1,39 @@
+---
+title: "Microprocessadores"
+code: "19411025"
+course_code: "LESTI"
+description: "Arquitetura de microprocessadores, microcontroladores e desenvolvimento de sistemas embebidos."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411005"
+learning_outcomes:
+  - "Compreender arquiteturas de microprocessadores e o fluxo de projeto top-down."
+  - "Programar microcontroladores utilizando C/Assembly para integrar sensores e atuadores."
+  - "Desenvolver protótipos embebidos com foco em depuração e validação."
+youtube_playlists:
+  - id: "PL-19411025-aulas"
+    priority: 1
+  - id: "PL-19411025-labs"
+    priority: 2
+topics:
+  - slug: "vlsi-e-estados"
+  - slug: "arquitetura-cpu"
+  - slug: "introducao-embebidos"
+  - slug: "arduino-e-atmega"
+  - slug: "projeto-embebido"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Circuitos integrados VLSI e microprocessadores vistos como máquinas de estados.
+- Princípios de arquitetura CPU, Von Neumann vs Harvard, RISC vs CISC.
+- Sistemas embebidos, restrições e aplicações.
+- Plataforma Arduino e microcontrolador ATmega328: GPIO, timers, comunicações.
+- Projeto completo de sistema embebido, depuração e testes.
+
+## Metodologia
+
+A UC integra sessões práticas em laboratório com placas Arduino e ferramentas de simulação, culminando num protótipo funcional apresentado em banca.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/introducao-embebidos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/introducao-embebidos.md
@@ -1,0 +1,19 @@
+---
+slug: "introducao-embebidos"
+title: "Introdução a Sistemas Embebidos"
+summary: "Componentes de sistemas embebidos e restrições comuns."
+youtube_playlists:
+  - id: "PL-TOPIC-introducao-embebidos"
+    priority: 1
+tags:
+  - "embedded"
+  - "tempo real"
+  - "restrições"
+type: topic
+layout: topic
+---
+Componentes de um sistema embutido (microcontrolador + sensores/atuadores + software dedicado);
+restrições comuns (tempo real, baixo consumo, memória limitada).
+
+Sessões de bancada com placas Arduino e instrumentos de medição permitem validar conceitos de
+hardware em situações reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/projeto-embebido.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/projeto-embebido.md
@@ -1,0 +1,20 @@
+---
+slug: "projeto-embebido"
+title: "Projeto Embebido"
+summary: "Desenvolvimento de protótipos com microcontroladores, sensores e atuadores."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-embebido"
+    priority: 1
+tags:
+  - "prototipagem"
+  - "sensores"
+  - "depuração"
+type: topic
+layout: topic
+---
+Desenvolvimento de pequenos projetos práticos: programação em C/Assembly para ler sensores,
+controlar atuadores e comunicar-se via interfaces seriais, integrando hardware e software com
+técnicas de depuração.
+
+Sessões de bancada com placas Arduino e instrumentos de medição permitem validar conceitos de
+hardware em situações reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411025/vlsi-e-estados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411025/vlsi-e-estados.md
@@ -1,0 +1,20 @@
+---
+slug: "vlsi-e-estados"
+title: "VLSI e Máquinas de Estados"
+summary: "Circuitos integrados de grande escala e modelação de CPUs como máquinas de estados."
+youtube_playlists:
+  - id: "PL-TOPIC-vlsi-e-estados"
+    priority: 1
+tags:
+  - "VLSI"
+  - "FSM"
+  - "design"
+type: topic
+layout: topic
+---
+Conceito de Circuitos Integrados de Escala Muito Grande (VLSI) e seu impacto na construção de CPUs;
+modelagem de operação do CPU como máquina de estados e design top-down de sistemas digitais
+complexos.
+
+Sessões de bancada com placas Arduino e instrumentos de medição permitem validar conceitos de
+hardware em situações reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/api-mapas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/api-mapas.md
@@ -1,0 +1,19 @@
+---
+slug: "api-mapas"
+title: "APIs de Mapas"
+summary: "Uso de bibliotecas JavaScript para mapas interativos e eventos do utilizador."
+youtube_playlists:
+  - id: "PL-TOPIC-api-mapas"
+    priority: 1
+tags:
+  - "Leaflet"
+  - "OpenLayers"
+  - "interatividade"
+type: topic
+layout: topic
+---
+Uso de bibliotecas JavaScript (Leaflet, OpenLayers) para carregar mapas base, sobrepor camadas e
+reagir a eventos do utilizador; integração com serviços externos como geocodificação ou trajetos.
+
+Atividades práticas envolvem QGIS, GeoServer e bibliotecas JavaScript para publicar serviços
+geográficos consumidos por aplicações Web.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/aplicacao-sig-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/aplicacao-sig-web.md
@@ -1,0 +1,19 @@
+---
+slug: "aplicacao-sig-web"
+title: "Aplicação SIG Web"
+summary: "Projeto completo integrando base espacial, serviços e interface web para consulta."
+youtube_playlists:
+  - id: "PL-TOPIC-aplicacao-sig-web"
+    priority: 1
+tags:
+  - "SIG Web"
+  - "projeto"
+  - "consultas"
+type: topic
+layout: topic
+---
+Desenvolvimento de uma aplicação web SIG: projeto de BD espacial, publicação de serviços de mapas e
+criação de interface web para navegação e consultas espaciais.
+
+Atividades práticas envolvem QGIS, GeoServer e bibliotecas JavaScript para publicar serviços
+geográficos consumidos por aplicações Web.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/bases-dados-espaciais.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/bases-dados-espaciais.md
@@ -1,0 +1,19 @@
+---
+slug: "bases-dados-espaciais"
+title: "Bases de Dados Espaciais"
+summary: "Tipos geométricos, consultas espaciais e capacidades de SGBDs como PostGIS."
+youtube_playlists:
+  - id: "PL-TOPIC-bases-dados-espaciais"
+    priority: 1
+tags:
+  - "PostGIS"
+  - "geometria"
+  - "consultas"
+type: topic
+layout: topic
+---
+Conceitos de dados espaciais em bancos de dados – tipos geométricos, consultas espaciais e
+capacidades de SGBDs espaciais (ex.: PostGIS) para armazenar e consultar esses dados.
+
+Atividades práticas envolvem QGIS, GeoServer e bibliotecas JavaScript para publicar serviços
+geográficos consumidos por aplicações Web.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/index.md
@@ -1,0 +1,40 @@
+---
+title: "Tecnologias e Aplicações para WebSIG"
+code: "19411026"
+course_code: "LESTI"
+description: "Sistemas de informação geográfica na Web, serviços de mapas e desenvolvimento de aplicações cliente-servidor."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites:
+  - "19411007"
+  - "19411012"
+learning_outcomes:
+  - "Manipular dados geoespaciais em ferramentas SIG e bases de dados espaciais."
+  - "Publicar serviços de mapas via padrões OGC e configurar clientes Web."
+  - "Desenvolver aplicações WebSIG integrando base de dados espacial, serviços e interface interativa."
+youtube_playlists:
+  - id: "PL-19411026-aulas"
+    priority: 1
+  - id: "PL-19411026-labs"
+    priority: 2
+topics:
+  - slug: "sistemas-informacao-geografica"
+  - slug: "bases-dados-espaciais"
+  - slug: "servicos-mapas-web"
+  - slug: "api-mapas"
+  - slug: "aplicacao-sig-web"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Fundamentos de geoinformação, sistemas de coordenadas e utilização de QGIS.
+- Bases de dados espaciais e consultas geográficas.
+- Servidores de mapas, protocolos WMS/WFS e geração de tiles.
+- Integração com APIs JavaScript (Leaflet, OpenLayers, Google Maps).
+- Projeto completo de aplicação WebSIG com base de dados espacial e frontend interativo.
+
+## Metodologia
+
+Exercícios guiados conduzem da modelação espacial à publicação de serviços e desenvolvimento de interface, finalizando com apresentação do projeto WebSIG.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/servicos-mapas-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/servicos-mapas-web.md
@@ -1,0 +1,19 @@
+---
+slug: "servicos-mapas-web"
+title: "Serviços de Mapas Web"
+summary: "Configuração de servidores de mapas via protocolos OGC (WMS/WFS)."
+youtube_playlists:
+  - id: "PL-TOPIC-servicos-mapas-web"
+    priority: 1
+tags:
+  - "WMS"
+  - "GeoServer"
+  - "OGC"
+type: topic
+layout: topic
+---
+Configuração de servidores de mapas (como GeoServer) para disponibilizar dados geográficos via
+protocolos OGC (WMS/WFS); geração de tiles de mapas e fluxo de requisições.
+
+Atividades práticas envolvem QGIS, GeoServer e bibliotecas JavaScript para publicar serviços
+geográficos consumidos por aplicações Web.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411026/sistemas-informacao-geografica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411026/sistemas-informacao-geografica.md
@@ -1,0 +1,20 @@
+---
+slug: "sistemas-informacao-geografica"
+title: "Sistemas de Informação Geográfica"
+summary: "Representação de dados geográficos, projeções e uso de ferramentas SIG."
+youtube_playlists:
+  - id: "PL-TOPIC-sistemas-informacao-geografica"
+    priority: 1
+tags:
+  - "SIG"
+  - "projeções"
+  - "mapas"
+type: topic
+layout: topic
+---
+Noções de SIG – representação de informações geográficas (vetorial e matricial), sistemas de
+projeção e coordenadas, e utilização de ferramentas SIG de desktop para visualizar e analisar dados
+geoespaciais.
+
+Atividades práticas envolvem QGIS, GeoServer e bibliotecas JavaScript para publicar serviços
+geográficos consumidos por aplicações Web.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/aplicacoes-fpga.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/aplicacoes-fpga.md
@@ -1,0 +1,19 @@
+---
+slug: "aplicacoes-fpga"
+title: "Aplicações em FPGA"
+summary: "Desenvolvimento e validação de circuitos reconfiguráveis em placas protótipo."
+youtube_playlists:
+  - id: "PL-TOPIC-aplicacoes-fpga"
+    priority: 1
+tags:
+  - "soft-core"
+  - "aceleradores"
+  - "prototipagem"
+type: topic
+layout: topic
+---
+Desenvolvimento na prática de circuitos no FPGA – implementar processadores soft-core ou
+aceleradores e testá-los em placas protótipo, incluindo depuração e validação.
+
+Laboratórios com placas FPGA demonstram ganhos de desempenho e flexibilidade, preparando para
+desafios de hardware especializado.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/arquitetura-fpga.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/arquitetura-fpga.md
@@ -1,0 +1,19 @@
+---
+slug: "arquitetura-fpga"
+title: "Arquitetura de FPGA"
+summary: "Estruturas de LUTs, interconexões e blocos dedicados em FPGAs."
+youtube_playlists:
+  - id: "PL-TOPIC-arquitetura-fpga"
+    priority: 1
+tags:
+  - "LUT"
+  - "interconexão"
+  - "DSP"
+type: topic
+layout: topic
+---
+Estruturas de um FPGA moderno – células lógicas configuráveis (LUTs + flip-flops), matrizes de
+interconexão, blocos dedicados (RAM, DSP); desafios de roteamento e temporização.
+
+Laboratórios com placas FPGA demonstram ganhos de desempenho e flexibilidade, preparando para
+desafios de hardware especializado.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/ferramentas-cad-hdl.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/ferramentas-cad-hdl.md
@@ -1,0 +1,19 @@
+---
+slug: "ferramentas-cad-hdl"
+title: "Ferramentas CAD para HDL"
+summary: "Uso de suites como Vivado/Quartus para simulação, síntese e place-and-route."
+youtube_playlists:
+  - id: "PL-TOPIC-ferramentas-cad-hdl"
+    priority: 1
+tags:
+  - "Vivado"
+  - "Quartus"
+  - "bitstream"
+type: topic
+layout: topic
+---
+Uso de ferramentas de projeto (Vivado, Quartus) – escrever código HDL, simular, sintetizar, realizar
+place-and-route e gerar bitstream, analisando relatórios de recursos e timing.
+
+Laboratórios com placas FPGA demonstram ganhos de desempenho e flexibilidade, preparando para
+desafios de hardware especializado.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/hardware-reconfiguravel.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/hardware-reconfiguravel.md
@@ -1,0 +1,19 @@
+---
+slug: "hardware-reconfiguravel"
+title: "Hardware Reconfigurável"
+summary: "Conceito de hardware programável pós-fabricação e vantagens sobre ASICs."
+youtube_playlists:
+  - id: "PL-TOPIC-hardware-reconfiguravel"
+    priority: 1
+tags:
+  - "reconfigurável"
+  - "FPGA"
+  - "ASIC"
+type: topic
+layout: topic
+---
+Conceito e motivação – possibilidade de alterar a função do hardware via programação, diferindo de
+ASICs fixos; vantagens em aplicações como processamento digital e criptografia.
+
+Laboratórios com placas FPGA demonstram ganhos de desempenho e flexibilidade, preparando para
+desafios de hardware especializado.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/index.md
@@ -1,0 +1,39 @@
+---
+title: "Computação Reconfigurável"
+code: "19411028"
+course_code: "LESTI"
+description: "Hardware reconfigurável, FPGAs, linguagens HDL e projeto de sistemas digitais."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411025"
+learning_outcomes:
+  - "Explicar vantagens e limitações de hardware reconfigurável em comparação com ASICs."
+  - "Descrever arquiteturas de FPGAs e interpretar relatórios de síntese e temporização."
+  - "Desenvolver e testar módulos digitais em VHDL/Verilog implementados numa placa FPGA."
+youtube_playlists:
+  - id: "PL-19411028-aulas"
+    priority: 1
+  - id: "PL-19411028-labs"
+    priority: 2
+topics:
+  - slug: "hardware-reconfiguravel"
+  - slug: "arquitetura-fpga"
+  - slug: "vhdl-verilog"
+  - slug: "ferramentas-cad-hdl"
+  - slug: "aplicacoes-fpga"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos de computação reconfigurável e aplicações típicas.
+- Arquitetura de FPGAs: LUTs, flip-flops, interconexões e blocos dedicados.
+- Linguagens HDL (VHDL/Verilog) para modelação combinatória e sequencial.
+- Fluxo de projeto: simulação, síntese, place-and-route e geração de bitstream.
+- Desenvolvimento de projetos completos em placas FPGA.
+
+## Metodologia
+
+Laboratórios hands-on com ferramentas CAD (Vivado/Quartus) e placas FPGA permitem consolidar o ciclo completo de desenvolvimento e depuração de hardware reconfigurável.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411028/vhdl-verilog.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411028/vhdl-verilog.md
@@ -1,0 +1,19 @@
+---
+slug: "vhdl-verilog"
+title: "VHDL e Verilog"
+summary: "Linguagens HDL para descrever circuitos combinatórios e sequenciais."
+youtube_playlists:
+  - id: "PL-TOPIC-vhdl-verilog"
+    priority: 1
+tags:
+  - "HDL"
+  - "VHDL"
+  - "Verilog"
+type: topic
+layout: topic
+---
+Introdução às linguagens VHDL e Verilog; diferenças de simulação vs síntese; exemplos de código para
+portas lógicas, flip-flops e máquinas de estados.
+
+Laboratórios com placas FPGA demonstram ganhos de desempenho e flexibilidade, preparando para
+desafios de hardware especializado.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/arquiteturas-distribuidas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/arquiteturas-distribuidas.md
@@ -1,0 +1,19 @@
+---
+slug: "arquiteturas-distribuidas"
+title: "Arquiteturas Distribuídas"
+summary: "Regiões, zonas de disponibilidade e trade-offs CAP em serviços cloud."
+youtube_playlists:
+  - id: "PL-TOPIC-arquiteturas-distribuidas"
+    priority: 1
+tags:
+  - "distribuição"
+  - "CAP"
+  - "latência"
+type: topic
+layout: topic
+---
+Noção de distribuição geográfica de serviços cloud, tolerância a falhas, latência e aplicação do
+teorema CAP no desenho de sistemas distribuídos.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/conceitos-cloud.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/conceitos-cloud.md
@@ -1,0 +1,19 @@
+---
+slug: "conceitos-cloud"
+title: "Conceitos de Cloud"
+summary: "Modelos de nuvem, elasticidade, custos e SLAs."
+youtube_playlists:
+  - id: "PL-TOPIC-conceitos-cloud"
+    priority: 1
+tags:
+  - "cloud"
+  - "SLA"
+  - "elasticidade"
+type: topic
+layout: topic
+---
+Entendimento do paradigma de computação em nuvem – alocação dinâmica de recursos sob demanda,
+pagamento conforme uso e considerações de SLA.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/index.md
@@ -1,0 +1,42 @@
+---
+title: "Computação em Nuvem"
+code: "19411029"
+course_code: "LESTI"
+description: "Fundamentos de cloud computing, virtualização, serviços IaaS/PaaS/SaaS e integração de APIs."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411014"
+  - "19411012"
+learning_outcomes:
+  - "Caracterizar modelos de nuvem e requisitos de SLA para workloads distribuídos."
+  - "Configurar ambientes virtualizados e contentorizados para implantação de serviços."
+  - "Integrar aplicações com serviços cloud, explorando APIs e arquiteturas distribuídas."
+youtube_playlists:
+  - id: "PL-19411029-aulas"
+    priority: 1
+  - id: "PL-19411029-labs"
+    priority: 2
+topics:
+  - slug: "conceitos-cloud"
+  - slug: "tecnicas-virtualizacao"
+  - slug: "servicos-nuvem"
+  - slug: "arquiteturas-distribuidas"
+  - slug: "pratica-cloud"
+  - slug: "webservices-integration"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos de computação em nuvem, modelos de implementação e SLA.
+- Virtualização de servidores, hypervisors e contentores.
+- Serviços IaaS, PaaS, SaaS e BaaS nos principais provedores.
+- Arquiteturas distribuídas, regiões, zonas de disponibilidade e teorema CAP.
+- Integração de serviços cloud com APIs REST e funções serverless.
+- Projeto prático de implantação e integração de serviços em nuvem.
+
+## Metodologia
+
+Aulas demonstrativas e laboratórios em plataformas cloud públicas (ou simuladores) permitem configurar ambientes, automatizar deploys e consumir APIs reais.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/pratica-cloud.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/pratica-cloud.md
@@ -1,0 +1,19 @@
+---
+slug: "pratica-cloud"
+title: "Prática em Cloud"
+summary: "Configuração de ambientes na nuvem, automação de deploy e monitorização."
+youtube_playlists:
+  - id: "PL-TOPIC-pratica-cloud"
+    priority: 1
+tags:
+  - "deploy"
+  - "VM"
+  - "monitorização"
+type: topic
+layout: topic
+---
+Uso de plataformas cloud para criar VMs, configurar redes e automatizar deploys, incluindo
+monitorização básica e boas práticas de gestão.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/servicos-nuvem.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/servicos-nuvem.md
@@ -1,0 +1,19 @@
+---
+slug: "servicos-nuvem"
+title: "Serviços em Nuvem"
+summary: "Modelos IaaS, PaaS, SaaS e BaaS com exemplos de provedores."
+youtube_playlists:
+  - id: "PL-TOPIC-servicos-nuvem"
+    priority: 1
+tags:
+  - "IaaS"
+  - "PaaS"
+  - "SaaS"
+type: topic
+layout: topic
+---
+Detalhes dos modelos IaaS, PaaS, SaaS e BaaS com exemplos reais (AWS, Azure, GCP) e casos de
+utilização.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/tecnicas-virtualizacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/tecnicas-virtualizacao.md
@@ -1,0 +1,19 @@
+---
+slug: "tecnicas-virtualizacao"
+title: "Técnicas de Virtualização"
+summary: "Hypervisors, VMs e conteinerização para isolamento de recursos."
+youtube_playlists:
+  - id: "PL-TOPIC-tecnicas-virtualizacao"
+    priority: 1
+tags:
+  - "hypervisor"
+  - "VM"
+  - "Docker"
+type: topic
+layout: topic
+---
+Funcionamento de hypervisors tipo 1/2, diferença entre virtualização tradicional e conteinerização
+(Docker/LXC) e papel na formação de nuvens.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411029/webservices-integration.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411029/webservices-integration.md
@@ -1,0 +1,19 @@
+---
+slug: "webservices-integration"
+title: "Integração de Web Services"
+summary: "Consumo de APIs REST/SOAP e implementação de funções serverless."
+youtube_playlists:
+  - id: "PL-TOPIC-webservices-integration"
+    priority: 1
+tags:
+  - "API"
+  - "REST"
+  - "serverless"
+type: topic
+layout: topic
+---
+Construção de aplicações distribuídas que consomem APIs REST/SOAP e utilizam serviços como funções
+serverless e bases de dados geridas.
+
+Os estudantes configuram ambientes em provedores públicos, automatizam deploys e discutem trade-offs
+de disponibilidade, custo e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/apresentacao-defesa.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/apresentacao-defesa.md
@@ -1,0 +1,19 @@
+---
+slug: "apresentacao-defesa"
+title: "Apresentação e Defesa"
+summary: "Preparação de apresentação oral e defesa perante avaliadores."
+youtube_playlists:
+  - id: "PL-TOPIC-apresentacao-defesa"
+    priority: 1
+tags:
+  - "apresentação"
+  - "defesa"
+  - "demonstração"
+type: topic
+layout: topic
+---
+Preparar apresentação oral com demonstração da solução, respondendo a questões técnicas e
+evidenciando contributos do projeto.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/desenvolvimento-solucao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/desenvolvimento-solucao.md
@@ -1,0 +1,19 @@
+---
+slug: "desenvolvimento-solucao"
+title: "Desenvolvimento da Solução"
+summary: "Conceção e implementação iterativa da solução acordada."
+youtube_playlists:
+  - id: "PL-TOPIC-desenvolvimento-solucao"
+    priority: 1
+tags:
+  - "implementação"
+  - "iterativo"
+  - "engenharia"
+type: topic
+layout: topic
+---
+Conceber e implementar a solução proposta, aplicando metodologias de engenharia e ajustando o
+trabalho com base em feedback contínuo.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/documentacao-relatorio.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/documentacao-relatorio.md
@@ -1,0 +1,19 @@
+---
+slug: "documentacao-relatorio"
+title: "Documentação e Relatório"
+summary: "Registo contínuo das atividades e elaboração de relatório técnico final."
+youtube_playlists:
+  - id: "PL-TOPIC-documentacao-relatorio"
+    priority: 1
+tags:
+  - "documentação"
+  - "relatório"
+  - "lições"
+type: topic
+layout: topic
+---
+Manter registro do trabalho realizado e produzir relatório técnico detalhando processo, solução,
+resultados e lições aprendidas.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/ferramentas-tecnologias.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/ferramentas-tecnologias.md
@@ -1,0 +1,19 @@
+---
+slug: "ferramentas-tecnologias"
+title: "Ferramentas e Tecnologias"
+summary: "Seleção e utilização de ferramentas técnicas adequadas ao projeto."
+youtube_playlists:
+  - id: "PL-TOPIC-ferramentas-tecnologias"
+    priority: 1
+tags:
+  - "ferramentas"
+  - "tecnologias"
+  - "aprendizagem"
+type: topic
+layout: topic
+---
+Utilizar ferramentas e tecnologias específicas do projeto (linguagens, frameworks, plataformas) e
+aprender novas competências conforme necessário.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/index.md
@@ -1,0 +1,37 @@
+---
+title: "Projeto na Empresa III"
+code: "19411030"
+course_code: "LESTI"
+description: "Projeto supervisionado em ambiente empresarial com foco em levantamento, planeamento e execução de soluções."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites:
+  - "19411001"
+learning_outcomes:
+  - "Levantar requisitos e definir objetivos claros em colaboração com parceiros externos."
+  - "Planejar e gerir atividades do projeto respeitando prazos e entregáveis."
+  - "Documentar e apresentar resultados técnicos alinhados às expectativas profissionais."
+youtube_playlists:
+  - id: "PL-19411030-orientacoes"
+    priority: 1
+topics:
+  - slug: "levantamento-requisitos"
+  - slug: "planeamento-projeto"
+  - slug: "desenvolvimento-solucao"
+  - slug: "ferramentas-tecnologias"
+  - slug: "documentacao-relatorio"
+  - slug: "apresentacao-defesa"
+type: uc
+layout: uc
+---
+## Orientações Gerais
+
+O estudante desenvolve um projeto em contexto empresarial, aplicando métodos de engenharia informática para responder a necessidades concretas. O plano de trabalho é definido com a entidade acolhedora e supervisionado por docente.
+
+## Entregáveis
+
+- Plano de projeto e cronograma aprovados pelo orientador.
+- Registos de reuniões, decisões e iterações da solução.
+- Protótipo, código ou relatório técnico conforme o domínio do projeto.
+- Relatório final e apresentação pública para banca avaliadora.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/levantamento-requisitos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/levantamento-requisitos.md
@@ -1,0 +1,19 @@
+---
+slug: "levantamento-requisitos"
+title: "Levantamento de Requisitos"
+summary: "Identificação de necessidades com stakeholders e definição de objetivos do projeto."
+youtube_playlists:
+  - id: "PL-TOPIC-levantamento-requisitos"
+    priority: 1
+tags:
+  - "requisitos"
+  - "stakeholders"
+  - "objetivos"
+type: topic
+layout: topic
+---
+Identificar e documentar as necessidades do cliente/parceiro e os objetivos do projeto,
+estabelecendo prioridades e critérios de sucesso.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411030/planeamento-projeto.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411030/planeamento-projeto.md
@@ -1,0 +1,19 @@
+---
+slug: "planeamento-projeto"
+title: "Planeamento do Projeto"
+summary: "Elaboração de planos de trabalho, cronogramas e definição de entregáveis."
+youtube_playlists:
+  - id: "PL-TOPIC-planeamento-projeto"
+    priority: 1
+tags:
+  - "planeamento"
+  - "cronograma"
+  - "deliverables"
+type: topic
+layout: topic
+---
+Elaborar um plano de trabalho com etapas, cronograma, recursos e entregáveis, definindo
+responsabilidades e indicadores de acompanhamento.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/comunicacao-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/comunicacao-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "comunicacao-iot"
+title: "Comunicação IoT"
+summary: "Protocolos sem fio e padrão publish/subscribe (MQTT)."
+youtube_playlists:
+  - id: "PL-TOPIC-comunicacao-iot"
+    priority: 1
+tags:
+  - "BLE"
+  - "MQTT"
+  - "LoRa"
+type: topic
+layout: topic
+---
+Protocolos de curto e longo alcance (BLE, ZigBee, LoRaWAN) e arquitetura publish/subscribe com MQTT
+para envio de dados sensor a servidores.
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/dados-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/dados-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "dados-iot"
+title: "Dados IoT"
+summary: "Formatos leves, ingestão em plataformas cloud e dashboards em tempo real."
+youtube_playlists:
+  - id: "PL-TOPIC-dados-iot"
+    priority: 1
+tags:
+  - "JSON"
+  - "cloud"
+  - "dashboards"
+type: topic
+layout: topic
+---
+Formato de dados leves (JSON), restrições de largura de banda e uso de plataformas cloud IoT para
+receber, armazenar e visualizar dados em dashboards.
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/fundamentos-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/fundamentos-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "fundamentos-iot"
+title: "Fundamentos de IoT"
+summary: "Conceito de Internet das Coisas e exemplos de aplicação."
+youtube_playlists:
+  - id: "PL-TOPIC-fundamentos-iot"
+    priority: 1
+tags:
+  - "IoT"
+  - "aplicações"
+  - "conectividade"
+type: topic
+layout: topic
+---
+Conceito de IoT – conectar dispositivos físicos à Internet para coleta e troca de dados; exemplos
+como casas inteligentes e monitorização industrial.
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/hardware-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/hardware-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "hardware-iot"
+title: "Hardware IoT"
+summary: "Microcontroladores conectados, sensores e atuadores para prototipagem."
+youtube_playlists:
+  - id: "PL-TOPIC-hardware-iot"
+    priority: 1
+tags:
+  - "microcontrolador"
+  - "sensores"
+  - "atuadores"
+type: topic
+layout: topic
+---
+Plataformas de prototipagem IoT – microcontroladores com conectividade, sensores (temperatura,
+umidade) e atuadores (relés, motores).
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/index.md
@@ -1,0 +1,42 @@
+---
+title: "Laboratório IoT"
+code: "19411031"
+course_code: "LESTI"
+description: "Prototipagem de soluções IoT com microcontroladores conectados, sensores e serviços cloud."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411025"
+  - "19411029"
+learning_outcomes:
+  - "Projetar arquiteturas IoT selecionando hardware, protocolos e serviços adequados."
+  - "Implementar protótipos com microcontroladores conectados, integrando sensores e atuadores."
+  - "Monitorizar e proteger redes IoT considerando requisitos de segurança e escalabilidade."
+youtube_playlists:
+  - id: "PL-19411031-aulas"
+    priority: 1
+  - id: "PL-19411031-labs"
+    priority: 2
+topics:
+  - slug: "fundamentos-iot"
+  - slug: "hardware-iot"
+  - slug: "comunicacao-iot"
+  - slug: "dados-iot"
+  - slug: "seguranca-iot"
+  - slug: "prototipo-iot"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos e casos de uso de IoT.
+- Hardware e plataformas de prototipagem com conectividade.
+- Protocolos de comunicação e publicação/assinatura (MQTT).
+- Gestão e visualização de dados IoT em plataformas cloud.
+- Segurança, autenticação e cifragem em dispositivos conectados.
+- Projeto integrador com demonstração ao vivo.
+
+## Metodologia
+
+A UC é baseada em laboratório com desenvolvimento iterativo de protótipos, documentação técnica e apresentação pública dos resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/prototipo-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/prototipo-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "prototipo-iot"
+title: "Protótipo IoT"
+summary: "Desenvolvimento de solução integrando dispositivos, rede e aplicação cloud."
+youtube_playlists:
+  - id: "PL-TOPIC-prototipo-iot"
+    priority: 1
+tags:
+  - "projeto"
+  - "sensores"
+  - "MQTT"
+type: topic
+layout: topic
+---
+Projeto final – montar rede de sensores que envia leituras via MQTT para um servidor e disponibiliza
+interface de visualização, abordando confiabilidade e escalabilidade.
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411031/seguranca-iot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411031/seguranca-iot.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-iot"
+title: "Segurança IoT"
+summary: "Riscos, autenticação de dispositivos e cifragem de comunicações."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-iot"
+    priority: 1
+tags:
+  - "segurança"
+  - "TLS"
+  - "autenticação"
+type: topic
+layout: topic
+---
+Riscos de dispositivos IoT (recursos limitados e exposição em rede) e boas práticas como
+autenticação, cifragem TLS e redes isoladas.
+
+Protótipos conectados são apresentados em demonstrações ao vivo, abordando desafios de
+conectividade, consumo energético e segurança.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/aplicacoes-robotica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/aplicacoes-robotica.md
@@ -1,0 +1,19 @@
+---
+slug: "aplicacoes-robotica"
+title: "Aplicações da Robótica"
+summary: "Áreas de uso, impactos sociais e questões éticas da robótica."
+youtube_playlists:
+  - id: "PL-TOPIC-aplicacoes-robotica"
+    priority: 1
+tags:
+  - "indústria"
+  - "ética"
+  - "autonomia"
+type: topic
+layout: topic
+---
+Discussão de aplicações industriais, domésticas, médicas e espaciais e reflexões éticas sobre
+autonomia e impacto no trabalho.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/cinematica-robot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/cinematica-robot.md
@@ -1,0 +1,19 @@
+---
+slug: "cinematica-robot"
+title: "Cinemática de Robôs"
+summary: "Representação de posições/orientações e cálculo de trajetórias simples."
+youtube_playlists:
+  - id: "PL-TOPIC-cinematica-robot"
+    priority: 1
+tags:
+  - "cinemática"
+  - "trajetória"
+  - "DH"
+type: topic
+layout: topic
+---
+Representação de posições e orientações (matrizes de rotação, Denavit-Hartenberg) e cálculo de
+trajetórias para manipuladores simples.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/controle-movimento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/controle-movimento.md
@@ -1,0 +1,19 @@
+---
+slug: "controle-movimento"
+title: "Controlo de Movimento"
+summary: "Controladores PID e comportamentos reativos para mobilidade."
+youtube_playlists:
+  - id: "PL-TOPIC-controle-movimento"
+    priority: 1
+tags:
+  - "PID"
+  - "malha fechada"
+  - "sensores"
+type: topic
+layout: topic
+---
+Conceito de controle em malha fechada, ajustes PID e implementação de comportamentos como seguir
+linha ou manter distância usando sensores.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/index.md
@@ -1,0 +1,42 @@
+---
+title: "Introdução à Robótica"
+code: "19411033"
+course_code: "LESTI"
+description: "Fundamentos de cinemática, sensores, atuadores e programação de robôs móveis e manipuladores simples."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411005"
+  - "19411019"
+learning_outcomes:
+  - "Descrever cinemática básica de robôs e representar movimentos em coordenadas apropriadas."
+  - "Selecionar sensores e atuadores adequados a tarefas robóticas básicas."
+  - "Programar comportamentos elementares de navegação ou manipulação num protótipo robótico."
+youtube_playlists:
+  - id: "PL-19411033-aulas"
+    priority: 1
+  - id: "PL-19411033-labs"
+    priority: 2
+topics:
+  - slug: "cinematica-robot"
+  - slug: "sensores-atuadores"
+  - slug: "plataforma-robotica"
+  - slug: "controle-movimento"
+  - slug: "programacao-robot"
+  - slug: "aplicacoes-robotica"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Modelação de posições e orientações, matrizes de transformação e trajetórias simples.
+- Sensores e atuadores utilizados em robótica.
+- Plataformas de prototipagem (Arduino, ROS) e arquitetura modular.
+- Controlo básico (PID) e comportamentos reativos.
+- Programação de robôs móveis ou manipuladores para tarefas elementares.
+- Aplicações e ética na robótica contemporânea.
+
+## Metodologia
+
+Sessões laboratoriais com kits robóticos e simulações digitais suportam a construção de protótipos funcionais avaliados em demonstrações práticas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/plataforma-robotica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/plataforma-robotica.md
@@ -1,0 +1,19 @@
+---
+slug: "plataforma-robotica"
+title: "Plataformas Robóticas"
+summary: "Uso de kits, microcontroladores e ROS para construir robôs."
+youtube_playlists:
+  - id: "PL-TOPIC-plataforma-robotica"
+    priority: 1
+tags:
+  - "Arduino"
+  - "ROS"
+  - "kits"
+type: topic
+layout: topic
+---
+Utilização de kits robóticos e microcontroladores (Arduino) e introdução ao ROS com conceitos de
+nodes e topics.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/programacao-robot.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/programacao-robot.md
@@ -1,0 +1,19 @@
+---
+slug: "programacao-robot"
+title: "Programação de Robôs"
+summary: "Algoritmos de navegação básica e sequenciamento de movimentos."
+youtube_playlists:
+  - id: "PL-TOPIC-programacao-robot"
+    priority: 1
+tags:
+  - "navegação"
+  - "obstáculos"
+  - "sequência"
+type: topic
+layout: topic
+---
+Programação de robôs móveis para seguir linha e desviar de obstáculos ou sequenciar movimentos de
+manipuladores para tarefas simples.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411033/sensores-atuadores.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411033/sensores-atuadores.md
@@ -1,0 +1,19 @@
+---
+slug: "sensores-atuadores"
+title: "Sensores e Atuadores"
+summary: "Tipos de sensores e atuadores usados em robótica e suas características."
+youtube_playlists:
+  - id: "PL-TOPIC-sensores-atuadores"
+    priority: 1
+tags:
+  - "sensores"
+  - "atuadores"
+  - "interface"
+type: topic
+layout: topic
+---
+Tipos de sensores (ultrassom, infravermelho, giroscópio, câmera) e atuadores (servos, motores DC,
+passo a passo) e como interfaciá-los com controladores.
+
+Oficinas com kits robóticos e simuladores permitem validar algoritmos de controlo e refletir sobre
+impactos sociais da robótica.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/apresentacao-publica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/apresentacao-publica.md
@@ -1,0 +1,19 @@
+---
+slug: "apresentacao-publica"
+title: "Apresentação Pública"
+summary: "Defesa perante banca académica e representantes da empresa."
+youtube_playlists:
+  - id: "PL-TOPIC-apresentacao-publica"
+    priority: 1
+tags:
+  - "defesa"
+  - "banca"
+  - "impacto"
+type: topic
+layout: topic
+---
+Preparação de defesa/apresentação final demonstrando o projeto a avaliadores, destacando impacto e
+respondendo a perguntas técnicas.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/definicao-projeto.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/definicao-projeto.md
@@ -1,0 +1,19 @@
+---
+slug: "definicao-projeto"
+title: "Definição do Projeto"
+summary: "Clarificação do problema e alinhamento com a entidade acolhedora."
+youtube_playlists:
+  - id: "PL-TOPIC-definicao-projeto"
+    priority: 1
+tags:
+  - "escopo"
+  - "alinhamento"
+  - "contexto"
+type: topic
+layout: topic
+---
+Entendimento aprofundado do problema proposto e levantamento de requisitos detalhados junto ao
+parceiro antes da execução.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/gestao-colaboracao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/gestao-colaboracao.md
@@ -1,0 +1,19 @@
+---
+slug: "gestao-colaboracao"
+title: "Gestão e Colaboração"
+summary: "Comunicação com equipas profissionais, gestão de tempo e adaptação."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-colaboracao"
+    priority: 1
+tags:
+  - "colaboração"
+  - "comunicação"
+  - "gestão de tempo"
+type: topic
+layout: topic
+---
+Experiência de trabalhar em ambiente profissional, incluindo comunicação com a equipa da empresa,
+gestão de tempo e adaptação a mudanças de escopo.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/implementacao-solucao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/implementacao-solucao.md
@@ -1,0 +1,19 @@
+---
+slug: "implementacao-solucao"
+title: "Implementação da Solução"
+summary: "Desenvolvimento técnico, integração de sistemas e testes."
+youtube_playlists:
+  - id: "PL-TOPIC-implementacao-solucao"
+    priority: 1
+tags:
+  - "desenvolvimento"
+  - "testes"
+  - "integração"
+type: topic
+layout: topic
+---
+Design, desenvolvimento e testes da solução, integrando múltiplos sistemas ou componentes conforme o
+escopo do projeto.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/index.md
@@ -1,0 +1,36 @@
+---
+title: "Projeto na Empresa IV"
+code: "19411034"
+course_code: "LESTI"
+description: "Projeto em empresa ou instituição com maior autonomia, integração de sistemas e relatório aprofundado."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411030"
+learning_outcomes:
+  - "Executar projetos de maior complexidade articulando múltiplas tecnologias."
+  - "Gerir comunicação com stakeholders e documentar decisões técnicas relevantes."
+  - "Produzir relatório e apresentação final que demonstrem competências profissionais avançadas."
+youtube_playlists:
+  - id: "PL-19411034-orientacoes"
+    priority: 1
+topics:
+  - slug: "definicao-projeto"
+  - slug: "metodologia-trabalho"
+  - slug: "implementacao-solucao"
+  - slug: "gestao-colaboracao"
+  - slug: "relatorio-avaliacao"
+  - slug: "apresentacao-publica"
+type: uc
+layout: uc
+---
+## Escopo do Projeto
+
+Continuação da experiência profissional iniciada no Projeto III, com foco em projetos de maior escala ou impacto. O estudante é incentivado a integrar metodologias de gestão, documentação e engenharia aprendidas nas UCs anteriores.
+
+## Entregáveis
+
+- Plano detalhado de trabalho aprovado pela entidade acolhedora.
+- Artefactos técnicos (código, infraestrutura, experimentos) acompanhados de documentação.
+- Relatório final extensivo e defesa pública perante banca académica e representantes da empresa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/metodologia-trabalho.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/metodologia-trabalho.md
@@ -1,0 +1,19 @@
+---
+slug: "metodologia-trabalho"
+title: "Metodologia de Trabalho"
+summary: "Escolha e adaptação de metodologias (ágil, experimental, etc.) ao projeto."
+youtube_playlists:
+  - id: "PL-TOPIC-metodologia-trabalho"
+    priority: 1
+tags:
+  - "metodologia"
+  - "Scrum"
+  - "monitorização"
+type: topic
+layout: topic
+---
+Escolha e uso de metodologia de desenvolvimento adequada (Scrum, Kanban, método experimental) com
+acompanhamento regular do progresso.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411034/relatorio-avaliacao.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411034/relatorio-avaliacao.md
@@ -1,0 +1,19 @@
+---
+slug: "relatorio-avaliacao"
+title: "Relatório e Avaliação"
+summary: "Documentação abrangente dos resultados e avaliação de objetivos."
+youtube_playlists:
+  - id: "PL-TOPIC-relatorio-avaliacao"
+    priority: 1
+tags:
+  - "relatório"
+  - "avaliação"
+  - "competências"
+type: topic
+layout: topic
+---
+Documentação abrangente das atividades, resultados e avaliação do cumprimento dos objetivos
+iniciais, incluindo reflexão sobre competências desenvolvidas.
+
+Os tópicos orientam a execução de projetos com parceiros externos, reforçando documentação
+profissional, comunicação e apresentação de resultados.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/aprendizagem-continuada.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/aprendizagem-continuada.md
@@ -1,0 +1,19 @@
+---
+slug: "aprendizagem-continuada"
+title: "Aprendizagem Continuada"
+summary: "Aquisição de novas competências técnicas e comportamentais durante o estágio."
+youtube_playlists:
+  - id: "PL-TOPIC-aprendizagem-continuada"
+    priority: 1
+tags:
+  - "aprendizagem"
+  - "competências"
+  - "ferramentas"
+type: topic
+layout: topic
+---
+Aprender novas ferramentas ou tecnologias exigidas pelas atividades, registrando evolução das
+competências técnicas e soft skills.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/atividade-tecnica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/atividade-tecnica.md
@@ -1,0 +1,19 @@
+---
+slug: "atividade-tecnica"
+title: "Atividade Técnica"
+summary: "Execução das tarefas técnicas definidas no plano de estágio."
+youtube_playlists:
+  - id: "PL-TOPIC-atividade-tecnica"
+    priority: 1
+tags:
+  - "tarefas"
+  - "desenvolvimento"
+  - "infraestrutura"
+type: topic
+layout: topic
+---
+Realizar tarefas técnicas atribuídas pela empresa – desenvolvimento de software, manutenção de
+infra-estrutura ou suporte técnico conforme o plano de estágio.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/etica-e-profissionalismo.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/etica-e-profissionalismo.md
@@ -1,0 +1,19 @@
+---
+slug: "etica-e-profissionalismo"
+title: "Ética e Profissionalismo"
+summary: "Conduta ética, confidencialidade e boas práticas no ambiente corporativo."
+youtube_playlists:
+  - id: "PL-TOPIC-etica-e-profissionalismo"
+    priority: 1
+tags:
+  - "ética"
+  - "confidencialidade"
+  - "conduta"
+type: topic
+layout: topic
+---
+Seguir normas de conduta, garantir confidencialidade e aplicar boas práticas de ética profissional
+ao manusear informações e recursos da empresa.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/gestao-tempo-projetos.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/gestao-tempo-projetos.md
@@ -1,0 +1,19 @@
+---
+slug: "gestao-tempo-projetos"
+title: "Gestão de Tempo e Projetos"
+summary: "Organização de prazos, uso de ferramentas internas e reporte de progresso."
+youtube_playlists:
+  - id: "PL-TOPIC-gestao-tempo-projetos"
+    priority: 1
+tags:
+  - "tempo"
+  - "ferramentas"
+  - "reportes"
+type: topic
+layout: topic
+---
+Gerenciar prazos e responsabilidades utilizando ferramentas internas (ticketing, gestão ágil) e
+reportar progresso aos supervisores.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/index.md
@@ -1,0 +1,36 @@
+---
+title: "Estágio"
+code: "19411035"
+course_code: "LESTI"
+description: "Estágio profissional de 30 ECTS em ambiente empresarial, com relatório e defesa final."
+ects: 30
+semester: 6
+language: "pt"
+prerequisites:
+  - "19411034"
+learning_outcomes:
+  - "Integrar-se numa organização aplicando competências técnicas e sociais adquiridas no curso."
+  - "Gerir tarefas, prazos e comunicação com supervisores seguindo práticas profissionais."
+  - "Produzir relatório de estágio que documente atividades, resultados e reflexão crítica."
+youtube_playlists:
+  - id: "PL-19411035-orientacoes"
+    priority: 1
+topics:
+  - slug: "integracao-profissional"
+  - slug: "atividade-tecnica"
+  - slug: "gestao-tempo-projetos"
+  - slug: "aprendizagem-continuada"
+  - slug: "etica-e-profissionalismo"
+  - slug: "relatorio-estagio"
+type: uc
+layout: uc
+---
+## Estrutura do Estágio
+
+O estágio decorre numa empresa ou instituição parceira, seguindo plano de trabalhos acordado entre estudante, entidade acolhedora e docente supervisor.
+
+## Avaliação
+
+- Relatórios de progresso e acompanhamento contínuo.
+- Relatório final detalhando atividades, resultados e reflexão crítica.
+- Defesa oral perante banca académica e representante da entidade.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/integracao-profissional.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/integracao-profissional.md
@@ -1,0 +1,19 @@
+---
+slug: "integracao-profissional"
+title: "Integração Profissional"
+summary: "Adaptação ao ambiente de trabalho e compreensão de processos organizacionais."
+youtube_playlists:
+  - id: "PL-TOPIC-integracao-profissional"
+    priority: 1
+tags:
+  - "integração"
+  - "empresa"
+  - "processos"
+type: topic
+layout: topic
+---
+Adaptar-se ao ambiente de trabalho, entender a estrutura e processos da organização e comunicar-se
+eficazmente com equipas profissionais.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411035/relatorio-estagio.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411035/relatorio-estagio.md
@@ -1,0 +1,19 @@
+---
+slug: "relatorio-estagio"
+title: "Relatório de Estágio"
+summary: "Documentação das atividades, resultados e reflexão crítica sobre o estágio."
+youtube_playlists:
+  - id: "PL-TOPIC-relatorio-estagio"
+    priority: 1
+tags:
+  - "relatório"
+  - "autoavaliação"
+  - "resultados"
+type: topic
+layout: topic
+---
+Produzir relatório final descrevendo a empresa, atividades realizadas, resultados obtidos e
+autoavaliação das competências desenvolvidas.
+
+A tutoria académica acompanha o estágio com reuniões periódicas e feedback, garantindo a ligação
+entre teoria e prática profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/analise-resultados.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/analise-resultados.md
@@ -1,0 +1,19 @@
+---
+slug: "analise-resultados"
+title: "Análise de Resultados"
+summary: "Avaliação do desempenho, comparação com objetivos e identificação de limitações."
+youtube_playlists:
+  - id: "PL-TOPIC-analise-resultados"
+    priority: 1
+tags:
+  - "avaliação"
+  - "desempenho"
+  - "limitações"
+type: topic
+layout: topic
+---
+Testes funcionais, avaliação de desempenho ou análise dos dados obtidos, comparando com expectativas
+ou estado da arte e identificando limitações.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/defesa-projeto.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/defesa-projeto.md
@@ -1,0 +1,19 @@
+---
+slug: "defesa-projeto"
+title: "Defesa do Projeto"
+summary: "Preparação da apresentação e defesa oral perante banca."
+youtube_playlists:
+  - id: "PL-TOPIC-defesa-projeto"
+    priority: 1
+tags:
+  - "defesa"
+  - "apresentação"
+  - "banca"
+type: topic
+layout: topic
+---
+Preparação da apresentação e defesa oral, demonstrando a solução e respondendo a questionamentos
+técnicos de avaliadores.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/documentacao-monografia.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/documentacao-monografia.md
@@ -1,0 +1,19 @@
+---
+slug: "documentacao-monografia"
+title: "Documentação e Monografia"
+summary: "Elaboração do documento final com descrição completa do projeto."
+youtube_playlists:
+  - id: "PL-TOPIC-documentacao-monografia"
+    priority: 1
+tags:
+  - "monografia"
+  - "documentação"
+  - "normas"
+type: topic
+layout: topic
+---
+Elaboração de monografia contendo introdução, fundamentação, metodologia, resultados, conclusão e
+trabalhos futuros, seguindo normas académicas.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/escolha-tema.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/escolha-tema.md
@@ -1,0 +1,19 @@
+---
+slug: "escolha-tema"
+title: "Escolha do Tema"
+summary: "Definição do problema, objetivos e revisão bibliográfica inicial."
+youtube_playlists:
+  - id: "PL-TOPIC-escolha-tema"
+    priority: 1
+tags:
+  - "tema"
+  - "revisão"
+  - "objetivos"
+type: topic
+layout: topic
+---
+Definição de um problema relevante a ser resolvido ou investigado e realização de revisão
+bibliográfica para contextualização.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/execucao-desenvolvimento.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/execucao-desenvolvimento.md
@@ -1,0 +1,19 @@
+---
+slug: "execucao-desenvolvimento"
+title: "Execução e Desenvolvimento"
+summary: "Implementação da solução ou realização de experimentos previstos."
+youtube_playlists:
+  - id: "PL-TOPIC-execucao-desenvolvimento"
+    priority: 1
+tags:
+  - "implementação"
+  - "experimentos"
+  - "iterações"
+type: topic
+layout: topic
+---
+Desenvolvimento da solução (software, protótipo ou estudo) ou execução de experimentos conforme o
+plano, com iterações de refinamento.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/index.md
@@ -1,0 +1,36 @@
+---
+title: "Projeto"
+code: "19411036"
+course_code: "LESTI"
+description: "Projeto final de curso de 30 ECTS, integrando investigação, desenvolvimento e documentação."
+ects: 30
+semester: 6
+language: "pt"
+prerequisites:
+  - "19411034"
+learning_outcomes:
+  - "Definir tema relevante e planear metodologia adequada para resolver o problema proposto."
+  - "Implementar solução ou conduzir investigação com rigor científico e técnico."
+  - "Documentar resultados em monografia e defender publicamente as contribuições do projeto."
+youtube_playlists:
+  - id: "PL-19411036-orientacoes"
+    priority: 1
+topics:
+  - slug: "escolha-tema"
+  - slug: "metodologia-projeto"
+  - slug: "execucao-desenvolvimento"
+  - slug: "analise-resultados"
+  - slug: "documentacao-monografia"
+  - slug: "defesa-projeto"
+type: uc
+layout: uc
+---
+## Organização
+
+O projeto pode ser desenvolvido individualmente ou em pequenos grupos, com orientação docente e, quando aplicável, coorientação externa.
+
+## Entregáveis
+
+- Proposta inicial com objetivos, requisitos e plano de trabalho.
+- Produto ou protótipo final acompanhado de evidências de testes.
+- Monografia completa e defesa pública perante banca avaliadora.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411036/metodologia-projeto.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411036/metodologia-projeto.md
@@ -1,0 +1,19 @@
+---
+slug: "metodologia-projeto"
+title: "Metodologia do Projeto"
+summary: "Planeamento das etapas de especificação, design, implementação e testes."
+youtube_playlists:
+  - id: "PL-TOPIC-metodologia-projeto"
+    priority: 1
+tags:
+  - "planeamento"
+  - "metodologia"
+  - "critérios"
+type: topic
+layout: topic
+---
+Planejamento das etapas do trabalho – especificação, design, implementação, testes/experimentação e
+critérios de sucesso.
+
+O projeto final é desenvolvido em proximidade com orientadores e especialistas externos,
+documentando decisões e avaliando contributos para a área de estudo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411037/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411037/index.md
@@ -1,0 +1,27 @@
+---
+title: "Optativa UAlg (3 ECTS)"
+code: "19411037"
+course_code: "LESTI"
+description: "Unidade optativa de 3 ECTS escolhida na oferta transversal da UAlg para complementar o percurso formativo."
+ects: 3
+semester: 2
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Selecionar uma UC optativa coerente com objetivos académicos e profissionais."
+  - "Integrar conhecimentos da optativa em projetos ou estudos do curso principal."
+  - "Comunicar resultados e aprendizagens da experiência optativa."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Nota sobre a Escolha
+
+A UC 19411037 corresponde a uma optativa aberta de 3 ECTS. Cabe ao estudante acompanhar a oferta semestral da Universidade do
+Algarve e proceder à inscrição na opção mais alinhada com o seu plano individual.
+
+## Registo e Avaliação
+
+O estudante deve anexar ao portefólio académico a ficha oficial da UC escolhida, bem como evidências de avaliação (relatórios,
+projetos ou exames) para garantir o reconhecimento dos créditos no plano da LESTI.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411038/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411038/index.md
@@ -1,0 +1,25 @@
+---
+title: "Unidade Optativa ISE (3º Semestre)"
+code: "19411038"
+course_code: "LESTI"
+description: "Optativa de 5 ECTS ofertada pelo ISE/UAlg, selecionada conforme interesses específicos do estudante."
+ects: 5
+semester: 3
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Definir objetivos de aprendizagem alinhados à optativa escolhida e ao percurso individual."
+  - "Aplicar metodologias próprias da área selecionada consolidando competências emergentes."
+  - "Produzir evidências de aprendizagem que articulem teoria e prática da UC optativa."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Nota sobre a Optativa
+
+Esta unidade corresponde a uma UC optativa de 5 ECTS escolhida entre as ofertas do ISE/UAlg. O estudante deve consultar a ficha oficial da UC selecionada para conhecer conteúdos, metodologias e critérios de avaliação.
+
+## Registo Académico
+
+Os conteúdos desenvolvidos, bem como os resultados de aprendizagem específicos, ficam documentados no relatório individual do estudante para efeitos de equivalência e acompanhamento do percurso formativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411039/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411039/index.md
@@ -1,0 +1,25 @@
+---
+title: "Optativa EE (4º Semestre)"
+code: "19411039"
+course_code: "LESTI"
+description: "Unidade optativa de 5 ECTS na área de Eletrónica/Energia escolhida pelo estudante."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Escolher uma optativa alinhada ao plano individual da pista de Eletrónica/Energia."
+  - "Aprofundar conhecimentos específicos da optativa, consolidando práticas laboratoriais ou teóricas."
+  - "Documentar resultados de aprendizagem e reflexões profissionais sobre a experiência optativa."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Informação Geral
+
+Esta unidade representa uma optativa da pista EE. O estudante deve registar a UC escolhida e anexar a ficha oficial com conteúdos e critérios de avaliação.
+
+## Evidências
+
+Relatórios, protótipos ou artigos produzidos durante a optativa devem ser arquivados para validação académica e profissional.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411040/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411040/index.md
@@ -1,0 +1,25 @@
+---
+title: "Optativa CI (4º Semestre)"
+code: "19411040"
+course_code: "LESTI"
+description: "Unidade optativa de 5 ECTS na área de Ciências Informáticas (CI) ou áreas afins."
+ects: 5
+semester: 4
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Selecionar uma optativa CI que complemente competências técnicas ou científicas."
+  - "Aplicar conhecimentos adquiridos na optativa em problemas ou projetos relacionados à engenharia informática."
+  - "Refletir criticamente sobre o impacto da optativa no percurso académico e profissional."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Informação Geral
+
+Optativa aberta às áreas de Ciências Informáticas, devendo o estudante consultar a ficha específica da UC pretendida. Os conteúdos e avaliações dependem da oferta selecionada.
+
+## Registo
+
+Um relatório reflexivo ao final do semestre consolida aprendizagens e evidencia competências desenvolvidas na UC optativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411041/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411041/index.md
@@ -1,0 +1,25 @@
+---
+title: "Optativa EE (5º Semestre)"
+code: "19411041"
+course_code: "LESTI"
+description: "Optativa adicional da pista de Eletrónica/Energia para aprofundar tópicos específicos."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Selecionar uma UC optativa que complemente a formação em eletrónica/energia."
+  - "Aplicar competências especializadas em projetos ou estudos dirigidos."
+  - "Registar aprendizagens e resultados alinhados a objetivos profissionais."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Informação
+
+Esta optativa é escolhida conforme a oferta da pista EE no semestre. Os conteúdos específicos devem ser consultados na ficha da UC selecionada.
+
+## Registo
+
+O estudante deve anexar relatório ou portefólio evidenciando os resultados da optativa.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411042/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411042/index.md
@@ -1,0 +1,25 @@
+---
+title: "Optativa CI (5º Semestre)"
+code: "19411042"
+course_code: "LESTI"
+description: "Optativa de 5 ECTS voltada à ampliação de competências em Ciências Informáticas."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Selecionar uma optativa CI alinhada aos objetivos pessoais ou de investigação."
+  - "Aplicar os conhecimentos da optativa em estudos ou protótipos dirigidos."
+  - "Documentar criticamente os resultados e impactos da experiência optativa."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Informação
+
+A escolha da optativa depende da oferta semestral do ISE/UAlg. É obrigatório consultar a ficha da UC escolhida para conhecer conteúdos e avaliações.
+
+## Evidência
+
+Entrega de relatório ou apresentação que demonstre o contributo da optativa para o percurso académico.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411043/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411043/index.md
@@ -1,0 +1,25 @@
+---
+title: "Optativa Livre (5º Semestre)"
+code: "19411043"
+course_code: "LESTI"
+description: "Optativa transversal de 5 ECTS (EE/CI/QAC) escolhida pelo estudante."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites: []
+learning_outcomes:
+  - "Escolher uma optativa alinhada aos interesses pessoais ou multidisciplinares."
+  - "Integrar conhecimentos de áreas complementares ao currículo base."
+  - "Registar evidências que demonstrem o contributo da optativa para o perfil profissional."
+youtube_playlists: []
+topics: []
+type: uc
+layout: uc
+---
+## Informação
+
+A UC corresponde a uma optativa aberta, devendo o estudante consultar a FUC da unidade escolhida e planear a integração dos resultados no portefólio académico.
+
+## Resultados
+
+Ao final do semestre, um relatório reflexivo sumariza aprendizagens, competências e impactos da optativa no percurso formativo.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/criptografia-basica.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/criptografia-basica.md
@@ -1,0 +1,19 @@
+---
+slug: "criptografia-basica"
+title: "Criptografia Básica"
+summary: "Algoritmos simétricos, assimétricos, hashes e assinaturas digitais."
+youtube_playlists:
+  - id: "PL-TOPIC-criptografia-basica"
+    priority: 1
+tags:
+  - "AES"
+  - "RSA"
+  - "hash"
+type: topic
+layout: topic
+---
+Funcionamento de algoritmos criptográficos simétricos (AES), assimétricos (RSA) e funções resumo
+(SHA-256) para garantir confidencialidade, autenticação e integridade.
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/index.md
@@ -1,0 +1,44 @@
+---
+title: "Cibersegurança"
+code: "19411049"
+course_code: "LESTI"
+description: "Princípios, técnicas e práticas de defesa em cibersegurança com foco em redes e aplicações."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411014"
+  - "19411021"
+learning_outcomes:
+  - "Analisar riscos e aplicar políticas de segurança da informação alinhadas ao pilar CIA."
+  - "Utilizar criptografia, firewalls e ferramentas de monitorização para proteger redes e sistemas."
+  - "Identificar e mitigar vulnerabilidades em aplicações Web seguindo recomendações OWASP."
+youtube_playlists:
+  - id: "PL-19411049-aulas"
+    priority: 1
+  - id: "PL-19411049-labs"
+    priority: 2
+topics:
+  - slug: "principios-ciberseguranca"
+  - slug: "criptografia-basica"
+  - slug: "seguranca-redes"
+  - slug: "seguranca-sistemas"
+  - slug: "seguranca-web"
+  - slug: "normas-e-politicas"
+  - slug: "laboratorio-ataques"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Fundamentos de segurança da informação e análise de risco.
+- Criptografia simétrica, assimétrica, hashing e assinaturas digitais.
+- Segurança em redes: firewalls, VPNs, IDS/IPS.
+- Segurança de sistemas operativos e gestão de patches.
+- Vulnerabilidades Web (OWASP Top 10) e contramedidas.
+- Normas e políticas de segurança (ISO 27001, NIST).
+- Laboratórios de ataque e defesa em ambiente controlado.
+
+## Metodologia
+
+A UC combina aulas expositivas com laboratórios hands-on em ambientes virtualizados, promovendo exercícios de ataque controlado, mitigação e documentação de incidentes.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/laboratorio-ataques.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/laboratorio-ataques.md
@@ -1,0 +1,19 @@
+---
+slug: "laboratorio-ataques"
+title: "Laboratório de Ataques e Defesa"
+summary: "Exercícios controlados de ataque, análise de vulnerabilidades e mitigação."
+youtube_playlists:
+  - id: "PL-TOPIC-laboratorio-ataques"
+    priority: 1
+tags:
+  - "pen test"
+  - "vulnerabilidades"
+  - "mitigação"
+type: topic
+layout: topic
+---
+Realização de atividades práticas – scanners de vulnerabilidades, exploração controlada e aplicação
+de correções documentadas.
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/normas-e-politicas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/normas-e-politicas.md
@@ -1,0 +1,19 @@
+---
+slug: "normas-e-politicas"
+title: "Normas e Políticas"
+summary: "Importância de políticas internas e normas ISO/NIST para segurança."
+youtube_playlists:
+  - id: "PL-TOPIC-normas-e-politicas"
+    priority: 1
+tags:
+  - "políticas"
+  - "ISO"
+  - "NIST"
+type: topic
+layout: topic
+---
+Importância de políticas de segurança organizacionais e introdução a normas como ISO 27001 e NIST
+Cybersecurity Framework.
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/principios-ciberseguranca.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/principios-ciberseguranca.md
@@ -1,0 +1,19 @@
+---
+slug: "principios-ciberseguranca"
+title: "Princípios de Cibersegurança"
+summary: "Pilares CIA, análise de riscos e políticas básicas de segurança."
+youtube_playlists:
+  - id: "PL-TOPIC-principios-ciberseguranca"
+    priority: 1
+tags:
+  - "CIA"
+  - "risco"
+  - "segurança"
+type: topic
+layout: topic
+---
+Pilar CIA (Confidentiality, Integrity, Availability) e conceitos relacionados como autenticidade e
+análise básica de riscos.
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-redes.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-redes.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-redes"
+title: "Segurança de Redes"
+summary: "Segmentação, firewalls, VPNs e IDS/IPS."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-redes"
+    priority: 1
+tags:
+  - "firewall"
+  - "VPN"
+  - "IDS"
+type: topic
+layout: topic
+---
+Design seguro de redes – segmentação, firewalls, VPNs para acesso remoto seguro e mecanismos de
+deteção de intrusão (IDS/IPS).
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-sistemas.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-sistemas.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-sistemas"
+title: "Segurança de Sistemas"
+summary: "Gestão de patches, modelos de controlo de acesso e mitigação de malware."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-sistemas"
+    priority: 1
+tags:
+  - "patch"
+  - "acesso"
+  - "malware"
+type: topic
+layout: topic
+---
+Manter sistemas atualizados, aplicar modelos de controlo de acesso e compreender tipologia de
+malware com estratégias de mitigação (antivírus, backups).
+
+As práticas decorrem em ambientes controlados onde é possível explorar vulnerabilidades e aplicar
+contramedidas documentadas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-web.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411049/seguranca-web.md
@@ -1,0 +1,19 @@
+---
+slug: "seguranca-web"
+title: "Segurança Web"
+summary: "Mitigação de vulnerabilidades comuns como SQL Injection, XSS e CSRF."
+youtube_playlists:
+  - id: "PL-TOPIC-seguranca-web"
+    priority: 1
+tags:
+  - "OWASP"
+  - "SQL Injection"
+  - "XSS"
+type: topic
+layout: topic
+---
+Melhores práticas de segurança em aplicações web – validação de entrada, uso de prepared statements,
+sanitização contra XSS, tokens anti-CSRF, HTTPS e armazenamento seguro de senhas.
+
+As equipas implementam aplicações fullstack com pipelines de testes e deploy contínuo, adotando
+padrões de segurança e performance modernos.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/desenho-visual.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/desenho-visual.md
@@ -1,0 +1,19 @@
+---
+slug: "desenho-visual"
+title: "Desenho Visual"
+summary: "Modelação de dados, interfaces e fluxos lógicos em ambientes visuais."
+youtube_playlists:
+  - id: "PL-TOPIC-desenho-visual"
+    priority: 1
+tags:
+  - "modelagem"
+  - "interfaces"
+  - "fluxos"
+type: topic
+layout: topic
+---
+Como modelar entidades, interfaces e fluxos lógicos em plataformas low-code usando componentes drag-
+and-drop e blocos lógicos.
+
+As atividades realçam governança, integrações e limites de extensibilidade necessários para entregar
+soluções low-code robustas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/desenvolvimento-rapido.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/desenvolvimento-rapido.md
@@ -1,0 +1,19 @@
+---
+slug: "desenvolvimento-rapido"
+title: "Desenvolvimento Rápido"
+summary: "Vantagens de prototipagem rápida, gestão de versões e deploy."
+youtube_playlists:
+  - id: "PL-TOPIC-desenvolvimento-rapido"
+    priority: 1
+tags:
+  - "prototipagem"
+  - "deploy"
+  - "versões"
+type: topic
+layout: topic
+---
+Vantagens de produtividade e prototipagem rápida com low-code; gestão de versões e implantação pela
+própria plataforma.
+
+As atividades realçam governança, integrações e limites de extensibilidade necessários para entregar
+soluções low-code robustas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/index.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/index.md
@@ -1,0 +1,39 @@
+---
+title: "Desenvolvimento de Aplicações com Low-Code"
+code: "19411050"
+course_code: "LESTI"
+description: "Exploração de plataformas low-code/no-code para construção rápida de aplicações empresariais."
+ects: 5
+semester: 5
+language: "pt"
+prerequisites:
+  - "19411021"
+learning_outcomes:
+  - "Comparar plataformas low-code e identificar casos de uso apropriados."
+  - "Modelar dados, interfaces e fluxos lógicos em ferramentas low-code."
+  - "Integrar aplicações low-code com serviços externos e entregar protótipos funcionais."
+youtube_playlists:
+  - id: "PL-19411050-aulas"
+    priority: 1
+  - id: "PL-19411050-oficinas"
+    priority: 2
+topics:
+  - slug: "plataformas-lowcode"
+  - slug: "desenho-visual"
+  - slug: "integracao-lowcode"
+  - slug: "desenvolvimento-rapido"
+  - slug: "projeto-lowcode"
+type: uc
+layout: uc
+---
+## Conteúdos Programáticos
+
+- Conceitos e panorama de plataformas low-code/no-code.
+- Modelação visual de dados, interfaces e processos.
+- Integração com APIs e serviços externos.
+- Boas práticas de manutenção, governança e versionamento.
+- Projeto final de aplicação empresarial utilizando plataforma low-code.
+
+## Metodologia
+
+Oficinas práticas guiadas levam à construção de protótipos iterativos avaliados por critérios de usabilidade e integração.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/integracao-lowcode.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/integracao-lowcode.md
@@ -1,0 +1,19 @@
+---
+slug: "integracao-lowcode"
+title: "Integração Low-Code"
+summary: "Conectores para APIs, bases de dados e componentes personalizados."
+youtube_playlists:
+  - id: "PL-TOPIC-integracao-lowcode"
+    priority: 1
+tags:
+  - "APIs"
+  - "conectores"
+  - "integração"
+type: topic
+layout: topic
+---
+Conectar aplicações low-code com serviços externos – uso de conectores para bases de dados, APIs
+REST/SOAP e integração de componentes personalizados.
+
+As atividades realçam governança, integrações e limites de extensibilidade necessários para entregar
+soluções low-code robustas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/plataformas-lowcode.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/plataformas-lowcode.md
@@ -1,0 +1,19 @@
+---
+slug: "plataformas-lowcode"
+title: "Plataformas Low-Code"
+summary: "Conceito de desenvolvimento low-code/no-code e panorama de ferramentas."
+youtube_playlists:
+  - id: "PL-TOPIC-plataformas-lowcode"
+    priority: 1
+tags:
+  - "low-code"
+  - "no-code"
+  - "plataformas"
+type: topic
+layout: topic
+---
+O que são ferramentas low-code – ambientes visuais para criar aplicações com mínimo código manual e
+exemplos de plataformas líderes.
+
+As atividades realçam governança, integrações e limites de extensibilidade necessários para entregar
+soluções low-code robustas.

--- a/content/pt/courses/LESTI/2025-2026/uc/19411050/projeto-lowcode.md
+++ b/content/pt/courses/LESTI/2025-2026/uc/19411050/projeto-lowcode.md
@@ -1,0 +1,19 @@
+---
+slug: "projeto-lowcode"
+title: "Projeto Low-Code"
+summary: "Desenvolvimento de aplicação empresarial completa em plataforma low-code."
+youtube_playlists:
+  - id: "PL-TOPIC-projeto-lowcode"
+    priority: 1
+tags:
+  - "aplicação"
+  - "empresarial"
+  - "publicação"
+type: topic
+layout: topic
+---
+Desenvolvimento de pequena aplicação empresarial (ex.: sistema de tíquetes) totalmente em plataforma
+low-code, desde modelagem até publicação e testes com utilizadores.
+
+As atividades realçam governança, integrações e limites de extensibilidade necessários para entregar
+soluções low-code robustas.


### PR DESCRIPTION
## Summary
- add the full Portuguese course overview for the 2025/2026 LESTI plan, including metadata and highlights
- document every mandatory unit with front matter, learning outcomes, syllabus text and linked topic markdown files based on the official FUC descriptions
- capture optional/alternative units for each track with placeholder descriptions so the plan reflects all choices in the curriculum

## Testing
- npm run lint:content

------
https://chatgpt.com/codex/tasks/task_e_68cf0180cb1c8322813c766c52b85704