### PR TITLE
Fix UC prerequisite rendering from Supabase

### DIFF
--- a/layouts/uc/single.html
+++ b/layouts/uc/single.html
@@ -20,7 +20,7 @@
               <dt class="col-6 col-lg-5">Idioma</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
               <dt class="col-6 col-lg-5">Pré-requisitos</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">
+              <dd class="col-6 col-lg-7 text-lg-end" data-facodi-uc-prerequisites>
                 {{ if $params.prerequisites }}
                   {{ delimit $params.prerequisites ", " }}
                 {{ else }}

--- a/static/js/loaders.js
+++ b/static/js/loaders.js
@@ -263,6 +263,14 @@
         updateText('.lead.text-muted', ucData.description || ucData.summary || '');
         updateHTML('#uc-learning-outcomes', `<h2 class="h5">Resultados de Aprendizagem</h2>${renderOutcomes(outcomeRows)}`);
         updateHTML('#uc-playlists', `<h2 class="h5">Playlists</h2>${renderPlaylists(playlistRows)}`);
+        const prerequisitesElement = document.querySelector('[data-facodi-uc-prerequisites]');
+        if (prerequisitesElement) {
+          if (Array.isArray(ucData.prerequisites) && ucData.prerequisites.length) {
+            prerequisitesElement.textContent = ucData.prerequisites.join(', ');
+          } else {
+            prerequisitesElement.innerHTML = '<span class="text-muted">Nenhum</span>';
+          }
+        }
         updateHTML('#uc-topics', `
           <div class="d-flex align-items-center justify-content-between mb-3">
             <h2 class="h4 mb-0">Tópicos</h2>


### PR DESCRIPTION
## Summary
- add a data hook to the UC template so prerequisites can be dynamically updated
- update the Supabase loader to render prerequisite lists or a default message from live data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf06f83bdc832298918ae3e1617cd0