### PR TITLE
Adjust hero spacing and restructure course units grid

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -213,7 +213,20 @@ a {
 }
 
 .facodi-hero__content {
-  max-width: 36rem;
+  max-width: min(100%, 48rem);
+}
+
+.facodi-hero__intro {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  margin-bottom: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.facodi-hero__badge {
+  align-self: flex-start;
+  box-shadow: 0 18px 38px rgba(106, 75, 255, 0.35);
 }
 
 .facodi-hero__title {
@@ -221,13 +234,14 @@ a {
   font-weight: 700;
   line-height: 1.1;
   color: $headings-color;
-  margin-top: 1rem;
+  margin: 0;
 }
 
 .facodi-hero__description {
-  margin-top: 1.25rem;
-  font-size: 1.1rem;
+  font-size: clamp(1rem, 1.2vw + 1rem, 1.25rem);
+  line-height: 1.6;
   color: rgba($body-color, 0.7);
+  margin: 0;
 }
 
 .facodi-hero__actions {
@@ -340,12 +354,36 @@ a {
   color: rgba($body-color, 0.6);
 }
 
+.section-wrap {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(100%, 72rem);
+  padding-left: clamp(1.25rem, 4vw, 3rem);
+  padding-right: clamp(1.25rem, 4vw, 3rem);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  margin-bottom: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.section-title {
+  font-size: clamp(2rem, 3.6vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  color: $headings-color;
+  margin: 0;
+}
+
 .facodi-section {
   padding: 4.5rem 0;
 }
 
 .facodi-section__header {
-  margin-bottom: 3rem;
+  margin-bottom: 0;
 }
 
 .facodi-section__eyebrow {
@@ -368,14 +406,11 @@ a {
 }
 
 .facodi-section__title {
-  margin-top: 1rem;
-  font-size: clamp(2rem, 3.5vw, 2.8rem);
-  font-weight: 700;
-  color: $headings-color;
+  margin: 0;
 }
 
 .facodi-section__subtitle {
-  margin-top: 1rem;
+  margin: 0;
   color: rgba($body-color, 0.65);
   max-width: 46rem;
   margin-left: auto;
@@ -497,6 +532,149 @@ a {
   color: rgba($body-color, 0.6);
 }
 
+.facodi-uc-groups {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.facodi-uc-year {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.facodi-uc-year__header {
+  margin-bottom: 0;
+}
+
+.facodi-uc-semester {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.facodi-uc-semester__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba($body-color, 0.7);
+  margin: 0;
+}
+
+.facodi-uc-grid {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.facodi-uc-card {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 20px 45px rgba(106, 75, 255, 0.12);
+  padding: 1.75rem;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.facodi-uc-card:hover,
+.facodi-uc-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 54px rgba(106, 75, 255, 0.18);
+}
+
+.facodi-uc-card:focus-within {
+  outline: 2px solid rgba($primary, 0.35);
+  outline-offset: 3px;
+}
+
+.facodi-uc-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.facodi-uc-card__code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba($primary, 0.12);
+  color: $primary;
+}
+
+.facodi-uc-card__semester {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba($body-color, 0.55);
+}
+
+.facodi-uc-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.facodi-uc-card__link {
+  color: $headings-color;
+  text-decoration: none;
+  border-radius: 0.75rem;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.facodi-uc-card__link:hover,
+.facodi-uc-card__link:focus {
+  color: darken($primary, 12%);
+  text-decoration-color: rgba($primary, 0.55);
+}
+
+.facodi-uc-card__link:focus-visible {
+  outline: 2px solid rgba($primary, 0.45);
+  outline-offset: 3px;
+}
+
+.facodi-uc-card__summary {
+  color: rgba($body-color, 0.65);
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.facodi-uc-card__meta {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  font-size: 0.85rem;
+  color: rgba($body-color, 0.6);
+  margin: 0;
+  margin-top: auto;
+}
+
+.facodi-uc-card__meta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.facodi-uc-card__meta dt {
+  font-weight: 600;
+  color: $headings-color;
+  margin: 0;
+}
+
+.facodi-uc-card__meta dd {
+  margin: 0;
+}
+
 .facodi-section--journey {
   padding-top: 0;
   padding-bottom: 0;
@@ -565,9 +743,8 @@ a {
 }
 
 .facodi-manifesto__title {
-  font-size: clamp(1.9rem, 3vw, 2.4rem);
   color: $headings-color;
-  margin: 1.25rem 0;
+  margin: clamp(1rem, 2vw, 1.5rem) 0;
 }
 
 .facodi-manifesto__description {
@@ -613,9 +790,8 @@ a {
 }
 
 .facodi-cta__title {
-  font-size: clamp(2rem, 3vw, 2.6rem);
-  font-weight: 700;
   color: $headings-color;
+  margin: 0;
 }
 
 .facodi-cta__description {

--- a/layouts/courses/course.html
+++ b/layouts/courses/course.html
@@ -60,27 +60,71 @@
         Ainda não adicionamos unidades curriculares por aqui. Bora sugerir playlists e conteúdos para abrir essa trilha?
       </div>
       {{ else }}
-      <div class="row g-4" id="course-ucs" data-facodi-slot="course-ucs">
-        {{ range sort $ucPages "Params.semester" "asc" }}
-        {{ $ucParams := .Params }}
-        <div class="col-md-6">
-          <article class="card h-100 shadow-sm border-0">
-            <div class="card-body d-flex flex-column">
-              <div class="d-flex justify-content-between mb-2">
-                <span class="badge bg-secondary-subtle text-secondary">{{ $ucParams.code }}</span>
-                {{ with $ucParams.semester }}<span class="text-muted small">Semestre {{ . }}</span>{{ end }}
-              </div>
-              <h3 class="h5"><a class="text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-              {{ with $ucParams.description }}<p class="text-muted">{{ . }}</p>{{ end }}
-              <dl class="row small text-muted mt-auto">
-                <dt class="col-5">ECTS</dt>
-                <dd class="col-7">{{ $ucParams.ects | default "--" }}</dd>
-                <dt class="col-5">Idioma</dt>
-                <dd class="col-7">{{ $ucParams.language | default "--" }}</dd>
-              </dl>
-            </div>
-          </article>
-        </div>
+      {{ $groups := newScratch }}
+      {{ $groups.Set "years" (slice) }}
+      {{ range $ucPages }}
+        {{ $ucPage := . }}
+        {{ $ucParams := $ucPage.Params }}
+        {{ $rawSemester := int (default 1 $ucParams.semester) }}
+        {{ $computedYear := add (div (sub $rawSemester 1) 2) 1 }}
+        {{ $year := int (default $computedYear $ucParams.year) }}
+        {{ $relativeSemester := $rawSemester }}
+        {{ if gt $rawSemester 2 }}
+          {{ $relativeSemester = add (mod (sub $rawSemester 1) 2) 1 }}
+        {{ end }}
+        {{ $relativeSemester = int $relativeSemester }}
+        {{ $existingYears := $groups.Get "years" | default (slice) }}
+        {{ if not (in $existingYears $year) }}
+          {{ $groups.Set "years" (append $existingYears $year) }}
+        {{ end }}
+        {{ $mapKey := printf "%d-%d" $year $relativeSemester }}
+        {{ $existing := $groups.Get $mapKey | default (slice) }}
+        {{ $groups.Set $mapKey (append $existing $ucPage) }}
+      {{ end }}
+      {{ $years := sort ($groups.Get "years" | default (slice)) }}
+      <div id="course-ucs" data-facodi-slot="course-ucs" class="facodi-uc-groups">
+        {{ range $years }}
+          {{ $year := . }}
+          {{ $yearHeadingID := printf "course-year-%d" $year }}
+          <section class="facodi-uc-year" aria-labelledby="{{ $yearHeadingID }}">
+            <header class="facodi-uc-year__header section-header">
+              <h2 id="{{ $yearHeadingID }}" class="section-title">Ano {{ $year }}</h2>
+            </header>
+            {{ range $semester := slice 1 2 }}
+              {{ $semesterKey := printf "%d-%d" $year $semester }}
+              {{ $semesterPages := $groups.Get $semesterKey }}
+              {{ if $semesterPages }}
+                {{ $semesterHeadingID := printf "course-year-%d-sem-%d" $year $semester }}
+                <div class="facodi-uc-semester" aria-labelledby="{{ $semesterHeadingID }}">
+                  <h3 id="{{ $semesterHeadingID }}" class="facodi-uc-semester__title">Semestre {{ $semester }}</h3>
+                  <div class="facodi-uc-grid">
+                    {{ range sort $semesterPages "Params.code" }}
+                      {{ $ucPage := . }}
+                      {{ $ucParams := $ucPage.Params }}
+                      <article class="facodi-uc-card" data-uc-code="{{ $ucParams.code }}">
+                        <div class="facodi-uc-card__header">
+                          {{ with $ucParams.code }}<span class="facodi-uc-card__code">{{ . }}</span>{{ end }}
+                          {{ with $ucParams.semester }}<span class="facodi-uc-card__semester">Semestre {{ . }}</span>{{ end }}
+                        </div>
+                        <h3 class="facodi-uc-card__title"><a class="facodi-uc-card__link" href="{{ $ucPage.RelPermalink }}">{{ $ucPage.Title }}</a></h3>
+                        {{ with $ucParams.description }}<p class="facodi-uc-card__summary">{{ . }}</p>{{ end }}
+                        <dl class="facodi-uc-card__meta">
+                          <div>
+                            <dt>ECTS</dt>
+                            <dd>{{ $ucParams.ects | default "--" }}</dd>
+                          </div>
+                          <div>
+                            <dt>Idioma</dt>
+                            <dd>{{ $ucParams.language | default "--" }}</dd>
+                          </div>
+                        </dl>
+                      </article>
+                    {{ end }}
+                  </div>
+                </div>
+              {{ end }}
+            {{ end }}
+          </section>
         {{ end }}
       </div>
       {{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -17,9 +17,11 @@
     <div class="container-lg">
       <div class="facodi-hero__grid">
         <div class="facodi-hero__content">
-          <span class="facodi-pill facodi-pill--brand">Ensino superior acessível, aberto e comunitário.</span>
-          <h1 class="facodi-hero__title">FACODI — Faculdade Comunitária Digital</h1>
-          <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
+          <div class="facodi-hero__intro">
+            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">Ensino superior acessível, aberto e comunitário.</span>
+            <h1 class="facodi-hero__title">FACODI — Faculdade Comunitária Digital</h1>
+            <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
+          </div>
           <div class="facodi-hero__actions">
             <a class="facodi-hero__cta" href="/courses/" role="button">Explorar trilhas</a>
             <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">Conheça o ecossistema Monynha Softwares</a>
@@ -50,7 +52,7 @@
 
   {{ with .Content }}
   <section class="facodi-section facodi-section--intro">
-    <div class="container-lg">
+    <div class="container-lg section-wrap">
       <div class="facodi-section__body">
         {{ . | safeHTML }}
       </div>
@@ -65,10 +67,10 @@
     (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
   }}
   <section class="facodi-section facodi-section--features">
-    <div class="container-lg">
-      <div class="facodi-section__header text-center">
+    <div class="container-lg section-wrap">
+      <div class="facodi-section__header text-center section-header">
         <span class="facodi-section__eyebrow">Experiência FACODI</span>
-        <h2 class="facodi-section__title">Experiência FACODI na palma da mão</h2>
+        <h2 class="facodi-section__title section-title">Experiência FACODI na palma da mão</h2>
         <p class="facodi-section__subtitle">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
       </div>
       <div class="facodi-grid facodi-grid--features">
@@ -85,11 +87,11 @@
 
   {{ with site.GetPage "section" "courses" }}
   <section class="facodi-section facodi-section--courses">
-    <div class="container-lg">
-      <div class="facodi-section__header facodi-section__header--split">
+    <div class="container-lg section-wrap">
+      <div class="facodi-section__header facodi-section__header--split section-header">
         <div>
           <span class="facodi-section__eyebrow">Currículos abertos</span>
-          <h2 class="facodi-section__title">Cursos em destaque na comunidade FACODI</h2>
+          <h2 class="facodi-section__title section-title">Cursos em destaque na comunidade FACODI</h2>
           <p class="facodi-section__subtitle">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
         </div>
         <div class="facodi-section__cta">
@@ -128,11 +130,11 @@
   {{ end }}
 
   <section class="facodi-section facodi-section--journey">
-    <div class="container-lg">
-      <div class="facodi-section__header facodi-section__header--split">
+    <div class="container-lg section-wrap">
+      <div class="facodi-section__header facodi-section__header--split section-header">
         <div>
           <span class="facodi-section__eyebrow facodi-section__eyebrow--light">Trilha comunitária</span>
-          <h2 class="facodi-section__title">Como rola a jornada FACODI</h2>
+          <h2 class="facodi-section__title section-title">Como rola a jornada FACODI</h2>
           <p class="facodi-section__subtitle">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
         </div>
       </div>
@@ -147,10 +149,10 @@
 
 {{ define "sidebar-prefooter" }}
 <section class="facodi-section facodi-section--manifesto">
-  <div class="container-lg">
+  <div class="container-lg section-wrap">
     <div class="facodi-manifesto">
       <span class="facodi-section__eyebrow">Manifesto Monynha Softwares</span>
-      <h2 class="facodi-manifesto__title">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
+      <h2 class="facodi-manifesto__title section-title">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
       <p class="facodi-manifesto__description">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
       <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener">Conheça o manifesto completo</a>
     </div>
@@ -160,9 +162,9 @@
 
 {{ define "sidebar-footer" }}
 <section class="facodi-section facodi-section--cta">
-  <div class="container-lg">
+  <div class="container-lg section-wrap">
     <div class="facodi-cta">
-      <h2 class="facodi-cta__title">Bora colar com a FACODI?</h2>
+      <h2 class="facodi-cta__title section-title">Bora colar com a FACODI?</h2>
       <p class="facodi-cta__description">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
       <div class="facodi-cta__actions">
         <a class="facodi-hero__cta" href="/courses/">Ver cursos e unidades curriculares</a>


### PR DESCRIPTION
## Summary
- stack the hero accessibility badge, heading, and lead copy with a new intro layout
- add reusable section layout utilities and apply them to homepage section headings for consistent rhythm
- regroup course units by academic year/semester with a responsive auto-fill grid and refreshed card styling

## Testing
- npm run build

## Additional Notes
- Screenshots and GIFs could not be captured in this environment.

------
https://chatgpt.com/codex/tasks/task_e_68cfe556cf188322817073ed117f7cb6