### PR TITLE
Localize loaders and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,57 +12,40 @@ Nosso objetivo é **democratizar o acesso ao ensino superior** por meio de trilh
 - 📚 Catálogo de cursos e currículos completos
 - 🎥 Aulas organizadas em **playlists do YouTube**
 - 📝 Conteúdo textual em **Markdown versionado**
-- 🔑 Autenticação via [Supabase Auth](https://supabase.com)
-- 📊 Acompanhamento de progresso por vídeo
-- 🌍 Multi-idioma: PT / EN / ES / FR
+- 🌙 Alternância de tema (claro/escuro) com persistência da preferência
+- 🌍 Interface multi-idioma (PT como padrão + EN / ES / FR configurados)
+- 🔌 Integração com [Supabase](https://supabase.com) para carregar dados dinâmicos
 
 ---
 
-<!-- ## 🏗️ Arquitetura
+## 🏗️ Arquitetura
 
-- **Frontend**: [Next.js 14](https://nextjs.org) (App Router)
-- **Banco de Dados**: [PostgreSQL + Supabase](https://supabase.com)
-- **Docs**: Arquivos `.md` sincronizados com banco
-- **Infra**: Deploy automatizado via [Coolify](https://coolify.io) em servidor Hetzner
-- **Design**: UI baseada em [shadcn/ui](https://ui.shadcn.com) + Tailwind + tokens Monynha
-
---- -->
+- **Frontend**: [Hugo](https://gohugo.io) com tema [Doks](https://getdoks.com)
+- **UI/Estilo**: SCSS customizado com tokens Monynha + componentes Bootstrap
+- **Integração dinâmica**: Vanilla JS (Supabase JS + Marked) carregando cursos/UCs/tópicos
+- **Banco de Dados**: [Supabase](https://supabase.com) (PostgreSQL) com RLS ativado
+- **Conteúdo**: Markdown versionado em `content/` sincronizado com Supabase
+- **Deploy**: Empacotamento estático via `hugo --minify` (utilizável em Netlify, Vercel, etc.)
 
 ## 📂 Estrutura do Repositório
 
 ```bash
-facodi-docs/
+facodi.pt/
 ├─ README.md
-├─ .github/
-│ └─ workflows/
-│ ├─ validate-md.yml
-│ └─ sync-md-to-supabase.yml
+├─ AGENTS.md
+├─ package.json / package-lock.json
 ├─ config/
-│ ├─ _default/
-├─ scripts/
-├─ package.json
-├─ package-lock.json
+│   └─ _default/              # Configurações do Hugo (idiomas, parâmetros, menus)
+├─ layouts/                   # Templates Hugo (home, cursos, UCs, tópicos)
+│   └─ _partials/             # Cabeçalho, rodapé e scripts compartilhados
 ├─ content/
-│ ├─ _index.md
-│ └─ courses/
-│ └─ LESTI/
-│ └─ 2024-2025/
-│ ├─ index.md
-│ └─ uc/
-│ ├─ LESTI-ALG1/
-│ │ ├─ index.md
-│ │ └─ estruturas-de-dados.md
-│ └─ LESTI-BD1/
-│ └─ index.md
-├─ static/ (opcional: imagens anexas ao conteúdo)
-│ └─ courses/
-│ └─ ...
-└─ schemas/ (opcional: documentação de esquema e seeds)
-├─ README.md
-├─ mapping.md
-└─ examples/
-└─ frontmatter-samples.md
-````
+│   └─ courses/               # Conteúdo em Markdown (cursos, UCs, tópicos)
+├─ static/
+│   └─ js/                    # Clientes Supabase + carregadores dinâmicos
+├─ assets/                    # SCSS e JS processados pelo Hugo Pipes
+├─ supabase/                  # Schemas e automações de sincronização
+└─ .github/workflows/         # Workflows de validação e sync para o banco
+```
 
 ---
 
@@ -74,14 +57,20 @@ git clone https://github.com/Monynha-Softwares/facodi.pt.git
 cd facodi.pt
 
 # Instalar dependências
-pnpm install
+npm install
 
-# Iniciar Supabase local
-pnpm supabase start
+# Rodar o site em modo desenvolvimento
+npm run dev
 
-# Rodar o frontend
-pnpm dev --filter=web
+# (Opcional) Build otimizado para produção
+npm run build
+
+# (Opcional) Formatar arquivos com Prettier
+npm run format
 ```
+
+> ℹ️ Para consumir dados dinâmicos do Supabase no ambiente local, defina as variáveis
+> `SUPABASE_URL` e `SUPABASE_ANON_KEY` (por exemplo, via `.env` ou variáveis de ambiente) antes de rodar `npm run dev`.
 
 ---
 
@@ -100,9 +89,9 @@ Consulte nosso guia em [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## 👩‍💻 Autores & Créditos
 
-* [Marcelo Santos](https://github.com/marcelo-m7) — fundador do projeto
-* Comunidade Monynha Softwares
-* Base acadêmica: planos curriculares da [UALG](https://www.ualg.pt)
+- [Marcelo Santos](https://github.com/marcelo-m7) — fundador do projeto
+- Comunidade Monynha Softwares
+- Base acadêmica: planos curriculares da [UALG](https://www.ualg.pt)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Política de Segurança
 
-Nós levamos a segurança do FACODI a sério.  
+Nós levamos a segurança do FACODI a sério.
 
 ## Como relatar vulnerabilidades
 
@@ -10,21 +10,22 @@ Em vez disso, envie um e-mail para:
 - **seguranca@monynha.com**
 
 Inclua:
-- Descrição clara da vulnerabilidade  
-- Passos para reproduzir  
-- Impacto esperado  
+
+- Descrição clara da vulnerabilidade
+- Passos para reproduzir
+- Impacto esperado
 
 Responderemos em até **72 horas** confirmando recebimento e indicando próximos passos.
 
 ## Política de divulgação responsável
 
-- Contribuidores devem aguardar que a vulnerabilidade seja corrigida antes de divulgação pública.  
-- Atualizações de segurança serão publicadas neste repositório e anunciadas nas notas de versão.  
+- Contribuidores devem aguardar que a vulnerabilidade seja corrigida antes de divulgação pública.
+- Atualizações de segurança serão publicadas neste repositório e anunciadas nas notas de versão.
 
 ## Escopo
 
-- **Incluído**: Frontend (Next.js), Supabase (schemas, RLS), scripts de sincronização de Markdown.  
-- **Excluído**: Serviços externos (YouTube, Google Cloud, etc.) fora do controle da Monynha Softwares.  
+- **Incluído**: Frontend (Hugo + JS personalizado), Supabase (schemas, RLS), scripts de sincronização de Markdown.
+- **Excluído**: Serviços externos (YouTube, Google Cloud, etc.) fora do controle da Monynha Softwares.
 
 ---
 

--- a/layouts/_partials/footer/script-footer-custom.html
+++ b/layouts/_partials/footer/script-footer-custom.html
@@ -1,5 +1,33 @@
 {{- $supabaseUrl := or (getenv "SUPABASE_URL") site.Params.facodi.supabaseUrl -}}
 {{- $supabaseAnon := or (getenv "SUPABASE_ANON_KEY") site.Params.facodi.supabaseAnonKey -}}
+{{- $translationKeys := slice
+  "course.noUcs"
+  "common.unit"
+  "common.units"
+  "common.semester"
+  "common.year"
+  "common.playlist"
+  "common.playlists"
+  "common.topic"
+  "common.topics"
+  "common.ects"
+  "common.language"
+  "uc.topics"
+  "uc.noTopics"
+  "uc.playlists"
+  "uc.noPlaylists"
+  "uc.learningOutcomes"
+  "uc.noLearningOutcomes"
+  "uc.noPrerequisites"
+  "topic.noTags"
+  "topic.relatedPlaylists"
+  "topic.noPlaylists"
+-}}
+{{- $translationMap := dict -}}
+{{- range $translationKeys -}}
+  {{- $translationMap = merge $translationMap (dict . (i18n .)) -}}
+{{- end -}}
+<script id="facodi-translations" type="application/json">{{ $translationMap | jsonify | safeHTML }}</script>
 <script id="facodi-config" type="application/json">{{ dict "supabaseUrl" $supabaseUrl "supabaseAnonKey" $supabaseAnon | jsonify | safeHTML }}</script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js" integrity="sha384-AkNSQdptcXlJ0/NBZc4qGk86cDVXcCevwoWgEKIpHOEfbvlXGLlIkimQtONt8KNf" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>

--- a/static/js/loaders.js
+++ b/static/js/loaders.js
@@ -1,406 +1,466 @@
 (function () {
-  const logPrefix = '[FACODI]';
+    const logPrefix = '[FACODI]';
 
-  const getClient = () => {
-    const client = window.facodiSupabase;
-    if (!client) {
-      console.info(`${logPrefix} Cliente Supabase indisponível.`);
-      return null;
-    }
-    return client;
-  };
+    const FALLBACK_TRANSLATIONS = {
+        'course.noUcs': 'Ainda não adicionamos unidades curriculares por aqui. Bora sugerir playlists e conteúdos para abrir essa trilha?',
+        'common.unit': 'unidade',
+        'common.units': 'unidades',
+        'common.semester': 'Semestre',
+        'common.year': 'Ano',
+        'common.playlist': 'playlist',
+        'common.playlists': 'playlists',
+        'common.topic': 'tópico',
+        'common.topics': 'tópicos',
+        'common.ects': 'ECTS',
+        'common.language': 'Idioma',
+        'uc.topics': 'Tópicos',
+        'uc.noTopics': 'Ainda não temos tópicos conectados. Indica teus conteúdos favoritos para turbinar esta UC!',
+        'uc.playlists': 'Playlists',
+        'uc.noPlaylists': 'Nenhuma playlist cadastrada por enquanto. Que tal sugerir uma nos canais da FACODI?',
+        'uc.learningOutcomes': 'Resultados de Aprendizagem',
+        'uc.noLearningOutcomes': 'Ainda estamos construindo os resultados de aprendizagem desta UC com a comunidade.',
+        'uc.noPrerequisites': 'Nenhum pré-requisito informado ainda.',
+        'topic.noTags': 'Nenhuma tag adicionada ainda. Fala tu, mona, e ajuda a indexar esse conteúdo!',
+        'topic.relatedPlaylists': 'Playlists relacionadas',
+        'topic.noPlaylists': 'Sem playlists cadastradas por enquanto. Compartilha tua seleção nos canais da FACODI!'
+    };
 
-  const renderMarkdown = (content) => {
-    if (!content) return '';
-    if (typeof window !== 'undefined' && window.marked && typeof window.marked.parse === 'function') {
-      return window.marked.parse(content);
-    }
-    return content.replace(/\n/g, '<br>');
-  };
+    const getTranslations = () => {
+        const script = document.getElementById('facodi-translations');
+        if (!script) {
+            return {};
+        }
+        try {
+            return JSON.parse(script.textContent || '{}') || {};
+        } catch (error) {
+            console.warn(`${logPrefix} Falha ao analisar traduções embutidas.`, error);
+            return {};
+        }
+    };
 
-  const updateHTML = (selector, html) => {
-    const element = typeof selector === 'string' ? document.querySelector(selector) : selector;
-    if (!element) return;
-    element.innerHTML = html;
-  };
+    const translations = getTranslations();
 
-  const updateText = (selector, text) => {
-    const element = typeof selector === 'string' ? document.querySelector(selector) : selector;
-    if (!element) return;
-    element.textContent = text;
-  };
+    const t = (key, fallback) => {
+        if (!key) {
+            return typeof fallback === 'string' ? fallback : '';
+        }
+        if (Object.prototype.hasOwnProperty.call(translations, key)) {
+            return translations[key];
+        }
+        if (fallback !== undefined) {
+            return fallback;
+        }
+        if (Object.prototype.hasOwnProperty.call(FALLBACK_TRANSLATIONS, key)) {
+            return FALLBACK_TRANSLATIONS[key];
+        }
+        return '';
+    };
 
-  const renderPlaylists = (playlists) => {
-    if (!playlists || !playlists.length) {
-      return '<p class="text-muted small">Sem playlists cadastradas.</p>';
-    }
-    const items = playlists
-      .slice()
-      .sort((a, b) => (a.priority || 0) - (b.priority || 0))
-      .map((playlist) => {
-        const id = playlist.id || playlist.playlist_id || '';
-        const label = id || 'Playlist';
-        return `<li class="mb-2"><a class="d-inline-flex align-items-center" href="https://www.youtube.com/playlist?list=${id}" target="_blank" rel="noopener"><span class="badge bg-danger me-2">YT</span>${label}</a></li>`;
-      });
-    return `<ul class="list-unstyled">${items.join('')}</ul>`;
-  };
+    const escapeHtml = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    };
 
-  const renderTags = (tags) => {
-    if (!tags || !tags.length) return '';
-    return tags
-      .map((tag) => `<span class="badge rounded-pill bg-light text-muted me-1">${tag}</span>`)
-      .join('');
-  };
+    const formatCount = (count, singularKey, pluralKey) => {
+        const singular = t(singularKey, FALLBACK_TRANSLATIONS[singularKey] || singularKey);
+        const plural = t(pluralKey, FALLBACK_TRANSLATIONS[pluralKey] || pluralKey);
+        const label = count === 1 ? singular : plural;
+        return `${count} ${label}`.trim();
+    };
 
-  const buildUcUrl = (courseCode, ucCode) => {
-    if (!courseCode || !ucCode) return '#';
-    return `/courses/${courseCode.toLowerCase()}/uc/${ucCode.toLowerCase()}/`;
-  };
+    const formatCountHtml = (count, singularKey, pluralKey) => escapeHtml(formatCount(count, singularKey, pluralKey));
 
-  const parseInteger = (value, fallback) => {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isNaN(parsed) ? fallback : parsed;
-  };
+    const normalizeSegment = (value) =>
+        encodeURIComponent(
+            String(value || '')
+                .trim()
+                .toLowerCase()
+        );
+    const normalizeTopicSegment = (value) => encodeURIComponent(String(value || '').trim());
 
-  const renderCourseUcs = (courseCode, ucs) => {
-    if (!ucs || !ucs.length) {
-      return '<div class="alert alert-warning" role="alert">Ainda não adicionamos unidades curriculares por aqui. Bora sugerir playlists e conteúdos para abrir essa trilha?</div>';
-    }
+    const buildUcUrl = (courseCode, ucCode) => {
+        const courseSegment = normalizeSegment(courseCode);
+        const ucSegment = normalizeSegment(ucCode);
+        if (!courseSegment || !ucSegment) {
+            return '#';
+        }
+        return `/courses/${courseSegment}/uc/${ucSegment}/`;
+    };
 
-    const grouped = new Map();
-    const yearOrder = [];
+    const buildTopicUrl = (courseCode, ucCode, slug) => {
+        const base = buildUcUrl(courseCode, ucCode);
+        const topicSegment = normalizeTopicSegment(slug);
+        if (base === '#' || !topicSegment) {
+            return '#';
+        }
+        return `${base}${topicSegment}/`;
+    };
 
-    ucs.forEach((uc) => {
-      const semesterGlobal = parseInteger(uc.semester, 1);
-      const derivedYear = Math.floor((semesterGlobal - 1) / 2) + 1;
-      const year = parseInteger(uc.year, derivedYear);
-      const semesterWithinYear = ((semesterGlobal - 1) % 2 + 2) % 2 + 1;
+    const getClient = () => {
+        const client = window.facodiSupabase;
+        if (!client) {
+            console.info(`${logPrefix} Cliente Supabase indisponível.`);
+            return null;
+        }
+        return client;
+    };
 
-      if (!grouped.has(year)) {
-        grouped.set(year, new Map());
-        yearOrder.push(year);
-      }
-      const semesterMap = grouped.get(year);
-      if (!semesterMap.has(semesterWithinYear)) {
-        semesterMap.set(semesterWithinYear, []);
-      }
-      semesterMap.get(semesterWithinYear).push({ ...uc, semesterGlobal });
-    });
+    const renderMarkdown = (content) => {
+        if (!content) return '';
+        if (typeof window !== 'undefined' && window.marked && typeof window.marked.parse === 'function') {
+            return window.marked.parse(content);
+        }
+        return content.replace(/\n/g, '<br>');
+    };
 
-    yearOrder.sort((a, b) => a - b);
+    const updateHTML = (selector, html) => {
+        const element = typeof selector === 'string' ? document.querySelector(selector) : selector;
+        if (!element) return;
+        element.innerHTML = html;
+    };
 
-    const renderCard = (uc) => {
-      const url = uc.path || buildUcUrl(courseCode, uc.code);
-      const description = uc.description || uc.summary || '';
-      const ects = typeof uc.ects === 'number' ? uc.ects : uc.ects || '--';
-      const language = uc.language || '--';
-      const semesterLabel = uc.semesterGlobal || uc.semester;
+    const updateText = (selector, text) => {
+        const element = typeof selector === 'string' ? document.querySelector(selector) : selector;
+        if (!element) return;
+        element.textContent = text;
+    };
 
-      return `
+    const renderTags = (tags) => {
+        if (!tags || !tags.length) return '';
+        return tags.map((tag) => `<span class="badge rounded-pill bg-light text-muted me-1">${escapeHtml(tag)}</span>`).join('');
+    };
+
+    const renderPlaylists = (playlists, options = {}) => {
+        const emptyKey = options.emptyKey || 'uc.noPlaylists';
+        const emptyText = t(emptyKey, FALLBACK_TRANSLATIONS[emptyKey] || '');
+        if (!playlists || !playlists.length) {
+            return emptyText ? `<p class="text-muted small">${escapeHtml(emptyText)}</p>` : '';
+        }
+        const items = playlists
+            .slice()
+            .sort((a, b) => (a.priority || 0) - (b.priority || 0))
+            .map((playlist) => {
+                const rawId = playlist.id || playlist.playlist_id || '';
+                const id = rawId ? String(rawId) : '';
+                const encodedId = encodeURIComponent(id);
+                const label = id || t('common.playlist', FALLBACK_TRANSLATIONS['common.playlist']);
+                return `<li class="mb-2"><a class="d-inline-flex align-items-center" href="https://www.youtube.com/playlist?list=${encodedId}" target="_blank" rel="noopener"><span class="badge bg-danger me-2">YT</span>${escapeHtml(label)}</a></li>`;
+            });
+        return `<ul class="list-unstyled">${items.join('')}</ul>`;
+    };
+
+    const parseInteger = (value, fallback) => {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isNaN(parsed) ? fallback : parsed;
+    };
+    const renderCourseUcs = (courseCode, ucs) => {
+        if (!ucs || !ucs.length) {
+            const empty = t('course.noUcs', FALLBACK_TRANSLATIONS['course.noUcs']);
+            return `<div class="alert alert-warning" role="alert">${escapeHtml(empty)}</div>`;
+        }
+
+        const yearLabel = escapeHtml(t('common.year', FALLBACK_TRANSLATIONS['common.year']));
+        const semesterLabel = escapeHtml(t('common.semester', FALLBACK_TRANSLATIONS['common.semester']));
+        const ectsLabel = escapeHtml(t('common.ects', FALLBACK_TRANSLATIONS['common.ects']));
+        const languageLabel = escapeHtml(t('common.language', FALLBACK_TRANSLATIONS['common.language']));
+
+        const grouped = new Map();
+        const yearOrder = [];
+
+        ucs.forEach((uc) => {
+            const semesterGlobal = parseInteger(uc.semester, 1);
+            const derivedYear = Math.floor((semesterGlobal - 1) / 2) + 1;
+            const year = parseInteger(uc.year, derivedYear);
+            const semesterWithinYear = ((((semesterGlobal - 1) % 2) + 2) % 2) + 1;
+
+            if (!grouped.has(year)) {
+                grouped.set(year, new Map());
+                yearOrder.push(year);
+            }
+            const semesterMap = grouped.get(year);
+            if (!semesterMap.has(semesterWithinYear)) {
+                semesterMap.set(semesterWithinYear, []);
+            }
+            semesterMap.get(semesterWithinYear).push({ ...uc, semesterGlobal });
+        });
+
+        yearOrder.sort((a, b) => a - b);
+
+        const renderCard = (uc) => {
+            const url = typeof uc.path === 'string' && uc.path ? uc.path : buildUcUrl(courseCode, uc.code);
+            const description = uc.description || uc.summary || '';
+            const ects = typeof uc.ects === 'number' ? uc.ects : uc.ects || '--';
+            const language = uc.language || '--';
+            const semesterWithinPlan = uc.semesterGlobal || uc.semester;
+
+            return `
         <article class="course-uc-card">
           <div class="course-uc-card__meta">
-            <span class="course-uc-card__code">${uc.code || ''}</span>
-            ${semesterLabel ? `<span class="course-uc-card__semester">Semestre ${semesterLabel}</span>` : ''}
+            <span class="course-uc-card__code">${escapeHtml(uc.code || '')}</span>
+            ${semesterWithinPlan ? `<span class="course-uc-card__semester">${semesterLabel} ${escapeHtml(String(semesterWithinPlan))}</span>` : ''}
           </div>
-          <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="${url}">${uc.name || uc.title || ''}</a></h3>
-          ${description ? `<p class="course-uc-card__summary">${description}</p>` : ''}
+          <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="${escapeHtml(url)}">${escapeHtml(uc.name || uc.title || '')}</a></h3>
+          ${description ? `<p class="course-uc-card__summary">${escapeHtml(description)}</p>` : ''}
           <dl class="course-uc-card__details">
-            <dt>ECTS</dt>
-            <dd>${ects}</dd>
-            <dt>Idioma</dt>
-            <dd>${language}</dd>
+            <dt>${ectsLabel}</dt>
+            <dd>${escapeHtml(String(ects))}</dd>
+            <dt>${languageLabel}</dt>
+            <dd>${escapeHtml(language)}</dd>
           </dl>
         </article>
       `;
-    };
+        };
 
-    const sections = yearOrder
-      .map((year) => {
-        const semesterMap = grouped.get(year);
-        const semesterSections = [1, 2]
-          .map((sem) => {
-            const list = semesterMap.get(sem);
-            if (!list || !list.length) return '';
-            const globalSemesterLabel = (year - 1) * 2 + sem;
-            const cards = list
-              .slice()
-              .sort((a, b) => (a.code || '').localeCompare(b.code || ''))
-              .map(renderCard)
-              .join('');
-            return `
+        const sections = yearOrder
+            .map((year) => {
+                const semesterMap = grouped.get(year);
+                const semesterSections = [1, 2]
+                    .map((sem) => {
+                        const list = semesterMap.get(sem);
+                        if (!list || !list.length) return '';
+                        const globalSemesterLabel = (year - 1) * 2 + sem;
+                        const cards = list
+                            .slice()
+                            .sort((a, b) => (a.code || '').localeCompare(b.code || ''))
+                            .map(renderCard)
+                            .join('');
+                        return `
               <div class="course-uc-semester">
-                <h4 class="course-uc-semester__title">Semestre ${globalSemesterLabel}</h4>
+                <h4 class="course-uc-semester__title">${semesterLabel} ${escapeHtml(String(globalSemesterLabel))}</h4>
                 <div class="course-uc-grid">${cards}</div>
               </div>
             `;
-          })
-          .join('');
+                    })
+                    .join('');
 
-        return `
+                return `
           <section class="course-uc-year">
             <header class="course-uc-year__header">
-              <h3 class="course-uc-year__title">Ano ${year}</h3>
+              <h3 class="course-uc-year__title">${yearLabel} ${escapeHtml(String(year))}</h3>
             </header>
             ${semesterSections}
           </section>
         `;
-      })
-      .join('');
+            })
+            .join('');
 
-    return sections;
-  };
+        return sections;
+    };
 
-  const renderUcTopics = (courseCode, ucCode, topics) => {
-    if (!topics || !topics.length) {
-      return '<div class="alert alert-info" role="alert">Nenhum tópico cadastrado ainda.</div>';
-    }
-    return `
+    const renderUcTopics = (courseCode, ucCode, topics) => {
+        if (!topics || !topics.length) {
+            const empty = t('uc.noTopics', FALLBACK_TRANSLATIONS['uc.noTopics']);
+            return `<div class="alert alert-info" role="alert">${escapeHtml(empty)}</div>`;
+        }
+        return `
       <div class="list-group list-group-flush">
         ${topics
-          .slice()
-          .sort((a, b) => (a.name || a.title || '').localeCompare(b.name || b.title || ''))
-          .map((topic) => {
-            const slug = topic.slug || '';
-            const url = topic.path || (slug ? `/courses/${courseCode.toLowerCase()}/uc/${ucCode.toLowerCase()}/${slug}/` : '#');
-            const summary = topic.summary || '';
-            const playlistCount = topic.playlists ? topic.playlists.length : (topic.youtube_playlists || []).length;
-            const tagsHtml = renderTags(topic.tags || []);
-            const playlistBadge = playlistCount ? `<span class="badge bg-primary-subtle text-primary">${playlistCount} playlists</span>` : '';
-            return `
-              <a class="list-group-item list-group-item-action" href="${url}">
+            .slice()
+            .sort((a, b) => (a.name || a.title || '').localeCompare(b.name || b.title || ''))
+            .map((topic) => {
+                const slug = topic.slug || '';
+                const url = typeof topic.path === 'string' && topic.path ? topic.path : buildTopicUrl(courseCode, ucCode, slug);
+                const summary = topic.summary || '';
+                const playlistCount = Array.isArray(topic.playlists) ? topic.playlists.length : (topic.youtube_playlists || []).length;
+                const playlistLabel = playlistCount === 1 ? t('common.playlist', FALLBACK_TRANSLATIONS['common.playlist']) : t('common.playlists', FALLBACK_TRANSLATIONS['common.playlists']);
+                const playlistBadge = playlistCount ? `<span class="badge bg-primary-subtle text-primary">${escapeHtml(`${playlistCount} ${playlistLabel}`)}</span>` : '';
+                const tagsHtml = renderTags(topic.tags || []);
+                return `
+              <a class="list-group-item list-group-item-action" href="${escapeHtml(url)}">
                 <div class="d-flex justify-content-between align-items-start">
                   <div>
-                    <h3 class="h6 mb-1">${topic.name || topic.title || slug}</h3>
-                    ${summary ? `<p class="mb-1 small text-muted">${summary}</p>` : ''}
+                    <h3 class="h6 mb-1">${escapeHtml(topic.name || topic.title || slug)}</h3>
+                    ${summary ? `<p class="mb-1 small text-muted">${escapeHtml(summary)}</p>` : ''}
                   </div>
                   ${playlistBadge}
                 </div>
                 ${tagsHtml ? `<div class="mt-2">${tagsHtml}</div>` : ''}
-              </a>`;
-          })
-          .join('')}
-      </div>`;
-  };
+              </a>
+            `;
+            })
+            .join('')}
+      </div>
+    `;
+    };
 
-  const renderOutcomes = (outcomes) => {
-    if (!outcomes || !outcomes.length) {
-      return '<p class="text-muted small">Nenhum resultado definido.</p>';
+    const renderOutcomes = (outcomes) => {
+        if (!outcomes || !outcomes.length) {
+            const empty = t('uc.noLearningOutcomes', FALLBACK_TRANSLATIONS['uc.noLearningOutcomes']);
+            return `<p class="text-muted small">${escapeHtml(empty)}</p>`;
+        }
+        const items = outcomes
+            .slice()
+            .sort((a, b) => (a.order || 0) - (b.order || 0))
+            .map((item) => {
+                const value = typeof item === 'string' ? item : item.outcome || '';
+                return `<li class="mb-2">${escapeHtml(value)}</li>`;
+            })
+            .join('');
+        return `<ol class="ps-3">${items}</ol>`;
+    };
+
+    const firstRow = (data) => {
+        if (!data) return null;
+        if (Array.isArray(data)) return data.length ? data[0] : null;
+        return data;
+    };
+    async function loadCoursePage(courseCode, planVersion) {
+        const client = getClient();
+        if (!client || !courseCode) return;
+
+        try {
+            let courseQuery = client.from('catalog.course').select('code,name,degree,ects_total,duration_semesters,plan_version,institution,school,language,summary').eq('code', courseCode);
+            if (planVersion) {
+                courseQuery = courseQuery.eq('plan_version', planVersion);
+            }
+            courseQuery = courseQuery.limit(1);
+            const { data: courseRows, error: courseError } = await courseQuery;
+            if (courseError) throw courseError;
+            const courseData = firstRow(courseRows);
+
+            const { data: ucRows, error: ucError } = await client.from('catalog.uc').select('code,name,description,ects,semester,language,course_code,prerequisites,year').eq('course_code', courseCode).order('semester', { ascending: true });
+            if (ucError) throw ucError;
+
+            if (courseData && courseData.summary) {
+                const summaryElement = document.querySelector('[data-facodi-course-summary]');
+                if (summaryElement) {
+                    summaryElement.textContent = courseData.summary;
+                }
+            }
+
+            const count = document.getElementById('course-uc-count');
+            if (count) {
+                const total = ucRows ? ucRows.length : 0;
+                count.textContent = formatCount(total, 'common.unit', 'common.units');
+            }
+
+            const container = document.querySelector('[data-facodi-slot="course-ucs"]');
+            if (container) {
+                container.innerHTML = renderCourseUcs(courseCode, ucRows || []);
+            }
+        } catch (error) {
+            console.error(`${logPrefix} Falha ao carregar informações do curso ${courseCode}.`, error);
+        }
     }
-    return `<ol class="ps-3">${outcomes
-      .slice()
-      .sort((a, b) => (a.order || 0) - (b.order || 0))
-      .map((item) => `<li class="mb-2">${item.outcome || item}</li>`)
-      .join('')}</ol>`;
-  };
 
-  const firstRow = (data) => {
-    if (!data) return null;
-    if (Array.isArray(data)) return data.length ? data[0] : null;
-    return data;
-  };
+    async function loadUCPage(ucCode) {
+        const client = getClient();
+        if (!client || !ucCode) return;
 
-  async function loadCoursePage(courseCode, planVersion) {
-    const client = getClient();
-    if (!client || !courseCode) return;
+        try {
+            const { data: ucRows, error: ucError } = await client.from('catalog.uc').select('code,name,description,ects,semester,language,prerequisites,course_code').eq('code', ucCode).limit(1);
+            if (ucError) throw ucError;
+            const ucData = firstRow(ucRows);
 
-    try {
-      let courseQuery = client
-        .from('catalog.course')
-        .select('code,name,degree,ects_total,duration_semesters,plan_version,institution,school,language,summary')
-        .eq('code', courseCode);
-      if (planVersion) {
-        courseQuery = courseQuery.eq('plan_version', planVersion);
-      }
-      courseQuery = courseQuery.limit(1);
-      const { data: courseRows, error: courseError } = await courseQuery;
-      if (courseError) throw courseError;
-      const courseData = firstRow(courseRows);
+            const { data: contentRows } = await client.from('catalog.uc_content').select('content_md').eq('uc_code', ucCode).limit(1);
+            const contentData = firstRow(contentRows);
 
-      const { data: ucRows, error: ucError } = await client
-        .from('catalog.uc')
-        .select('code,name,description,ects,semester,language,course_code,prerequisites')
-        .eq('course_code', courseCode)
-        .order('semester', { ascending: true });
-      if (ucError) throw ucError;
+            const { data: outcomeRows } = await client.from('catalog.uc_learning_outcome').select('outcome,order').eq('uc_code', ucCode).order('order', { ascending: true });
 
-      if (courseData && courseData.summary) {
-        const summaryElement = document.querySelector('[data-facodi-course-summary]');
-        if (summaryElement) {
-          summaryElement.textContent = courseData.summary;
-        }
-      }
+            const { data: playlistRows } = await client.from('mapping.uc_playlist').select('playlist_id,priority').eq('uc_code', ucCode).order('priority', { ascending: true });
 
-      const count = document.getElementById('course-uc-count');
-      if (count) {
-        const total = ucRows ? ucRows.length : 0;
-        count.textContent = `${total} ${total === 1 ? 'unidade' : 'unidades'}`;
-      }
+            const { data: topicMappings } = await client.from('mapping.uc_topic').select('topic_slug').eq('uc_code', ucCode);
 
-      const container = document.querySelector('[data-facodi-slot="course-ucs"]');
-      if (container && ucRows) {
-        container.innerHTML = renderCourseUcs(courseCode, ucRows);
-      }
-    } catch (error) {
-      console.error(`${logPrefix} Falha ao carregar informações do curso ${courseCode}.`, error);
-    }
-  }
+            let topics = [];
+            if (topicMappings && topicMappings.length) {
+                const slugs = topicMappings.map((item) => item.topic_slug).filter(Boolean);
+                if (slugs.length) {
+                    const { data: topicRows } = await client.from('subjects.topic').select('slug,name,summary').in('slug', slugs);
+                    const { data: topicPlaylistRows } = await client.from('mapping.topic_playlist').select('topic_slug,playlist_id,priority').in('topic_slug', slugs);
+                    const { data: topicTagRows } = await client.from('subjects.topic_tag').select('topic_slug,tag').in('topic_slug', slugs);
 
-  async function loadUCPage(ucCode) {
-    const client = getClient();
-    if (!client || !ucCode) return;
+                    topics = (topicRows || []).map((topic) => {
+                        const slug = topic.slug;
+                        const playlists = (topicPlaylistRows || []).filter((item) => item.topic_slug === slug);
+                        const tags = (topicTagRows || []).filter((item) => item.topic_slug === slug).map((item) => item.tag);
+                        return {
+                            slug,
+                            name: topic.name,
+                            summary: topic.summary,
+                            playlists,
+                            tags
+                        };
+                    });
+                }
+            }
 
-    try {
-      const { data: ucRows, error: ucError } = await client
-        .from('catalog.uc')
-        .select('code,name,description,ects,semester,language,prerequisites,course_code')
-        .eq('code', ucCode)
-        .limit(1);
-      if (ucError) throw ucError;
-      const ucData = firstRow(ucRows);
-
-      const { data: contentRows } = await client
-        .from('catalog.uc_content')
-        .select('content_md')
-        .eq('uc_code', ucCode)
-        .limit(1);
-      const contentData = firstRow(contentRows);
-
-      const { data: outcomeRows } = await client
-        .from('catalog.uc_learning_outcome')
-        .select('outcome,order')
-        .eq('uc_code', ucCode)
-        .order('order', { ascending: true });
-
-      const { data: playlistRows } = await client
-        .from('mapping.uc_playlist')
-        .select('playlist_id,priority')
-        .eq('uc_code', ucCode)
-        .order('priority', { ascending: true });
-
-      const { data: topicMappings } = await client
-        .from('mapping.uc_topic')
-        .select('topic_slug')
-        .eq('uc_code', ucCode);
-
-      let topics = [];
-      if (topicMappings && topicMappings.length) {
-        const slugs = topicMappings.map((item) => item.topic_slug).filter(Boolean);
-        if (slugs.length) {
-          const { data: topicRows } = await client
-            .from('subjects.topic')
-            .select('slug,name,summary')
-            .in('slug', slugs);
-          const { data: topicPlaylistRows } = await client
-            .from('mapping.topic_playlist')
-            .select('topic_slug,playlist_id,priority')
-            .in('topic_slug', slugs);
-          const { data: topicTagRows } = await client
-            .from('subjects.topic_tag')
-            .select('topic_slug,tag')
-            .in('topic_slug', slugs);
-
-          topics = (topicRows || []).map((topic) => {
-            const slug = topic.slug;
-            const playlists = (topicPlaylistRows || []).filter((item) => item.topic_slug === slug);
-            const tags = (topicTagRows || [])
-              .filter((item) => item.topic_slug === slug)
-              .map((item) => item.tag);
-            return {
-              slug,
-              name: topic.name,
-              summary: topic.summary,
-              playlists,
-              tags
-            };
-          });
-        }
-      }
-
-      if (ucData) {
-        updateText('.lead.text-muted', ucData.description || ucData.summary || '');
-        updateHTML('#uc-learning-outcomes', `<h2 class="h5">Resultados de Aprendizagem</h2>${renderOutcomes(outcomeRows)}`);
-        updateHTML('#uc-playlists', `<h2 class="h5">Playlists</h2>${renderPlaylists(playlistRows)}`);
-        const prerequisitesElement = document.querySelector('[data-facodi-uc-prerequisites]');
-        if (prerequisitesElement) {
-          if (Array.isArray(ucData.prerequisites) && ucData.prerequisites.length) {
-            prerequisitesElement.textContent = ucData.prerequisites.join(', ');
-          } else {
-            prerequisitesElement.innerHTML = '<span class="text-muted">Nenhum</span>';
-          }
-        }
-        updateHTML('#uc-topics', `
+            if (ucData) {
+                updateText('.lead.text-muted', ucData.description || ucData.summary || '');
+                updateHTML('#uc-learning-outcomes', `<h2 class="h5">${escapeHtml(t('uc.learningOutcomes', FALLBACK_TRANSLATIONS['uc.learningOutcomes']))}</h2>${renderOutcomes(outcomeRows)}`);
+                updateHTML('#uc-playlists', `<h2 class="h5">${escapeHtml(t('uc.playlists', FALLBACK_TRANSLATIONS['uc.playlists']))}</h2>${renderPlaylists(playlistRows, { emptyKey: 'uc.noPlaylists' })}`);
+                const prerequisitesElement = document.querySelector('[data-facodi-uc-prerequisites]');
+                if (prerequisitesElement) {
+                    if (Array.isArray(ucData.prerequisites) && ucData.prerequisites.length) {
+                        prerequisitesElement.textContent = ucData.prerequisites.join(', ');
+                        prerequisitesElement.classList.remove('text-muted');
+                    } else {
+                        prerequisitesElement.textContent = t('uc.noPrerequisites', FALLBACK_TRANSLATIONS['uc.noPrerequisites']);
+                        prerequisitesElement.classList.add('text-muted');
+                    }
+                }
+                updateHTML(
+                    '#uc-topics',
+                    `
           <div class="d-flex align-items-center justify-content-between mb-3">
-            <h2 class="h4 mb-0">Tópicos</h2>
-            <span class="text-muted small">${topics.length} tópicos</span>
+            <h2 class="h4 mb-0">${escapeHtml(t('uc.topics', FALLBACK_TRANSLATIONS['uc.topics']))}</h2>
+            <span class="text-muted small">${formatCountHtml(topics.length, 'common.topic', 'common.topics')}</span>
           </div>
           ${renderUcTopics(ucData.course_code || '', ucData.code, topics)}
-        `);
-      }
+        `
+                );
+            }
 
-      if (contentData && contentData.content_md) {
-        updateHTML('#uc-content', renderMarkdown(contentData.content_md));
-      }
-    } catch (error) {
-      console.error(`${logPrefix} Falha ao carregar dados da UC ${ucCode}.`, error);
-    }
-  }
-
-  async function loadTopicPage(topicSlug) {
-    const client = getClient();
-    if (!client || !topicSlug) return;
-
-    try {
-      const { data: topicRows, error: topicError } = await client
-        .from('subjects.topic')
-        .select('slug,name,summary')
-        .eq('slug', topicSlug)
-        .limit(1);
-      if (topicError) throw topicError;
-      const topicData = firstRow(topicRows);
-
-      const { data: contentRows } = await client
-        .from('subjects.topic_content')
-        .select('content_md')
-        .eq('topic_slug', topicSlug)
-        .limit(1);
-      const contentData = firstRow(contentRows);
-
-      const { data: playlistRows } = await client
-        .from('mapping.topic_playlist')
-        .select('playlist_id,priority')
-        .eq('topic_slug', topicSlug)
-        .order('priority', { ascending: true });
-
-      const { data: tagRows } = await client
-        .from('subjects.topic_tag')
-        .select('tag')
-        .eq('topic_slug', topicSlug);
-
-      if (topicData) {
-        updateText('.lead.text-muted', topicData.summary || '');
-        const tagContainer = document.querySelector('[data-facodi-slot="topic-tags"]');
-        if (tagContainer) {
-          tagContainer.innerHTML = tagRows && tagRows.length
-            ? renderTags(tagRows.map((item) => item.tag))
-            : '<span class="text-muted small">Sem tags definidas.</span>';
+            if (contentData && contentData.content_md) {
+                updateHTML('#uc-content', renderMarkdown(contentData.content_md));
+            }
+        } catch (error) {
+            console.error(`${logPrefix} Falha ao carregar dados da UC ${ucCode}.`, error);
         }
-      }
-
-      if (playlistRows) {
-        updateHTML('#topic-playlists', `<h2 class="h5">Playlists relacionadas</h2>${renderPlaylists(playlistRows)}`);
-      }
-
-      if (contentData && contentData.content_md) {
-        updateHTML('#topic-content', renderMarkdown(contentData.content_md));
-      }
-    } catch (error) {
-      console.error(`${logPrefix} Falha ao carregar dados do tópico ${topicSlug}.`, error);
     }
-  }
 
-  window.facodiLoaders = {
-    loadCoursePage,
-    loadUCPage,
-    loadTopicPage
-  };
+    async function loadTopicPage(topicSlug) {
+        const client = getClient();
+        if (!client || !topicSlug) return;
+
+        try {
+            const { data: topicRows, error: topicError } = await client.from('subjects.topic').select('slug,name,summary').eq('slug', topicSlug).limit(1);
+            if (topicError) throw topicError;
+            const topicData = firstRow(topicRows);
+
+            const { data: contentRows } = await client.from('subjects.topic_content').select('content_md').eq('topic_slug', topicSlug).limit(1);
+            const contentData = firstRow(contentRows);
+
+            const { data: playlistRows } = await client.from('mapping.topic_playlist').select('playlist_id,priority').eq('topic_slug', topicSlug).order('priority', { ascending: true });
+
+            const { data: tagRows } = await client.from('subjects.topic_tag').select('tag').eq('topic_slug', topicSlug);
+
+            if (topicData) {
+                updateText('.lead.text-muted', topicData.summary || '');
+                const tagContainer = document.querySelector('[data-facodi-slot="topic-tags"]');
+                if (tagContainer) {
+                    if (tagRows && tagRows.length) {
+                        tagContainer.innerHTML = renderTags(tagRows.map((item) => item.tag));
+                    } else {
+                        tagContainer.innerHTML = `<span class="text-muted small">${escapeHtml(t('topic.noTags', FALLBACK_TRANSLATIONS['topic.noTags']))}</span>`;
+                    }
+                }
+            }
+
+            updateHTML('#topic-playlists', `<h2 class="h5">${escapeHtml(t('topic.relatedPlaylists', FALLBACK_TRANSLATIONS['topic.relatedPlaylists']))}</h2>${renderPlaylists(playlistRows, { emptyKey: 'topic.noPlaylists' })}`);
+
+            if (contentData && contentData.content_md) {
+                updateHTML('#topic-content', renderMarkdown(contentData.content_md));
+            }
+        } catch (error) {
+            console.error(`${logPrefix} Falha ao carregar dados do tópico ${topicSlug}.`, error);
+        }
+    }
+
+    window.facodiLoaders = {
+        loadCoursePage,
+        loadUCPage,
+        loadTopicPage
+    };
 })();


### PR DESCRIPTION
## Summary
- expose interface translation strings to the Supabase loaders
- internationalize the dynamic course/UC/topic renderers and harden their markup
- document the Hugo-based workflow and update the security scope wording

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02a6977f0832297f7945289ff9e0a