### PR TITLE
Reestiliza home com visual inspirado na proposta

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1,1 +1,536 @@
-// Put your custom SCSS code here
+:root {
+  --facodi-gradient: linear-gradient(120deg, #6a3bff 0%, #8f4dff 45%, #ff7bd2 100%);
+  --facodi-surface: #ffffff;
+  --facodi-surface-alt: rgba(255, 255, 255, 0.85);
+  --facodi-shadow-soft: 0 25px 60px -25px rgba(51, 28, 92, 0.45);
+  --facodi-shadow-strong: 0 40px 90px -40px rgba(106, 59, 255, 0.55);
+}
+
+body {
+  background: radial-gradient(120% 120% at 50% 0%, #f7f2ff 0%, #ffffff 65%);
+  color: $body-color;
+  font-family: $font-family-base;
+  line-height: 1.7;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: mix(#000000, $primary, 35%);
+  transition: color 0.2s ease, opacity 0.2s ease;
+
+  &:hover,
+  &:focus {
+    color: $primary;
+  }
+}
+
+.navbar {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(18px);
+  border-radius: 999px;
+  box-shadow: 0 20px 60px -28px rgba(32, 19, 67, 0.6);
+  margin: 1.25rem auto;
+  padding: 0.75rem 1.5rem;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+
+  &.is-sticky,
+  &.navbar-scrolled {
+    transform: translateY(-6px);
+  }
+
+  .navbar-brand {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: $body-color;
+  }
+
+  .nav-link {
+    color: rgba($body-color, 0.75);
+    font-weight: 600;
+    margin-inline: 0.35rem;
+    padding-inline: 0.75rem;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+
+    &:hover,
+    &:focus,
+    &.active {
+      background: rgba($primary, 0.1);
+      color: $primary;
+    }
+  }
+}
+
+.btn-primary {
+  background-image: var(--facodi-gradient);
+  background-size: 180% 180%;
+  border: none;
+  box-shadow: 0 20px 45px -20px rgba(106, 59, 255, 0.55);
+  color: #fff;
+  font-weight: 600;
+  transition: background-position 0.35s ease, box-shadow 0.3s ease, transform 0.2s ease;
+
+  &:hover,
+  &:focus {
+    background-position: 100% 50%;
+    box-shadow: 0 25px 55px -25px rgba(106, 59, 255, 0.65);
+    color: #fff;
+    transform: translateY(-1px);
+  }
+}
+
+.btn-outline-primary {
+  border: 2px solid rgba($primary, 0.25);
+  color: $primary;
+  font-weight: 600;
+  transition: all 0.25s ease;
+
+  &:hover,
+  &:focus {
+    background: rgba($primary, 0.08);
+    border-color: rgba($primary, 0.45);
+    color: $primary;
+  }
+}
+
+.hero {
+  border-radius: 2.5rem;
+  margin-top: -3rem;
+  padding-inline: clamp(1rem, 4vw, 3rem);
+}
+
+.hero-home {
+  background: linear-gradient(145deg, rgba(246, 237, 255, 0.95) 0%, rgba(254, 240, 255, 0.95) 100%);
+  position: relative;
+
+  .container {
+    position: relative;
+  }
+}
+
+.hero-glow {
+  position: absolute;
+  z-index: 0;
+  width: clamp(18rem, 22vw, 24rem);
+  height: clamp(18rem, 22vw, 24rem);
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 70%),
+    radial-gradient(circle at 70% 70%, rgba(106, 59, 255, 0.5) 0%, rgba(106, 59, 255, 0) 70%);
+  filter: blur(70px);
+  opacity: 0.85;
+
+  &.hero-glow-top {
+    top: -8rem;
+    right: -5rem;
+  }
+
+  &.hero-glow-bottom {
+    bottom: -6rem;
+    left: -4rem;
+  }
+}
+
+.hero-home .row {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-eyebrow {
+  background: rgba($primary, 0.08);
+  border: 1px solid rgba($primary, 0.12);
+  border-radius: 999px;
+  color: rgba($primary, 0.85);
+  display: inline-flex;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  padding: 0.45rem 1rem;
+  text-transform: uppercase;
+}
+
+.hero-title {
+  color: $body-color;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.1;
+}
+
+.hero-lead {
+  color: rgba($body-color, 0.75);
+}
+
+.hero-pill-group {
+  margin-top: 2rem;
+}
+
+.hero-pill {
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(106, 59, 255, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: 0 18px 45px -28px rgba(35, 17, 76, 0.35);
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  color: rgba($body-color, 0.72);
+
+  .hero-pill-icon {
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+}
+
+.glass-card {
+  background: linear-gradient(155deg, rgba(57, 27, 112, 0.92) 0%, rgba(105, 47, 200, 0.92) 60%, rgba(163, 86, 255, 0.88) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 2rem;
+  box-shadow: var(--facodi-shadow-strong);
+  color: #fff;
+  overflow: hidden;
+  padding: clamp(2rem, 4vw, 3rem);
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 55%);
+    pointer-events: none;
+  }
+}
+
+.hero-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero-card-subtitle {
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 0.2em;
+}
+
+.hero-stats {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.hero-stat {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 1.35rem;
+  padding: 1.35rem 1.5rem;
+  position: relative;
+}
+
+.hero-stat-value {
+  display: block;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.hero-stat-label {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.95rem;
+}
+
+.hero-note {
+  font-size: 0.95rem;
+  max-width: 32ch;
+}
+
+.hero-card-footer {
+  font-size: 0.9rem;
+  max-width: 36ch;
+}
+
+.text-white-75 {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.mission-intro {
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+
+  .mission-card {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(106, 59, 255, 0.12);
+    border-radius: 1.75rem;
+    box-shadow: 0 35px 65px -35px rgba(62, 34, 109, 0.4);
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+  }
+}
+
+.section-title {
+  color: $body-color;
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.section-subtitle {
+  color: rgba($body-color, 0.65);
+  font-size: 1.05rem;
+}
+
+.features-section {
+  background: linear-gradient(180deg, rgba(247, 241, 255, 0.6) 0%, rgba(255, 255, 255, 0.6) 100%);
+  border-radius: 2rem;
+  margin-block: clamp(3rem, 6vw, 5rem);
+  padding-block: clamp(3rem, 6vw, 5rem);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset-inline: 10%;
+    inset-block-start: -30%;
+    height: 60%;
+    background: radial-gradient(circle, rgba(106, 59, 255, 0.08) 0%, rgba(106, 59, 255, 0) 65%);
+    pointer-events: none;
+  }
+}
+
+.feature-card {
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(106, 59, 255, 0.1);
+  border-radius: 1.75rem;
+  box-shadow: 0 25px 55px -30px rgba(33, 20, 70, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 35px 65px -30px rgba(33, 20, 70, 0.45);
+  }
+}
+
+.feature-icon {
+  align-items: center;
+  background: rgba($primary, 0.1);
+  border-radius: 1.25rem;
+  color: $primary;
+  display: inline-flex;
+  font-size: 1.75rem;
+  height: 3.5rem;
+  justify-content: center;
+  width: 3.5rem;
+}
+
+.feature-title {
+  color: $body-color;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.feature-description {
+  color: rgba($body-color, 0.65);
+}
+
+.courses-section {
+  margin-block: clamp(3rem, 6vw, 5rem);
+}
+
+.course-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(106, 59, 255, 0.12);
+  border-radius: 1.85rem;
+  box-shadow: 0 25px 60px -30px rgba(36, 19, 74, 0.4);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 2.25rem 2.5rem 2rem;
+  position: relative;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+
+  &:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 35px 70px -32px rgba(36, 19, 74, 0.45);
+  }
+}
+
+.course-card-body {
+  flex: 1;
+}
+
+.course-card-footer {
+  border-top: 1px solid rgba(106, 59, 255, 0.12);
+  color: rgba($body-color, 0.55);
+  font-size: 0.95rem;
+  margin-top: 1.75rem;
+  padding-top: 1.25rem;
+}
+
+.course-plan {
+  background: rgba($primary, 0.1);
+  border-radius: 999px;
+  color: rgba($primary, 0.9);
+  display: inline-flex;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  padding: 0.4rem 1rem;
+  text-transform: uppercase;
+}
+
+.course-title {
+  color: $body-color;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 0.75rem;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: $primary;
+    }
+  }
+}
+
+.course-summary {
+  color: rgba($body-color, 0.65);
+  font-size: 1rem;
+  margin-top: 0.75rem;
+}
+
+.course-meta {
+  color: rgba($body-color, 0.6);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.journey-section {
+  background: linear-gradient(140deg, #28144d 0%, #3b1f6a 50%, #522b90 100%);
+  border-radius: 2.5rem;
+  box-shadow: var(--facodi-shadow-soft);
+  margin-block: clamp(3rem, 6vw, 5.5rem);
+  padding-block: clamp(3rem, 6vw, 5rem);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset-block-start: -30%;
+    inset-inline-end: -20%;
+    width: clamp(22rem, 35vw, 30rem);
+    height: clamp(22rem, 35vw, 30rem);
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 65%);
+    filter: blur(45px);
+    pointer-events: none;
+  }
+}
+
+.journey-steps {
+  counter-reset: journey;
+  display: grid;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 1.5rem;
+    color: rgba(255, 255, 255, 0.85);
+    counter-increment: journey;
+    font-size: 1.05rem;
+    padding: 1.35rem 1.5rem 1.35rem 3.5rem;
+    position: relative;
+
+    &::before {
+      align-items: center;
+      background: rgba(255, 255, 255, 0.18);
+      border-radius: 50%;
+      content: counter(journey);
+      display: inline-flex;
+      font-weight: 700;
+      height: 2.4rem;
+      justify-content: center;
+      left: 1rem;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 2.4rem;
+    }
+  }
+}
+
+.manifesto-section {
+  margin-block: clamp(3rem, 6vw, 5rem);
+
+  .manifesto-card {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(106, 59, 255, 0.15);
+    border-radius: 2rem;
+    box-shadow: 0 25px 60px -35px rgba(42, 21, 81, 0.4);
+    padding: clamp(2rem, 5vw, 3rem);
+  }
+}
+
+.cta-section {
+  padding-block: clamp(3rem, 6vw, 5rem);
+
+  .cta-card {
+    background: linear-gradient(120deg, rgba(106, 59, 255, 0.1) 0%, rgba(255, 123, 210, 0.16) 100%);
+    border: 1px solid rgba(106, 59, 255, 0.18);
+    border-radius: 2rem;
+    box-shadow: 0 30px 65px -35px rgba(40, 21, 77, 0.45);
+    padding: clamp(2rem, 5vw, 3rem);
+  }
+}
+
+.footer {
+  background: rgba(255, 255, 255, 0.85);
+  border-top: 1px solid rgba(106, 59, 255, 0.08);
+}
+
+@media (max-width: 991.98px) {
+  .navbar {
+    border-radius: 1.5rem;
+  }
+
+  .hero {
+    margin-top: 0;
+    padding-inline: 1.25rem;
+  }
+
+  .hero-card {
+    margin-top: 1.5rem;
+  }
+
+  .hero-pill-group {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .hero-title {
+    font-size: clamp(2.1rem, 5vw, 2.6rem);
+  }
+
+  .hero-card {
+    gap: 1.25rem;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .course-card {
+    padding: 2rem;
+  }
+
+  .journey-steps li {
+    padding-left: 3rem;
+  }
+}

--- a/assets/scss/common/_variables-custom.scss
+++ b/assets/scss/common/_variables-custom.scss
@@ -1,1 +1,13 @@
-// Put your custom SCSS variables here
+$primary: #6a3bff;
+$secondary: #ff7bd2;
+$body-bg: #f6f3ff;
+$body-color: #241c3c;
+$font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+$btn-border-radius: 999px;
+$btn-border-radius-sm: 999px;
+$btn-border-radius-lg: 999px;
+$btn-padding-y: 0.75rem;
+$btn-padding-x: 1.75rem;
+$card-border-radius: 1.5rem;
+$card-border-radius-lg: 1.75rem;
+$border-radius: 1rem;

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -12,48 +12,58 @@
       {{ end }}
     {{ end }}
   {{ end }}
-  <section class="section container-fluid mt-n3 py-5 py-lg-5">
-    <div class="row align-items-center justify-content-center g-5">
-      <div class="col-lg-6 col-xl-5 text-center text-lg-start">
-        <span class="badge rounded-pill bg-primary text-uppercase mb-3">FACODI — Faculdade Comunitária Digital</span>
-        <h1 class="display-5 fw-bold mb-4">Educação aberta, orgulhosamente comunitária e gratuita</h1>
-        <p class="lead text-muted mb-4">{{ .Params.lead | safeHTML }}</p>
-        <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center justify-content-lg-start mb-4">
-          <a class="btn btn-primary btn-lg rounded-pill px-4" href="/courses/" role="button">Explorar currículos</a>
-          <a class="btn btn-outline-primary btn-lg rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha Softwares</a>
-        </div>
-        <div class="d-flex flex-column flex-lg-row gap-3 align-items-center align-items-lg-start text-muted small">
-          <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-success text-white rounded-pill">Aberta e gratuita</span>
-            <span>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</span>
+  <section class="hero hero-home position-relative overflow-hidden">
+    <div class="container position-relative">
+      <span class="hero-glow hero-glow-top"></span>
+      <span class="hero-glow hero-glow-bottom"></span>
+      <div class="row align-items-center justify-content-between g-5">
+        <div class="col-lg-6 col-xl-5 text-center text-lg-start">
+          <div class="hero-eyebrow text-uppercase fw-semibold">Ensino superior acessível, aberto e comunitário.</div>
+          <h1 class="hero-title display-4 fw-bold mb-3">FACODI — Faculdade Comunitária Digital</h1>
+          <p class="hero-lead lead text-muted mb-4">{{ .Params.lead | safeHTML }}</p>
+          <div class="hero-actions d-flex flex-column flex-sm-row gap-3 justify-content-center justify-content-lg-start mb-4">
+            <a class="btn btn-primary btn-lg px-4" href="/courses/" role="button">Explorar trilhas</a>
+            <a class="btn btn-outline-primary btn-lg px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha Softwares</a>
           </div>
-          <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-light text-dark border rounded-pill">Comunidade Monynha</span>
-            <span>Curadoria colaborativa com orgulho, diversidade e transparência.</span>
+          <div class="hero-pill-group d-flex flex-column flex-md-row align-items-stretch gap-3 text-muted small">
+            <div class="hero-pill">
+              <span class="hero-pill-icon">💜</span>
+              <span>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</span>
+            </div>
+            <div class="hero-pill">
+              <span class="hero-pill-icon">🤝</span>
+              <span>Curadoria colaborativa com orgulho, diversidade e transparência.</span>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="col-lg-5 col-xl-5">
-        <div class="card shadow-sm border-0 h-100">
-          <div class="card-body p-4 p-lg-5">
-            <p class="text-uppercase text-muted fw-semibold mb-3">Em números comunitários</p>
-            <ul class="list-unstyled fs-5 mb-4">
-              <li class="mb-2"><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos oficiais organizados</li>
-              <li class="mb-2"><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares com playlists e materiais livres</li>
-              <li>Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</li>
-            </ul>
-            <p class="mb-0 text-muted">Criado pela <a class="text-decoration-none" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
+        <div class="col-lg-6 col-xl-5 ms-xl-auto">
+          <div class="hero-card glass-card h-100">
+            <p class="hero-card-subtitle text-uppercase fw-semibold mb-3">Em números comunitários</p>
+            <div class="hero-stats mb-4">
+              <div class="hero-stat">
+                <span class="hero-stat-value">{{ $scratch.Get "coursesCount" }}</span>
+                <p class="hero-stat-label mb-0">cursos oficiais organizados</p>
+              </div>
+              <div class="hero-stat">
+                <span class="hero-stat-value">{{ $scratch.Get "ucCount" }}</span>
+                <p class="hero-stat-label mb-0">unidades curriculares com playlists e materiais livres</p>
+              </div>
+            </div>
+            <p class="hero-note text-white-75 mb-4">Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</p>
+            <p class="hero-card-footer text-white-75 mb-0">Criado pela <a class="link-light text-decoration-none" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
           </div>
         </div>
       </div>
     </div>
   </section>
   {{ with .Content }}
-  <section class="section section-sm pt-0">
+  <section class="section section-sm pt-0 mission-intro">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-lg-10 col-xl-8 lead text-muted">
-          {{ . | safeHTML }}
+        <div class="col-lg-10 col-xl-8">
+          <div class="mission-card lead text-muted">
+            {{ . | safeHTML }}
+          </div>
         </div>
       </div>
     </div>
@@ -65,23 +75,21 @@
     (dict "icon" "✅" "title" "Marcação de progresso" "description" "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo.")
     (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
   }}
-  <section class="section section-md bg-light">
+  <section class="section section-md features-section">
     <div class="container">
       <div class="row justify-content-center text-center mb-5">
         <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Experiência FACODI na palma da mão</h2>
-          <p class="text-muted">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
+          <h2 class="section-title">Experiência FACODI na palma da mão</h2>
+          <p class="section-subtitle">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
         </div>
       </div>
       <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
         {{ range $features }}
         <div class="col">
-          <div class="card h-100 border-0 shadow-sm">
-            <div class="card-body p-4">
-              <span class="d-inline-flex justify-content-center align-items-center rounded-circle bg-primary bg-opacity-10 text-primary fs-3 mb-3" style="width:3rem;height:3rem;">{{ .icon }}</span>
-              <h3 class="h5 fw-semibold">{{ .title }}</h3>
-              <p class="text-muted mb-0">{{ .description }}</p>
-            </div>
+          <div class="feature-card h-100">
+            <div class="feature-icon">{{ .icon }}</div>
+            <h3 class="feature-title">{{ .title }}</h3>
+            <p class="feature-description mb-0">{{ .description }}</p>
           </div>
         </div>
         {{ end }}
@@ -89,39 +97,39 @@
     </div>
   </section>
   {{ with site.GetPage "section" "courses" }}
-  <section class="section section-md">
+  <section class="section section-md courses-section">
     <div class="container">
       <div class="row justify-content-between align-items-end mb-4">
         <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Cursos em destaque na comunidade FACODI</h2>
-          <p class="text-muted mb-0">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
+          <h2 class="section-title">Cursos em destaque na comunidade FACODI</h2>
+          <p class="section-subtitle mb-0">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
         </div>
         <div class="col-lg-4 text-lg-end mt-3 mt-lg-0">
-          <a class="btn btn-outline-primary rounded-pill" href="/courses/">Ver todos os cursos</a>
+          <a class="btn btn-outline-primary" href="/courses/">Ver todos os cursos</a>
         </div>
       </div>
       <div class="row row-cols-1 row-cols-lg-2 g-4">
         {{ range .Sections }}
           {{ if .Params.code }}
           <div class="col">
-            <div class="card h-100 shadow-sm border-0">
-              <div class="card-body p-4">
+            <div class="course-card h-100">
+              <div class="course-card-body">
                 {{ with .Params.plan_version }}
-                <span class="badge bg-secondary text-uppercase mb-3">Plano {{ . }}</span>
+                <span class="course-plan">Plano {{ . }}</span>
                 {{ end }}
-                <h3 class="h4"><a class="stretched-link text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+                <h3 class="course-title"><a class="stretched-link" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
                 {{ with .Params.summary }}
-                <p class="text-muted">{{ . }}</p>
+                <p class="course-summary">{{ . }}</p>
                 {{ end }}
-                <div class="d-flex flex-wrap gap-3 text-muted small">
+                <div class="course-meta">
                   {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> ECTS</span>{{ end }}
                   {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> semestres</span>{{ end }}
                   {{ with .Params.code }}<span>Código {{ . }}</span>{{ end }}
                 </div>
               </div>
               {{ with .Params.ucs }}
-              <div class="card-footer bg-transparent border-0 pt-0 pb-4 px-4">
-                <span class="small text-muted">{{ len . }} unidades curriculares já mapeadas pela comunidade</span>
+              <div class="course-card-footer">
+                <span>{{ len . }} unidades curriculares já mapeadas pela comunidade</span>
               </div>
               {{ end }}
             </div>
@@ -132,18 +140,18 @@
     </div>
   </section>
   {{ end }}
-  <section class="section section-md bg-dark text-white">
+  <section class="section section-md journey-section text-white">
     <div class="container">
       <div class="row g-5 align-items-center">
         <div class="col-lg-5">
-          <h2 class="h3 fw-bold">Como rola a jornada FACODI</h2>
-          <p class="text-white-50">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
+          <h2 class="section-title text-white">Como rola a jornada FACODI</h2>
+          <p class="section-subtitle text-white-75">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
         </div>
         <div class="col-lg-7">
-          <ol class="list-group list-group-numbered list-group-flush bg-dark">
-            <li class="list-group-item bg-dark text-white-50 px-0">Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
+          <ol class="journey-steps">
+            <li>Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
+            <li>Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
+            <li>Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
           </ol>
         </div>
       </div>
@@ -152,27 +160,31 @@
 {{ end }}
 
 {{ define "sidebar-prefooter" }}
-<section class="section container-fluid py-5">
+<section class="section container-fluid py-5 manifesto-section">
   <div class="row justify-content-center text-center">
     <div class="col-lg-8">
-      <p class="text-uppercase text-muted small mb-2">Manifesto Monynha Softwares</p>
-      <h2 class="h4 fw-bold">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
-      <p class="text-muted">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
-      <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
+      <div class="manifesto-card">
+        <p class="text-uppercase small text-muted mb-2">Manifesto Monynha Softwares</p>
+        <h2 class="section-title">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
+        <p class="section-subtitle">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
+        <a class="btn btn-outline-primary" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
+      </div>
     </div>
   </div>
 </section>
 {{ end }}
 
 {{ define "sidebar-footer" }}
-<section class="section section-md container-fluid bg-light">
+<section class="section section-md container-fluid cta-section">
   <div class="row justify-content-center text-center">
     <div class="col-lg-7">
-      <h2 class="fw-bold">Bora colar com a FACODI?</h2>
-      <p class="text-muted">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
-      <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
-        <a class="btn btn-primary rounded-pill px-4" href="/courses/">Ver cursos e unidades curriculares</a>
-        <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Falar com a Monynha e sugerir materiais</a>
+      <div class="cta-card">
+        <h2 class="section-title">Bora colar com a FACODI?</h2>
+        <p class="section-subtitle">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
+        <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
+          <a class="btn btn-primary" href="/courses/">Ver cursos e unidades curriculares</a>
+          <a class="btn btn-outline-primary" href="https://monynha.com" target="_blank" rel="noopener">Falar com a Monynha e sugerir materiais</a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- redesenha o herói da home com novo layout, destaques e cartão de métricas em estilo glassmorphism
- atualiza as seções de conteúdo, recursos, cursos e chamadas finais para seguirem a estética da proposta
- adiciona variáveis e SCSS customizados com nova paleta, gradientes, botões e cartões responsivos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfba7e73308322b1e13bdfa96f7c84