### PR TITLE
Atualiza narrativa do FACODI para proposta comunitária digital

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,17 +1,40 @@
 ---
-title: "FACODI — Formação Aberta em Computação e Dados"
-description: "Portal colaborativo da comunidade de Engenharia Informática com currículos, unidades curriculares e recursos multimídia."
-lead: "Uma iniciativa da Monynha Softwares para mapear e disponibilizar, de forma aberta, a estrutura curricular das formações em Computação e Dados."
+title: "FACODI — Faculdade Comunitária Digital"
+description: "Plataforma comunitária e gratuita que organiza currículos oficiais e conecta playlists abertas para qualquer pessoa aprender."
+lead: "Organizamos currículos de licenciaturas e recheamos cada unidade com playlists abertas para que qualquer pessoa estude, compartilhe e brilhe junto com a comunidade."
 date: 2024-05-20T00:00:00+00:00
 lastmod: 2024-05-20T00:00:00+00:00
 draft: false
 seo:
-  title: "FACODI — Formação Aberta em Computação e Dados"
-  description: "Conheça o catálogo vivo de cursos, unidades curriculares e playlists da comunidade FACODI."
+  title: "FACODI — Faculdade Comunitária Digital"
+  description: "Currículos oficiais com playlists abertas, progresso comunitário e orgulho Monynha Softwares."
   canonical: ""
   noindex: false
 ---
 
-A plataforma FACODI nasce para dar visibilidade aos currículos, disciplinas e tópicos que moldam a formação em Computação e Dados em Portugal. Aqui você encontra percursos oficiais enriquecidos por contribuições da comunidade, playlists selecionadas e conteúdos abertos para estudo contínuo.
+A FACODI (Faculdade Comunitária Digital) é uma iniciativa gratuita da Monynha Softwares, inspirada nas universidades abertas e adaptada ao jeitinho da educação digital brasileira. A missão é clara: organizar os currículos oficiais de licenciaturas e áreas afins e popular cada unidade com playlists do YouTube e materiais públicos, costurando uma jornada de aprendizado estruturada, acessível e colaborativa. Chega mais, mona, porque conhecimento bom é aquele que todo mundo alcança.
 
-Nosso objetivo é oferecer transparência curricular e ampliar o acesso a recursos educacionais, conectando estudantes, docentes e profissionais em um ecossistema de aprendizagem em constante evolução.
+### Propósito e valores que guiam a FACODI
+
+- **Acesso gratuito:** todo conteúdo permanece aberto, sem barreiras financeiras nem pegadinhas.
+- **Comunidade:** estudantes, professoras, professores e voluntárias(os) curam o material coletivamente.
+- **Transparência:** cada trilha está ligada aos currículos oficiais, garantindo credibilidade.
+- **Inclusão e diversidade:** linguagem clara, acessibilidade digital e orgulho das nossas culturas.
+- **Sustentabilidade:** aproveitamos conteúdos públicos existentes e reduzimos custos de produção.
+
+### Pra quem é esse rolê
+
+* Estudantes universitários que querem revisar ou aprofundar as unidades curriculares com autonomia.
+* Pessoas interessadas em formação livre que buscam caminhos acadêmicos bem estruturados sem precisar se matricular.
+* Educadoras(es) e tutoras(es) que necessitam de acervos curados para ampliar suas aulas.
+* Toda a comunidade global que acredita em educação aberta como ferramenta de transformação social.
+
+### O que você encontra aqui
+
+1. **Catálogo de cursos** baseado em planos curriculares oficiais de licenciaturas e áreas correlatas.
+2. **Unidades curriculares detalhadas** com módulos, tópicos, playlists e materiais livres.
+3. **Mapa curricular interativo** para navegar por cursos, semestres e disciplinas sem se perder.
+4. **Marcação de progresso** simples para acompanhar o que já foi estudado.
+5. **Histórico de versões** para registrar cada atualização e garantir rastreabilidade acadêmica.
+
+FACODI é tecnologia com propósito: gratuita, aberta, orgulhosamente comunitária e com o brilho inclusivo da Monynha Softwares. Bora aprender juntes?

--- a/content/courses/_index.md
+++ b/content/courses/_index.md
@@ -1,8 +1,8 @@
 ---
 title: "Catálogo de Cursos"
-lead: "Explore as trilhas académicas disponíveis na FACODI."
+lead: "Escolha um curso e bora trilhar a FACODI com currículo oficial, playlists abertas e muito afeto comunitário."
 layout: "catalog"
 contributors: []
 ---
 
