### PR TITLE
refactor: redesign landing page with custom styling

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -1,1 +1,1356 @@
-// Put your custom SCSS code here
+// Global resets and typography
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: var(--facodi-font-sans);
+  color: var(--facodi-color-ink);
+  background: var(--facodi-page-gradient);
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-size: 16px;
+  line-height: 1.6;
+  background: transparent;
+}
+
+a {
+  color: var(--facodi-link);
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--facodi-primary-dark);
+}
+
+p {
+  color: var(--facodi-color-muted);
+  margin-bottom: 1.1rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 0.75rem;
+  letter-spacing: -0.02em;
+  color: var(--facodi-color-ink);
+}
+
+::selection {
+  background: rgba(95, 88, 255, 0.15);
+}
+
+img,
+svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.shell {
+  width: 100%;
+  max-width: var(--facodi-shell-max);
+  margin: 0 auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-main {
+  flex: 1 0 auto;
+}
+
+// Header and navigation
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid rgba(113, 101, 224, 0.12);
+  transition: box-shadow 180ms ease, background 180ms ease;
+}
+
+.site-header.is-scrolled {
+  box-shadow: var(--facodi-shadow-header);
+  background: rgba(250, 248, 255, 0.95);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0.5rem;
+}
+
+.site-logo {
+  font-weight: 800;
+  font-size: 1.15rem;
+  letter-spacing: -0.03em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--facodi-color-ink);
+}
+
+.site-logo span {
+  background: linear-gradient(120deg, #533cff 0%, #8761ff 45%, #ff6cdd 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.site-header__group {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.35rem;
+}
+
+.site-nav__link {
+  position: relative;
+  font-weight: 500;
+  font-size: 0.97rem;
+  color: var(--facodi-color-muted);
+  padding: 0.4rem 0;
+}
+
+.site-nav__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--facodi-cta-gradient);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 180ms ease;
+}
+
+.site-nav__link:hover::after,
+.site-nav__link:focus-visible::after,
+.site-nav__link[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
+.language-toggle {
+  border: 1px solid var(--facodi-border);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--facodi-color-muted);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border 160ms ease, background 160ms ease;
+}
+
+.language-toggle:hover,
+.language-toggle:focus-visible {
+  border-color: var(--facodi-border-strong);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--facodi-color-ink);
+}
+
+.site-header__menu {
+  display: none;
+  border: none;
+  background: rgba(113, 101, 224, 0.12);
+  color: var(--facodi-color-ink);
+  padding: 0.55rem;
+  border-radius: 0.85rem;
+  cursor: pointer;
+}
+
+.site-header__menu svg {
+  display: block;
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.cta--primary {
+  background: var(--facodi-cta-gradient);
+  color: #fff;
+  box-shadow: 0 20px 40px rgba(84, 66, 198, 0.35);
+}
+
+.cta--primary:hover,
+.cta--primary:focus-visible {
+  background: var(--facodi-cta-gradient-hover);
+  transform: translateY(-1px);
+}
+
+.cta--secondary {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(104, 92, 215, 0.26);
+  color: var(--facodi-color-ink);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+}
+
+.cta--secondary:hover,
+.cta--secondary:focus-visible {
+  border-color: rgba(104, 92, 215, 0.42);
+  color: var(--facodi-primary-dark);
+}
+
+.cta--ghost {
+  background: transparent;
+  border: 1px solid rgba(104, 92, 215, 0.4);
+  color: var(--facodi-color-ink);
+}
+
+.cta--ghost:hover,
+.cta--ghost:focus-visible {
+  background: rgba(103, 94, 205, 0.08);
+}
+
+.cta--small {
+  padding: 0.55rem 1.2rem;
+  font-size: 0.9rem;
+}
+
+// Hero section
+.landing {
+  position: relative;
+  padding: 4.5rem 0 4rem;
+  background: var(--facodi-hero-gradient);
+  overflow: hidden;
+}
+
+.landing::before,
+.landing::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.landing::before {
+  width: 480px;
+  height: 480px;
+  top: -180px;
+  left: -140px;
+  background: rgba(125, 101, 255, 0.35);
+}
+
+.landing::after {
+  width: 420px;
+  height: 420px;
+  bottom: -220px;
+  right: -120px;
+  background: rgba(255, 140, 225, 0.35);
+}
+
+.landing__grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: center;
+}
+
+.landing__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.landing__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  color: var(--facodi-primary-dark);
+  background: rgba(111, 94, 255, 0.16);
+  border: 1px solid rgba(120, 105, 255, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.landing__title {
+  font-size: clamp(2.5rem, 4.1vw, 3.6rem);
+  line-height: 1.05;
+  max-width: 18ch;
+}
+
+.landing__lead {
+  font-size: 1.08rem;
+  max-width: 52ch;
+  color: var(--facodi-color-soft);
+}
+
+.landing__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.landing__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.landing__stat {
+  padding: 1.1rem 1.35rem;
+  border-radius: 1.4rem;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(125, 113, 214, 0.18);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--facodi-shadow-soft);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.landing__stat dt {
+  font-size: 0.78rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(33, 25, 68, 0.6);
+}
+
+.landing__stat-value {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--facodi-color-ink);
+}
+
+.landing__stat-caption {
+  font-size: 0.85rem;
+  color: var(--facodi-color-soft);
+}
+
+.landing__aside {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-card {
+  position: relative;
+  padding: 2px;
+  border-radius: 28px;
+  background: var(--facodi-card-gradient);
+  box-shadow: var(--facodi-shadow-strong);
+  max-width: 420px;
+  width: 100%;
+}
+
+.hero-card__inner {
+  position: relative;
+  padding: clamp(2rem, 4vw, 2.6rem);
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.hero-card__chip {
+  align-self: flex-start;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: rgba(84, 60, 198, 0.85);
+  background: rgba(125, 101, 255, 0.14);
+  border: 1px solid rgba(125, 101, 255, 0.26);
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+}
+
+.hero-card__title {
+  font-size: clamp(1.45rem, 2.5vw, 1.75rem);
+  line-height: 1.3;
+}
+
+.hero-card__lead {
+  font-size: 1rem;
+  color: var(--facodi-color-soft);
+}
+
+.hero-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.hero-card__list li {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.93rem;
+  color: var(--facodi-color-muted);
+}
+
+.hero-card__list strong {
+  color: var(--facodi-color-ink);
+}
+
+.hero-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed rgba(115, 102, 214, 0.25);
+  font-size: 0.85rem;
+  color: var(--facodi-color-soft);
+}
+
+.hero-card__avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7c6dff, #ff8ddf);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+}
+
+.home-richtext {
+  padding: clamp(2rem, 4vw, 3rem) 0 clamp(3rem, 5vw, 4.5rem);
+}
+
+.home-richtext__inner {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 32px;
+  border: 1px solid rgba(112, 101, 225, 0.16);
+  box-shadow: 0 16px 46px rgba(84, 66, 198, 0.08);
+  padding: clamp(2.2rem, 4vw, 3rem);
+}
+
+.home-richtext__inner p {
+  font-size: 1.05rem;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.6rem;
+  margin-bottom: clamp(2rem, 4vw, 2.8rem);
+}
+
+.section-header__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: rgba(33, 25, 68, 0.58);
+}
+
+.section-header__title {
+  font-size: clamp(1.95rem, 3vw, 2.5rem);
+}
+
+.section-header__description {
+  color: var(--facodi-color-soft);
+  max-width: 60ch;
+}
+
+.section-header--split {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.section-header--split .section-header__description {
+  max-width: 40ch;
+}
+
+.experience {
+  padding: clamp(3rem, 5vw, 5rem) 0;
+  background: linear-gradient(180deg, rgba(244, 241, 255, 0.9) 0%, #ffffff 100%);
+}
+
+.experience__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1.5rem;
+}
+
+.experience__item {
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(120, 105, 255, 0.15);
+  box-shadow: var(--facodi-shadow-soft);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.experience__item:hover,
+.experience__item:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 50px rgba(84, 66, 198, 0.14);
+}
+
+.experience__icon {
+  display: inline-flex;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 18px;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
+  background: rgba(98, 87, 227, 0.14);
+}
+
+.course-showcase {
+  padding: clamp(3rem, 5vw, 5rem) 0;
+}
+
+.course-showcase__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.8rem;
+}
+
+.course-card {
+  position: relative;
+  padding: 2px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(103, 90, 220, 0.35), rgba(255, 126, 216, 0.25));
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.course-card__inner {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 26px;
+  padding: 2.2rem 2rem;
+  display: grid;
+  gap: 1.2rem;
+  min-height: 100%;
+}
+
+.course-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 48px rgba(84, 66, 198, 0.18);
+}
+
+.course-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  color: rgba(33, 25, 68, 0.65);
+}
+
+.course-card__badge {
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(120, 105, 255, 0.12);
+  border: 1px solid rgba(120, 105, 255, 0.28);
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.course-card__title {
+  font-size: 1.35rem;
+}
+
+.course-card__title a {
+  color: inherit;
+}
+
+.course-card__description {
+  color: var(--facodi-color-soft);
+  font-size: 0.98rem;
+}
+
+.course-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem;
+  font-size: 0.85rem;
+  color: rgba(33, 25, 68, 0.6);
+}
+
+.course-card__meta span strong {
+  color: var(--facodi-color-ink);
+}
+
+.course-card__footer {
+  font-size: 0.82rem;
+  color: rgba(33, 25, 68, 0.55);
+}
+
+.journey {
+  padding: clamp(3rem, 5vw, 5rem) 0;
+  background: radial-gradient(140% 140% at 20% 20%, rgba(125, 101, 255, 0.08) 0%, rgba(125, 101, 255, 0) 60%),
+    #f9f7ff;
+}
+
+.journey__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.journey__intro p {
+  font-size: 1rem;
+}
+
+.journey__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.journey__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: flex-start;
+  gap: 1.2rem;
+  padding: 1.4rem 1.6rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(115, 102, 214, 0.16);
+  box-shadow: var(--facodi-shadow-soft);
+}
+
+.journey__step {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  background: rgba(103, 90, 220, 0.16);
+  color: var(--facodi-primary-dark);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.journey__item p {
+  margin: 0;
+  color: var(--facodi-color-soft);
+  font-size: 0.95rem;
+}
+
+.cta-panel,
+.bottom-cta {
+  padding: clamp(3rem, 5vw, 4.5rem) 0;
+}
+
+.cta-panel__inner {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.75));
+  border-radius: 32px;
+  padding: clamp(2.5rem, 4vw, 3.2rem);
+  border: 1px solid rgba(125, 113, 214, 0.2);
+  box-shadow: 0 20px 40px rgba(84, 66, 198, 0.12);
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.bottom-cta__inner {
+  background: linear-gradient(120deg, rgba(99, 82, 233, 0.18), rgba(255, 121, 220, 0.12));
+  border-radius: 32px;
+  padding: clamp(2.6rem, 5vw, 3.4rem);
+  border: 1px solid rgba(125, 113, 214, 0.25);
+  text-align: center;
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--facodi-shadow-soft);
+}
+
+.bottom-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+/* Utility support for existing content templates */
+.section {
+  padding: clamp(2.5rem, 5vw, 4rem) 0;
+}
+
+.section-sm {
+  padding: clamp(2rem, 4vw, 3rem) 0;
+}
+
+.section-md {
+  padding: clamp(2.5rem, 5vw, 4rem) 0;
+}
+
+.section-lg {
+  padding: clamp(3rem, 6vw, 5rem) 0;
+}
+
+.container,
+.container-fluid {
+  width: 100%;
+  max-width: var(--facodi-shell-max);
+  margin: 0 auto;
+}
+
+.container-fluid {
+  max-width: var(--facodi-shell-fluid);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 1.5rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
+
+.row.g-4 {
+  row-gap: 1.8rem;
+}
+
+.row.g-5 {
+  row-gap: 2rem;
+}
+
+.row > [class*="col-"],
+.row > .col {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  width: 100%;
+}
+
+.col-12 {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+@media (min-width: 768px) {
+  .row > .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}
+
+@media (min-width: 992px) {
+  .row > .col-lg-10 {
+    flex: 0 0 83.333%;
+    max-width: 83.333%;
+  }
+
+  .row > .col-lg-8 {
+    flex: 0 0 66.666%;
+    max-width: 66.666%;
+  }
+
+  .row > .col-lg-7 {
+    flex: 0 0 58.333%;
+    max-width: 58.333%;
+  }
+
+  .row > .col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .row > .col-lg-5 {
+    flex: 0 0 41.666%;
+    max-width: 41.666%;
+  }
+
+  .row > .col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+
+  .flex-lg-row {
+    flex-direction: row;
+  }
+
+  .align-items-lg-center {
+    align-items: center;
+  }
+
+  .justify-content-lg-between {
+    justify-content: space-between;
+  }
+
+  .justify-content-lg-end {
+    justify-content: flex-end;
+  }
+
+  .text-lg-end {
+    text-align: right;
+  }
+
+  .order-lg-0 {
+    order: 0;
+  }
+
+  .order-lg-1 {
+    order: 1;
+  }
+
+  .order-lg-2 {
+    order: 2;
+  }
+}
+
+@media (min-width: 1200px) {
+  .row > .col-xl-5 {
+    flex: 0 0 41.666%;
+    max-width: 41.666%;
+  }
+}
+
+.justify-content-center {
+  justify-content: center;
+}
+
+.justify-content-between {
+  justify-content: space-between;
+}
+
+.align-items-center {
+  align-items: center;
+}
+
+.align-items-start {
+  align-items: flex-start;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-muted {
+  color: var(--facodi-color-soft) !important;
+}
+
+.text-primary {
+  color: var(--facodi-primary-dark) !important;
+}
+
+.text-secondary {
+  color: rgba(66, 56, 143, 0.85) !important;
+}
+
+.text-info {
+  color: #3861ff !important;
+}
+
+.text-warning {
+  color: #b97b00 !important;
+}
+
+.d-flex {
+  display: flex;
+}
+
+.d-inline-flex {
+  display: inline-flex;
+}
+
+.flex-column {
+  flex-direction: column;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.gap-2 {
+  gap: 0.75rem;
+}
+
+.gap-3 {
+  gap: 1rem;
+}
+
+.gap-4 {
+  gap: 1.5rem;
+}
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-1 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-2 {
+  margin-bottom: 1rem;
+}
+
+.mb-3 {
+  margin-bottom: 1.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 2rem;
+}
+
+.mb-5 {
+  margin-bottom: 2.8rem;
+}
+
+.mt-2 {
+  margin-top: 1rem;
+}
+
+.mt-3 {
+  margin-top: 1.5rem;
+}
+
+.mt-5 {
+  margin-top: 3rem;
+}
+
+.mt-auto {
+  margin-top: auto;
+}
+
+.mt-lg-0 {
+  margin-top: 0;
+}
+
+.ms-2 {
+  margin-left: 0.5rem;
+}
+
+.me-1 {
+  margin-right: 0.25rem;
+}
+
+.me-2 {
+  margin-right: 0.5rem;
+}
+
+.py-5 {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
+}
+
+.pt-0 {
+  padding-top: 0;
+}
+
+.pb-4 {
+  padding-bottom: 2rem;
+}
+
+.px-4 {
+  padding-left: 1.6rem;
+  padding-right: 1.6rem;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  background: rgba(121, 109, 255, 0.14);
+  color: var(--facodi-primary-dark);
+}
+
+.badge.bg-primary-subtle {
+  background: rgba(112, 101, 225, 0.16);
+  color: var(--facodi-primary-dark);
+}
+
+.badge.bg-secondary-subtle {
+  background: rgba(91, 82, 210, 0.14);
+  color: rgba(54, 42, 135, 0.95);
+}
+
+.badge.bg-info-subtle {
+  background: rgba(80, 145, 255, 0.16);
+  color: #3861ff;
+}
+
+.badge.bg-warning-subtle {
+  background: rgba(255, 211, 106, 0.2);
+  color: #b97b00;
+}
+
+.badge.bg-light {
+  background: rgba(244, 243, 255, 0.85);
+  color: var(--facodi-color-soft);
+}
+
+.badge.bg-danger {
+  background: rgba(255, 95, 124, 0.15);
+  color: #d62839;
+}
+
+.badge.rounded-pill,
+.rounded-pill {
+  border-radius: 999px;
+}
+
+.fw-semibold {
+  font-weight: 600;
+}
+
+.fw-bold {
+  font-weight: 700;
+}
+
+.lead {
+  font-size: 1.05rem;
+  color: var(--facodi-color-soft);
+}
+
+.display-5 {
+  font-size: clamp(2.2rem, 4vw, 2.9rem);
+}
+
+.display-6 {
+  font-size: clamp(1.9rem, 3.5vw, 2.4rem);
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 26px;
+  border: 1px solid rgba(113, 101, 224, 0.18);
+  box-shadow: var(--facodi-shadow-soft);
+}
+
+.card.shadow-sm {
+  box-shadow: 0 16px 40px rgba(84, 66, 198, 0.12);
+}
+
+.card.border-0 {
+  border: none;
+}
+
+.card-body {
+  padding: 1.8rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card-footer {
+  padding: 1rem 1.8rem 1.6rem;
+  border-top: 1px solid rgba(113, 101, 224, 0.14);
+  background: transparent;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--facodi-primary-dark);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border 160ms ease;
+  text-decoration: none;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: rgba(111, 94, 255, 0.12);
+}
+
+.btn-outline-primary {
+  border-color: rgba(112, 101, 225, 0.45);
+  background: transparent;
+  color: var(--facodi-primary-dark);
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus-visible {
+  background: rgba(112, 101, 225, 0.14);
+}
+
+.alert {
+  padding: 1rem 1.4rem;
+  border-radius: 24px;
+  border: 1px solid rgba(113, 101, 224, 0.2);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--facodi-color-ink);
+  box-shadow: var(--facodi-shadow-soft);
+}
+
+.alert-warning {
+  background: rgba(255, 245, 225, 0.9);
+  border-color: rgba(255, 196, 106, 0.55);
+  color: #8a6200;
+}
+
+.alert-info {
+  background: rgba(243, 241, 255, 0.92);
+  border-color: rgba(113, 101, 224, 0.3);
+  color: var(--facodi-color-ink);
+}
+
+.list-group {
+  border-radius: 26px;
+  border: 1px solid rgba(113, 101, 224, 0.16);
+  overflow: hidden;
+}
+
+.list-group-flush {
+  border-radius: 20px;
+  border: none;
+}
+
+.list-group-item {
+  display: block;
+  padding: 1rem 1.4rem;
+  border-bottom: 1px solid rgba(113, 101, 224, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--facodi-color-ink);
+  transition: background 160ms ease;
+}
+
+.list-group-item:last-child {
+  border-bottom: none;
+}
+
+.list-group-item-action {
+  cursor: pointer;
+}
+
+.list-group-item-action:hover,
+.list-group-item-action:focus-visible {
+  background: rgba(113, 101, 224, 0.08);
+}
+
+.list-unstyled {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.content {
+  display: grid;
+  gap: 1rem;
+  color: var(--facodi-color-soft);
+}
+
+.content h2,
+.content h3,
+.content h4 {
+  color: var(--facodi-color-ink);
+}
+
+.content ul,
+.content ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.list-group .badge {
+  justify-self: flex-start;
+}
+
+.ps-3 {
+  padding-left: 1.2rem;
+}
+
+.small,
+small {
+  font-size: 0.85rem;
+}
+
+.h4 {
+  font-size: 1.35rem;
+}
+
+.h5 {
+  font-size: 1.1rem;
+}
+
+.h6 {
+  font-size: 1rem;
+}
+
+.list-group-item .small {
+  color: var(--facodi-color-soft);
+}
+
+.bg-transparent {
+  background: transparent;
+}
+
+.border-0 {
+  border: none !important;
+}
+
+.site-footer {
+  padding: 2.5rem 0 3rem;
+  background: #0f0629;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.site-footer__inner {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.site-footer a {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+// Responsive adjustments
+@media (max-width: 1024px) {
+  .site-header__inner {
+    padding: 0.85rem 0;
+  }
+
+  .landing__grid,
+  .journey__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing__aside {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 900px) {
+  .site-header__group {
+    gap: 1rem;
+  }
+
+  .site-nav {
+    position: absolute;
+    inset: 100% 0 auto;
+    background: rgba(255, 255, 255, 0.97);
+    border-bottom: 1px solid rgba(113, 101, 224, 0.14);
+    display: grid;
+    gap: 0.75rem;
+    padding: 1.2rem 1.5rem;
+    transform-origin: top;
+    transform: scaleY(0);
+    transition: transform 180ms ease;
+  }
+
+  .site-nav.is-open {
+    transform: scaleY(1);
+  }
+
+  .site-header__menu {
+    display: inline-flex;
+  }
+
+  .site-header__inner {
+    position: relative;
+  }
+}
+
+@media (max-width: 768px) {
+  .landing {
+    padding: 3.8rem 0 3.2rem;
+  }
+
+  .landing__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .landing__stat {
+    padding: 1rem 1.2rem;
+  }
+
+  .course-card__inner {
+    padding: 1.8rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .site-header {
+    border-radius: 0 0 24px 24px;
+  }
+
+  .hero-card {
+    max-width: 100%;
+  }
+
+  .journey__item {
+    grid-template-columns: 1fr;
+  }
+
+  .journey__step {
+    justify-self: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/scss/common/_variables-custom.scss
+++ b/assets/scss/common/_variables-custom.scss
@@ -1,1 +1,42 @@
-// Put your custom SCSS variables here
+// Custom design tokens for the refreshed FACODI visual identity
+:root {
+  --facodi-font-sans: "Plus Jakarta Sans", "Inter", "Segoe UI", system-ui, -apple-system,
+    BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --facodi-color-ink: #211944;
+  --facodi-color-muted: #5f5a7c;
+  --facodi-color-soft: #8b84b4;
+  --facodi-color-outline: rgba(125, 113, 214, 0.22);
+  --facodi-color-outline-strong: rgba(108, 83, 226, 0.45);
+  --facodi-surface-1: #ffffff;
+  --facodi-surface-2: rgba(255, 255, 255, 0.78);
+  --facodi-surface-3: rgba(244, 241, 255, 0.72);
+  --facodi-surface-ink: rgba(20, 12, 64, 0.9);
+  --facodi-primary: #6558ff;
+  --facodi-primary-dark: #4430ff;
+  --facodi-primary-soft: rgba(114, 104, 255, 0.14);
+  --facodi-accent: #ff72e1;
+  --facodi-accent-strong: #f53dbe;
+  --facodi-sky: #4cb2ff;
+  --facodi-border: rgba(112, 101, 225, 0.2);
+  --facodi-border-strong: rgba(112, 101, 225, 0.45);
+  --facodi-shadow-strong: 0 28px 65px rgba(84, 66, 198, 0.18);
+  --facodi-shadow-soft: 0 12px 40px rgba(86, 58, 198, 0.12);
+  --facodi-shadow-header: 0 12px 32px rgba(34, 22, 76, 0.12);
+  --facodi-shell-max: 1120px;
+  --facodi-shell-fluid: 1240px;
+  --facodi-hero-gradient:
+    radial-gradient(110% 120% at 20% 20%, rgba(146, 107, 255, 0.28) 0%, rgba(146, 107, 255, 0) 60%),
+    radial-gradient(130% 140% at 80% 10%, rgba(255, 129, 226, 0.32) 0%, rgba(255, 129, 226, 0) 65%),
+    linear-gradient(135deg, #f4f1ff 0%, #f4f1ff 45%, #f7e9ff 100%);
+  --facodi-page-gradient: linear-gradient(180deg, #f4f1ff 0%, #fbf9ff 35%, #ffffff 100%);
+  --facodi-card-gradient: linear-gradient(135deg, rgba(114, 104, 255, 0.18), rgba(255, 129, 226, 0.18));
+  --facodi-cta-gradient: linear-gradient(120deg, #5b4eff 0%, #7a5bff 45%, #ff72e1 100%);
+  --facodi-cta-gradient-hover: linear-gradient(120deg, #5143ff 0%, #6650ff 42%, #ff5fd8 100%);
+  --facodi-link: #4f3dff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: light;
+  }
+}

--- a/assets/scss/facodi.scss
+++ b/assets/scss/facodi.scss
@@ -1,0 +1,2 @@
+@import "common/variables-custom";
+@import "common/custom";

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,75 @@
+{{- $brand := "FACODI — Faculdade Comunitária Digital" -}}
+{{- $description := .Params.description | default site.Params.description -}}
+{{- $sass := resources.Get "scss/facodi.scss" | toCSS (dict "targetPath" "css/facodi.css" "outputStyle" "compressed") | fingerprint -}}
+<!DOCTYPE html>
+<html lang="{{ .Lang | default "pt" }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ if .IsHome }}{{ $brand }}{{ else }}{{ .Title }} · {{ $brand }}{{ end }}</title>
+    {{ with $description }}<meta name="description" content="{{ . }}" />{{ end }}
+    {{ hugo.Generator }}
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon.png" | relURL }}" />
+    <link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}" />
+    <link rel="stylesheet" href="{{ $sass.RelPermalink }}" integrity="{{ $sass.Data.Integrity }}" />
+    {{ partial "head/custom-head.html" . }}
+    {{ partial "head/script-header.html" . }}
+  </head>
+  <body class="site-body">
+    <div class="site-wrapper">
+      <header class="site-header" id="site-header">
+        <div class="shell site-header__inner">
+          <a class="site-logo" href="/" aria-label="FACODI – Início">
+            <span>FACODI</span>
+            <span class="sr-only">Faculdade Comunitária Digital</span>
+          </a>
+          <div class="site-header__group">
+            <button
+              class="site-header__menu"
+              type="button"
+              aria-expanded="false"
+              aria-controls="main-navigation"
+              data-nav-toggle
+            >
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="sr-only">Abrir menu</span>
+            </button>
+            <nav class="site-nav" id="main-navigation" data-nav>
+              <a class="site-nav__link" href="/" aria-current="{{ if .IsHome }}page{{ else }}false{{ end }}">Início</a>
+              {{ range .Site.Menus.main }}
+                <a class="site-nav__link" href="{{ .URL }}">{{ .Name }}</a>
+              {{ end }}
+            </nav>
+          </div>
+          <div class="site-header__group">
+            <button class="language-toggle" type="button" aria-label="Selecionar idioma">Português</button>
+            <a class="cta cta--primary cta--small" href="/courses/">Explorar trilhas</a>
+          </div>
+        </div>
+      </header>
+      <main id="main-content" class="site-main">
+        {{ block "main" . }}{{ end }}
+      </main>
+      {{ block "sidebar-prefooter" . }}{{ end }}
+      {{ block "sidebar-footer" . }}{{ end }}
+      <footer class="site-footer">
+        <div class="shell site-footer__inner">
+          <p>© {{ now.Format "2006" }} FACODI — Faculdade Comunitária Digital. Comunidade aberta e colaborativa.</p>
+          <p>
+            Produzido com carinho pela <a href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a>.
+          </p>
+        </div>
+      </footer>
+    </div>
+    {{ partial "footer/script-footer-custom.html" . }}
+    {{ block "scripts" . }}{{ end }}
+  </body>
+</html>

--- a/layouts/_partials/head/custom-head.html
+++ b/layouts/_partials/head/custom-head.html
@@ -1,1 +1,7 @@
 <!-- Custom head -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap"
+  rel="stylesheet"
+/>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -12,51 +12,57 @@
       {{ end }}
     {{ end }}
   {{ end }}
-  <section class="section container-fluid mt-n3 py-5 py-lg-5">
-    <div class="row align-items-center justify-content-center g-5">
-      <div class="col-lg-6 col-xl-5 text-center text-lg-start">
-        <span class="badge rounded-pill bg-primary text-uppercase mb-3">FACODI — Faculdade Comunitária Digital</span>
-        <h1 class="display-5 fw-bold mb-4">Educação aberta, orgulhosamente comunitária e gratuita</h1>
-        <p class="lead text-muted mb-4">{{ .Params.lead | safeHTML }}</p>
-        <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center justify-content-lg-start mb-4">
-          <a class="btn btn-primary btn-lg rounded-pill px-4" href="/courses/" role="button">Explorar currículos</a>
-          <a class="btn btn-outline-primary btn-lg rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha Softwares</a>
+  <section class="landing">
+    <div class="shell landing__grid">
+      <div class="landing__content">
+        <span class="landing__eyebrow">Ensino superior acessível, aberto e comunitário.</span>
+        <h1 class="landing__title">FACODI — Faculdade Comunitária Digital</h1>
+        <p class="landing__lead">{{ .Params.lead | safeHTML }}</p>
+        <div class="landing__actions">
+          <a class="cta cta--primary" href="/courses/">Explorar trilhas</a>
+          <a class="cta cta--secondary" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha</a>
         </div>
-        <div class="d-flex flex-column flex-lg-row gap-3 align-items-center align-items-lg-start text-muted small">
-          <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-success text-white rounded-pill">Aberta e gratuita</span>
-            <span>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</span>
+        <dl class="landing__stats">
+          <div class="landing__stat">
+            <dt>Currículos comunitários</dt>
+            <dd class="landing__stat-value" data-animate-count data-target="{{ $scratch.Get "coursesCount" }}">{{ $scratch.Get "coursesCount" }}</dd>
+            <span class="landing__stat-caption">Cursos oficiais já organizados e disponíveis</span>
           </div>
-          <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-light text-dark border rounded-pill">Comunidade Monynha</span>
-            <span>Curadoria colaborativa com orgulho, diversidade e transparência.</span>
+          <div class="landing__stat">
+            <dt>Unidades curriculares</dt>
+            <dd class="landing__stat-value" data-animate-count data-target="{{ $scratch.Get "ucCount" }}">{{ $scratch.Get "ucCount" }}</dd>
+            <span class="landing__stat-caption">Playlists abertas, conteúdos públicos e resultados</span>
           </div>
-        </div>
+          <div class="landing__stat">
+            <dt>Comunidade ativa</dt>
+            <dd class="landing__stat-value" data-animate-count data-target="365">365</dd>
+            <span class="landing__stat-caption">Dias por ano de curadoria colaborativa e transparente</span>
+          </div>
+        </dl>
       </div>
-      <div class="col-lg-5 col-xl-5">
-        <div class="card shadow-sm border-0 h-100">
-          <div class="card-body p-4 p-lg-5">
-            <p class="text-uppercase text-muted fw-semibold mb-3">Em números comunitários</p>
-            <ul class="list-unstyled fs-5 mb-4">
-              <li class="mb-2"><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos oficiais organizados</li>
-              <li class="mb-2"><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares com playlists e materiais livres</li>
-              <li>Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</li>
+      <div class="landing__aside">
+        <article class="hero-card">
+          <div class="hero-card__inner">
+            <span class="hero-card__chip">Trilhas abertas pela comunidade</span>
+            <h2 class="hero-card__title">Educação superior gratuita, com carinho e tecnologia acessível</h2>
+            <p class="hero-card__lead">Currículos oficiais ganham nova vida com playlists, materiais e orientações construídas a muitas mãos.</p>
+            <ul class="hero-card__list">
+              <li><strong>Playlists públicas:</strong> vídeos, podcasts e referências abertas organizadas por quem estuda.</li>
+              <li><strong>Resultados de aprendizagem:</strong> objetivos claros para acompanhar o que foi conquistado em cada trilha.</li>
+              <li><strong>Transparência total:</strong> histórico de versões e sugestões visíveis para toda a comunidade.</li>
             </ul>
-            <p class="mb-0 text-muted">Criado pela <a class="text-decoration-none" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
+            <div class="hero-card__footer">
+              <span class="hero-card__avatar">∞</span>
+              <span>Progresso que abraça diferentes ritmos, histórias e contextos culturais.</span>
+            </div>
           </div>
-        </div>
+        </article>
       </div>
     </div>
   </section>
   {{ with .Content }}
-  <section class="section section-sm pt-0">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-10 col-xl-8 lead text-muted">
-          {{ . | safeHTML }}
-        </div>
-      </div>
-    </div>
+  <section class="home-richtext">
+    <div class="shell home-richtext__inner">{{ . | safeHTML }}</div>
   </section>
   {{ end }}
   {{ $features := slice
@@ -65,116 +71,122 @@
     (dict "icon" "✅" "title" "Marcação de progresso" "description" "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo.")
     (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
   }}
-  <section class="section section-md bg-light">
-    <div class="container">
-      <div class="row justify-content-center text-center mb-5">
-        <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Experiência FACODI na palma da mão</h2>
-          <p class="text-muted">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
-        </div>
-      </div>
-      <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
+  <section class="experience">
+    <div class="shell">
+      <header class="section-header">
+        <span class="section-header__eyebrow">Experiência FACODI</span>
+        <h2 class="section-header__title">Tecnologia aberta para acolher, conectar e transformar</h2>
+        <p class="section-header__description">Explorar uma trilha FACODI é descobrir conteúdos acessíveis, caminhos flexíveis e acompanhamento transparente — tudo construído com carinho pela comunidade Monynha.</p>
+      </header>
+      <div class="experience__grid">
         {{ range $features }}
-        <div class="col">
-          <div class="card h-100 border-0 shadow-sm">
-            <div class="card-body p-4">
-              <span class="d-inline-flex justify-content-center align-items-center rounded-circle bg-primary bg-opacity-10 text-primary fs-3 mb-3" style="width:3rem;height:3rem;">{{ .icon }}</span>
-              <h3 class="h5 fw-semibold">{{ .title }}</h3>
-              <p class="text-muted mb-0">{{ .description }}</p>
-            </div>
-          </div>
-        </div>
+        <article class="experience__item">
+          <span class="experience__icon">{{ .icon }}</span>
+          <h3>{{ .title }}</h3>
+          <p>{{ .description }}</p>
+        </article>
         {{ end }}
       </div>
     </div>
   </section>
   {{ with site.GetPage "section" "courses" }}
-  <section class="section section-md">
-    <div class="container">
-      <div class="row justify-content-between align-items-end mb-4">
-        <div class="col-lg-8">
-          <h2 class="h3 fw-bold">Cursos em destaque na comunidade FACODI</h2>
-          <p class="text-muted mb-0">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
+  <section class="course-showcase" id="cursos">
+    <div class="shell">
+      <header class="section-header section-header--split">
+        <div>
+          <span class="section-header__eyebrow">Cursos em destaque</span>
+          <h2 class="section-header__title">Currículos que a comunidade FACODI já abraçou</h2>
+          <p class="section-header__description">Licenciaturas e trilhas tecnológicas com conteúdos abertos, orientações detalhadas e espaços para você contribuir.</p>
         </div>
-        <div class="col-lg-4 text-lg-end mt-3 mt-lg-0">
-          <a class="btn btn-outline-primary rounded-pill" href="/courses/">Ver todos os cursos</a>
-        </div>
-      </div>
-      <div class="row row-cols-1 row-cols-lg-2 g-4">
+        <a class="cta cta--ghost" href="/courses/">Ver todas as trilhas</a>
+      </header>
+      <div class="course-showcase__grid">
         {{ range .Sections }}
           {{ if .Params.code }}
-          <div class="col">
-            <div class="card h-100 shadow-sm border-0">
-              <div class="card-body p-4">
-                {{ with .Params.plan_version }}
-                <span class="badge bg-secondary text-uppercase mb-3">Plano {{ . }}</span>
-                {{ end }}
-                <h3 class="h4"><a class="stretched-link text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-                {{ with .Params.summary }}
-                <p class="text-muted">{{ . }}</p>
-                {{ end }}
-                <div class="d-flex flex-wrap gap-3 text-muted small">
-                  {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> ECTS</span>{{ end }}
-                  {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> semestres</span>{{ end }}
-                  {{ with .Params.code }}<span>Código {{ . }}</span>{{ end }}
-                </div>
+          <article class="course-card">
+            <div class="course-card__inner">
+              <div class="course-card__badges">
+                <span class="course-card__badge">{{ .Params.code }}</span>
+                {{ with .Params.plan_version }}<span class="course-card__badge">Plano {{ . }}</span>{{ end }}
+              </div>
+              <h3 class="course-card__title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+              {{ with .Params.summary }}<p class="course-card__description">{{ . }}</p>{{ end }}
+              <div class="course-card__meta">
+                {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> ECTS</span>{{ end }}
+                {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> semestres</span>{{ end }}
+                {{ with .Params.language }}<span>{{ . | title }}</span>{{ end }}
               </div>
               {{ with .Params.ucs }}
-              <div class="card-footer bg-transparent border-0 pt-0 pb-4 px-4">
-                <span class="small text-muted">{{ len . }} unidades curriculares já mapeadas pela comunidade</span>
-              </div>
+              <div class="course-card__footer">{{ len . }} unidades curriculares com playlists em evolução</div>
               {{ end }}
             </div>
-          </div>
+          </article>
           {{ end }}
         {{ end }}
       </div>
     </div>
   </section>
   {{ end }}
-  <section class="section section-md bg-dark text-white">
-    <div class="container">
-      <div class="row g-5 align-items-center">
-        <div class="col-lg-5">
-          <h2 class="h3 fw-bold">Como rola a jornada FACODI</h2>
-          <p class="text-white-50">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
-        </div>
-        <div class="col-lg-7">
-          <ol class="list-group list-group-numbered list-group-flush bg-dark">
-            <li class="list-group-item bg-dark text-white-50 px-0">Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
-            <li class="list-group-item bg-dark text-white-50 px-0">Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
-          </ol>
-        </div>
+  <section class="journey">
+    <div class="shell journey__grid">
+      <div class="journey__intro">
+        <header class="section-header">
+          <span class="section-header__eyebrow">Jornada comunitária</span>
+          <h2 class="section-header__title">Como a FACODI acompanha cada pessoa que aprende</h2>
+          <p class="section-header__description">Da pesquisa do currículo à conquista das competências, cada etapa é documentada com transparência para que todo mundo possa colaborar, propor melhorias e celebrar avanços.</p>
+        </header>
       </div>
+      <ol class="journey__list">
+        <li class="journey__item">
+          <span class="journey__step">1</span>
+          <div>
+            <h3>Escolha um currículo oficial</h3>
+            <p>Visualize semestres, cargas horárias, versões e contexto institucional das trilhas abertas pela comunidade FACODI.</p>
+          </div>
+        </li>
+        <li class="journey__item">
+          <span class="journey__step">2</span>
+          <div>
+            <h3>Explore unidades curriculares</h3>
+            <p>Resultados de aprendizagem, playlists abertas e tópicos relacionados para estudar no seu ritmo e com repertórios diversos.</p>
+          </div>
+        </li>
+        <li class="journey__item">
+          <span class="journey__step">3</span>
+          <div>
+            <h3>Construa junto com a comunidade</h3>
+            <p>Marque progresso, compartilhe materiais e acompanhe o histórico de revisões para manter tudo vivo e confiável.</p>
+          </div>
+        </li>
+      </ol>
     </div>
   </section>
 {{ end }}
 
 {{ define "sidebar-prefooter" }}
-<section class="section container-fluid py-5">
-  <div class="row justify-content-center text-center">
-    <div class="col-lg-8">
-      <p class="text-uppercase text-muted small mb-2">Manifesto Monynha Softwares</p>
-      <h2 class="h4 fw-bold">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
-      <p class="text-muted">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
-      <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
-    </div>
+<section class="cta-panel">
+  <div class="shell cta-panel__inner">
+    <span class="section-header__eyebrow">Manifesto Monynha Softwares</span>
+    <h2>Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
+    <p>A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
+    <a class="cta cta--secondary" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
   </div>
 </section>
 {{ end }}
 
 {{ define "sidebar-footer" }}
-<section class="section section-md container-fluid bg-light">
-  <div class="row justify-content-center text-center">
-    <div class="col-lg-7">
-      <h2 class="fw-bold">Bora colar com a FACODI?</h2>
-      <p class="text-muted">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
-      <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
-        <a class="btn btn-primary rounded-pill px-4" href="/courses/">Ver cursos e unidades curriculares</a>
-        <a class="btn btn-outline-primary rounded-pill px-4" href="https://monynha.com" target="_blank" rel="noopener">Falar com a Monynha e sugerir materiais</a>
-      </div>
+<section class="bottom-cta">
+  <div class="shell bottom-cta__inner">
+    <h2>Bora colar com a FACODI?</h2>
+    <p>Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
+    <div class="bottom-cta__actions">
+      <a class="cta cta--primary" href="/courses/">Ver cursos e unidades curriculares</a>
+      <a class="cta cta--ghost" href="https://monynha.com" target="_blank" rel="noopener">Falar com a Monynha e contribuir</a>
     </div>
   </div>
 </section>
+{{ end }}
+
+{{ define "scripts" }}
+<script src="{{ "js/home-hero.js" | relURL }}" defer></script>
 {{ end }}

--- a/static/js/home-hero.js
+++ b/static/js/home-hero.js
@@ -1,0 +1,85 @@
+(function () {
+  const header = document.getElementById('site-header');
+  const navToggle = document.querySelector('[data-nav-toggle]');
+  const nav = document.querySelector('[data-nav]');
+
+  const toggleHeaderShadow = () => {
+    if (!header) return;
+    const threshold = 12;
+    if (window.scrollY > threshold) {
+      header.classList.add('is-scrolled');
+    } else {
+      header.classList.remove('is-scrolled');
+    }
+  };
+
+  toggleHeaderShadow();
+  window.addEventListener('scroll', toggleHeaderShadow, { passive: true });
+
+  if (navToggle && nav) {
+    navToggle.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('is-open');
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    nav.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth <= 900) {
+          nav.classList.remove('is-open');
+          navToggle.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  }
+
+  const animateCount = (element) => {
+    const target = Number(element.dataset.target || element.textContent || 0);
+    if (!Number.isFinite(target)) {
+      return;
+    }
+    const duration = 1200;
+    const startTime = performance.now();
+
+    const update = (now) => {
+      const progress = Math.min((now - startTime) / duration, 1);
+      const eased = progress < 0.5
+        ? 2 * progress * progress
+        : -1 + (4 - 2 * progress) * progress;
+      element.textContent = Math.round(target * eased).toString();
+      if (progress < 1) {
+        requestAnimationFrame(update);
+      } else {
+        element.textContent = target.toString();
+      }
+    };
+
+    requestAnimationFrame(update);
+  };
+
+  const counters = document.querySelectorAll('[data-animate-count]');
+  if (!counters.length) {
+    return;
+  }
+
+  const startAnimation = (element) => {
+    if (element.dataset.animated === 'true') return;
+    element.dataset.animated = 'true';
+    element.textContent = '0';
+    animateCount(element);
+  };
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          startAnimation(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.6 });
+
+    counters.forEach((counter) => observer.observe(counter));
+  } else {
+    counters.forEach(startAnimation);
+  }
+})();


### PR DESCRIPTION
## Summary
- build a standalone base layout with a gradient navigation shell and footer to replace the theme markup
- redesign the home template with the new hero, feature, course showcase and journey sections plus refreshed CTAs
- add custom SCSS tokens/utilities and a small JS helper for header behaviour and animated statistics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfba7e73308322b1e13bdfa96f7c84