-A FACODI organiza os cursos por planos curriculares completos, com unidades curriculares e tópicos detalhados.
+A FACODI organiza os cursos a partir de planos curriculares oficiais, respeitando versões, semestres e competências previstas. Cada curso recebe um tratamento carinhoso: unidades curriculares detalhadas, tópicos associados, playlists priorizadas e espaço para a comunidade sugerir novos materiais. Chega junto, mona, porque aqui a jornada acadêmica é aberta, transparente e feita para compartilhar.

--- a/layouts/courses/catalog.html
+++ b/layouts/courses/catalog.html
@@ -14,7 +14,7 @@
     {{ if not (len $courses) }}
     <div class="col-12">
       <div class="alert alert-warning" role="alert">
-        Ainda não existem cursos publicados.
+        Ainda não temos cursos publicados por aqui. Chama a comunidade e vamos catalogar juntes!
       </div>
     </div>
     {{ end }}
@@ -44,7 +44,7 @@
             <dd class="col-7">{{ $params.duration_semesters | default "--" }} semestres</dd>
           </dl>
           <div class="mt-auto">
-            <a class="btn btn-outline-primary w-100" href="{{ .RelPermalink }}">Ver plano completo</a>
+            <a class="btn btn-outline-primary w-100" href="{{ .RelPermalink }}">Ver currículo completo</a>
           </div>
         </div>
       </div>

--- a/layouts/courses/course.html
+++ b/layouts/courses/course.html
@@ -57,7 +57,7 @@
       {{ $ucPages := $scratch.Get "ucs" }}
       {{ if not (len $ucPages) }}
       <div class="alert alert-warning" role="alert" data-facodi-slot="course-ucs">
-        Ainda não existem unidades curriculares associadas.
+        Ainda não adicionamos unidades curriculares por aqui. Bora sugerir playlists e conteúdos para abrir essa trilha?
       </div>
       {{ else }}
       <div class="row g-4" id="course-ucs" data-facodi-slot="course-ucs">

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -15,34 +15,34 @@
   <section class="section container-fluid mt-n3 py-5 py-lg-5">
     <div class="row align-items-center justify-content-center g-5">
       <div class="col-lg-6 col-xl-5 text-center text-lg-start">
-        <span class="badge rounded-pill bg-primary text-uppercase mb-3">Projeto FACODI</span>
-        <h1 class="display-5 fw-bold mb-4">Formação aberta em Computação e Dados para toda a comunidade</h1>
+        <span class="badge rounded-pill bg-primary text-uppercase mb-3">FACODI — Faculdade Comunitária Digital</span>
+        <h1 class="display-5 fw-bold mb-4">Educação aberta, orgulhosamente comunitária e gratuita</h1>
         <p class="lead text-muted mb-4">{{ .Params.lead | safeHTML }}</p>
         <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center justify-content-lg-start mb-4">
-          <a class="btn btn-primary btn-lg rounded-pill px-4" href="/courses/" role="button">Explorar cursos</a>
-          <a class="btn btn-outline-primary btn-lg rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça a Monynha Softwares</a>
+          <a class="btn btn-primary btn-lg rounded-pill px-4" href="/courses/" role="button">Explorar currículos</a>
+          <a class="btn btn-outline-primary btn-lg rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha Softwares</a>
         </div>
         <div class="d-flex flex-column flex-lg-row gap-3 align-items-center align-items-lg-start text-muted small">
           <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-success text-white rounded-pill">Aberto</span>
-            <span>Infraestrutura colaborativa e transparente para currículos digitais.</span>
+            <span class="badge bg-success text-white rounded-pill">Aberta e gratuita</span>
+            <span>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</span>
           </div>
           <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-light text-dark border rounded-pill">Supabase</span>
-            <span>Dados versionados e acessíveis via API.</span>
+            <span class="badge bg-light text-dark border rounded-pill">Comunidade Monynha</span>
+            <span>Curadoria colaborativa com orgulho, diversidade e transparência.</span>
           </div>
         </div>
       </div>
       <div class="col-lg-5 col-xl-5">
         <div class="card shadow-sm border-0 h-100">
           <div class="card-body p-4 p-lg-5">
-            <p class="text-uppercase text-muted fw-semibold mb-3">Em números</p>
+            <p class="text-uppercase text-muted fw-semibold mb-3">Em números comunitários</p>
             <ul class="list-unstyled fs-5 mb-4">
-              <li class="mb-2"><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos já catalogados</li>
-              <li class="mb-2"><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares conectadas</li>
-              <li>Integração direta com playlists, tópicos e recursos multimídia.</li>
+              <li class="mb-2"><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos oficiais organizados</li>
+              <li class="mb-2"><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares com playlists e materiais livres</li>
+              <li>Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</li>
             </ul>
-            <p class="mb-0 text-muted">Criado pela <a class="text-decoration-none" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para acelerar iniciativas educacionais abertas em Portugal.</p>
+            <p class="mb-0 text-muted">Criado pela <a class="text-decoration-none" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
           </div>
         </div>
       </div>
@@ -60,17 +60,17 @@
   </section>
   {{ end }}
   {{ $features := slice
-    (dict "icon" "📚" "title" "Catálogo vivo" "description" "Planos curriculares organizados com metadados completos, versões e ligação a conteúdos oficiais.")
-    (dict "icon" "🧭" "title" "Percursos guiados" "description" "Unidades curriculares agrupadas por semestre com resultados de aprendizagem, playlists e tópicos sugeridos.")
-    (dict "icon" "🤝" "title" "Comunidade conectada" "description" "Espaço para colaboração entre estudantes, docentes e parceiros institucionais.")
-    (dict "icon" "🚀" "title" "Tecnologia aberta" "description" "Hugo e Supabase formam a base para publicações rápidas, dados abertos e integrações personalizadas.")
+    (dict "icon" "🗺️" "title" "Mapa curricular interativo" "description" "Navegue por cursos, semestres e disciplinas com uma visão organizada dos currículos oficiais.")
+    (dict "icon" "🎧" "title" "Playlists integradas" "description" "Cada unidade curricular recebe playlists do YouTube e materiais públicos selecionados pela comunidade.")
+    (dict "icon" "✅" "title" "Marcação de progresso" "description" "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo.")
+    (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
   }}
   <section class="section section-md bg-light">
     <div class="container">
       <div class="row justify-content-center text-center mb-5">
         <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Tudo o que você precisa para navegar pela FACODI</h2>
-          <p class="text-muted">Uma experiência desenhada para evidenciar os currículos e facilitar o acesso a materiais de aprendizagem.</p>
+          <h2 class="h3 fw-bold">Experiência FACODI na palma da mão</h2>
+          <p class="text-muted">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
         </div>
       </div>
       <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
@@ -93,8 +93,8 @@
     <div class="container">
       <div class="row justify-content-between align-items-end mb-4">
         <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Cursos em destaque</h2>
-          <p class="text-muted mb-0">Percursos curriculares completos com unidades curriculares, resultados de aprendizagem e recursos multimédia.</p>
+          <h2 class="h3 fw-bold">Cursos em destaque na comunidade FACODI</h2>
+          <p class="text-muted mb-0">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
         </div>
         <div class="col-lg-4 text-lg-end mt-3 mt-lg-0">
           <a class="btn btn-outline-primary rounded-pill" href="/courses/">Ver todos os cursos</a>
@@ -121,7 +121,7 @@
               </div>
               {{ with .Params.ucs }}
               <div class="card-footer bg-transparent border-0 pt-0 pb-4 px-4">
-                <span class="small text-muted">{{ len . }} unidades curriculares já documentadas</span>
+                <span class="small text-muted">{{ len . }} unidades curriculares já mapeadas pela comunidade</span>
               </div>
               {{ end }}
             </div>
@@ -136,14 +136,14 @@
     <div class="container">
       <div class="row g-5 align-items-center">
         <div class="col-lg-5">
-          <h2 class="h3 fw-bold">Como a FACODI apoia a sua jornada</h2>
-          <p class="text-white-50">Do primeiro contacto com o currículo à curadoria de playlists, cada etapa foi desenhada para simplificar o estudo e fomentar a colaboração.</p>
+          <h2 class="h3 fw-bold">Como rola a jornada FACODI</h2>
+          <p class="text-white-50">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
         </div>
         <div class="col-lg-7">
           <ol class="list-group list-group-numbered list-group-flush bg-dark">
-            <li class="list-group-item bg-dark text-white-50 px-0">Explore planos curriculares completos, com semestres, créditos e descrição institucional.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Aprofunde-se nas unidades curriculares para conhecer competências, conteúdos e ligações a tópicos.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Acesse playlists e recursos recomendados pela comunidade para acelerar a prática.</li>
+            <li class="list-group-item bg-dark text-white-50 px-0">Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
+            <li class="list-group-item bg-dark text-white-50 px-0">Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
+            <li class="list-group-item bg-dark text-white-50 px-0">Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
           </ol>
         </div>
       </div>
@@ -155,10 +155,10 @@
 <section class="section container-fluid py-5">
   <div class="row justify-content-center text-center">
     <div class="col-lg-8">
-      <p class="text-uppercase text-muted small mb-2">Uma iniciativa Monynha Softwares</p>
-      <h2 class="h4 fw-bold">Tecnologia com propósito para educação aberta</h2>
-      <p class="text-muted">A Monynha Softwares desenvolve soluções digitais centradas em pessoas. A FACODI é o espaço para entregar essa visão à comunidade académica, promovendo partilha, transparência e inovação.</p>
-      <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Visite monynha.com</a>
+      <p class="text-uppercase text-muted small mb-2">Manifesto Monynha Softwares</p>
+      <h2 class="h4 fw-bold">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
+      <p class="text-muted">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
+      <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
     </div>
   </div>
 </section>
@@ -168,11 +168,11 @@
 <section class="section section-md container-fluid bg-light">
   <div class="row justify-content-center text-center">
     <div class="col-lg-7">
-      <h2 class="fw-bold">Pronto para colaborar com a FACODI?</h2>
-      <p class="text-muted">Contribua com conteúdos, playlists ou novas trilhas e ajude a comunidade a evoluir continuamente.</p>
+      <h2 class="fw-bold">Bora colar com a FACODI?</h2>
+      <p class="text-muted">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
       <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
-        <a class="btn btn-primary rounded-pill px-4" href="/courses/">Começar pelos cursos</a>
-        <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Fale com a Monynha Softwares</a>
+        <a class="btn btn-primary rounded-pill px-4" href="/courses/">Ver cursos e unidades curriculares</a>
+        <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Falar com a Monynha e sugerir materiais</a>
       </div>
     </div>
   </div>

--- a/layouts/topic/single.html
+++ b/layouts/topic/single.html
@@ -10,7 +10,7 @@
         {{ with $params.tags }}
           {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1">{{ . }}</span>{{ end }}
         {{ else }}
-          <span class="text-muted small">Sem tags definidas.</span>
+          <span class="text-muted small">Nenhuma tag adicionada ainda. Fala tu, mona, e ajuda a indexar esse conteúdo!</span>
         {{ end }}
       </div>
     </div>
@@ -31,7 +31,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">Sem playlists cadastradas.</p>
+        <p class="text-muted small">Sem playlists cadastradas por enquanto. Compartilha tua seleção nos canais da FACODI!</p>
         {{ end }}
       </section>
     </div>

--- a/layouts/uc/single.html
+++ b/layouts/uc/single.html
@@ -24,7 +24,7 @@
                 {{ if $params.prerequisites }}
                   {{ delimit $params.prerequisites ", " }}
                 {{ else }}
-                  <span class="text-muted">Nenhum</span>
+                  <span class="text-muted">Nenhum pré-requisito informado ainda.</span>
                 {{ end }}
               </dd>
             </dl>
@@ -43,7 +43,7 @@
           <span class="text-muted small">{{ len $topics }} tópicos</span>
         </div>
         {{ if not (len $topics) }}
-        <div class="alert alert-info" role="alert">Nenhum tópico cadastrado ainda.</div>
+        <div class="alert alert-info" role="alert">Ainda não temos tópicos conectados. Indica teus conteúdos favoritos para turbinar esta UC!</div>
         {{ else }}
         <div class="list-group list-group-flush">
           {{ range sort $topics "Title" }}
@@ -76,7 +76,7 @@
           {{ range $params.learning_outcomes }}<li class="mb-2">{{ . }}</li>{{ end }}
         </ol>
         {{ else }}
-        <p class="text-muted small">Nenhum resultado definido.</p>
+        <p class="text-muted small">Ainda estamos construindo os resultados de aprendizagem desta UC com a comunidade.</p>
         {{ end }}
       </aside>
       <aside id="uc-playlists" data-facodi-slot="uc-playlists">
@@ -92,7 +92,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">Sem playlists cadastradas.</p>
+        <p class="text-muted small">Nenhuma playlist cadastrada por enquanto. Que tal sugerir uma nos canais da FACODI?</p>
         {{ end }}
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- Ajusta o conteúdo editorial da página inicial para refletir a proposta 2025 da Faculdade Comunitária Digital, reforçando missão, valores e chamadas para ação inclusivas.
- Atualiza textos de catálogo, cursos, unidades curriculares e tópicos para convidar a comunidade a colaborar com playlists e materiais livres.
- Revisa os metadados e descrições institucionais para alinhar SEO e páginas internas à nova identidade do FACODI.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf260a647483228ebad29db1a72257