### PR TITLE
Add Google Translate support to the navigation

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,11 @@
 const THEME_STORAGE_KEY = 'facodi-theme-preference';
+const GOOGLE_TRANSLATE_STORAGE_KEY = 'facodi-google-translate-target';
+const GOOGLE_TRANSLATE_SCRIPT_URL =
+  'https://translate.google.com/translate_a/element.js?cb=facodiGoogleTranslateInit';
 const root = document.documentElement;
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+let googleTranslateLoader = null;
 
 function readStoredTheme() {
   try {
@@ -15,6 +20,26 @@ function storeTheme(value) {
     localStorage.setItem(THEME_STORAGE_KEY, value);
   } catch (error) {
     // Ignore storage errors (e.g., private mode).
+  }
+}
+
+function readStoredGoogleTarget() {
+  try {
+    return localStorage.getItem(GOOGLE_TRANSLATE_STORAGE_KEY) || '';
+  } catch (error) {
+    return '';
+  }
+}
+
+function storeGoogleTarget(value) {
+  try {
+    if (value) {
+      localStorage.setItem(GOOGLE_TRANSLATE_STORAGE_KEY, value);
+    } else {
+      localStorage.removeItem(GOOGLE_TRANSLATE_STORAGE_KEY);
+    }
+  } catch (error) {
+    // Ignore storage errors.
   }
 }
 
@@ -56,6 +81,198 @@ function initTheme() {
   }
 }
 
+function loadGoogleTranslateElement(options) {
+  const { defaultLanguage, languages, containerId } = options;
+
+  if (!Array.isArray(languages) || languages.length === 0) {
+    return Promise.reject(new Error('Google Translate languages are not configured.'));
+  }
+
+  if (window.facodiGoogleTranslateElement) {
+    return Promise.resolve(window.facodiGoogleTranslateElement);
+  }
+
+  if (
+    window.google &&
+    window.google.translate &&
+    typeof window.google.translate.TranslateElement === 'function'
+  ) {
+    window.facodiGoogleTranslateElement = new window.google.translate.TranslateElement(
+      {
+        pageLanguage: defaultLanguage,
+        includedLanguages: languages.join(','),
+        autoDisplay: false,
+      },
+      containerId
+    );
+    return Promise.resolve(window.facodiGoogleTranslateElement);
+  }
+
+  if (googleTranslateLoader) {
+    return googleTranslateLoader;
+  }
+
+  googleTranslateLoader = new Promise((resolve, reject) => {
+    const cleanup = () => {
+      delete window.facodiGoogleTranslateInit;
+    };
+
+    window.facodiGoogleTranslateInit = () => {
+      try {
+        window.facodiGoogleTranslateElement = new window.google.translate.TranslateElement(
+          {
+            pageLanguage: defaultLanguage,
+            includedLanguages: languages.join(','),
+            autoDisplay: false,
+          },
+          containerId
+        );
+        cleanup();
+        resolve(window.facodiGoogleTranslateElement);
+      } catch (error) {
+        cleanup();
+        googleTranslateLoader = null;
+        reject(error);
+      }
+    };
+
+    const script = document.createElement('script');
+    script.src = GOOGLE_TRANSLATE_SCRIPT_URL;
+    script.async = true;
+    script.onerror = () => {
+      cleanup();
+      googleTranslateLoader = null;
+      reject(new Error('Google Translate failed to load'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return googleTranslateLoader;
+}
+
+function initGoogleTranslate() {
+  const select = document.querySelector('[data-facodi-google-translate-select]');
+  const container = document.getElementById('facodi-google-translate-container');
+
+  if (!select || !container) {
+    return;
+  }
+
+  const languagesAttr = select.getAttribute('data-google-translate-languages') || '';
+  const languages = languagesAttr
+    .split(',')
+    .map((lang) => lang.trim())
+    .filter(Boolean);
+
+  if (languages.length === 0) {
+    return;
+  }
+
+  const defaultLanguage = select.getAttribute('data-default-lang') || 'pt';
+  const defaultNote = select.getAttribute('data-note-default') || '';
+  const activePrefix = select.getAttribute('data-note-prefix') || '';
+  const errorMessage = select.getAttribute('data-error-message') || '';
+  const note = document.getElementById('facodi-google-translate-note');
+
+  if (note) {
+    note.textContent = defaultNote;
+  }
+
+  const updateNote = (value) => {
+    if (!note) {
+      return;
+    }
+    note.classList.remove('facodi-navbar__note--error');
+    if (!value) {
+      note.textContent = defaultNote;
+      note.classList.remove('facodi-navbar__note--active');
+      return;
+    }
+    const option = select.querySelector(`option[value="${value}"]`);
+    const label = option ? option.textContent.trim() : value;
+    const message = activePrefix ? `${activePrefix} ${label}` : label;
+    note.textContent = activePrefix ? `${message}.` : message;
+    note.classList.add('facodi-navbar__note--active');
+  };
+
+  let googleCombo = null;
+
+  const applySelection = (value) => {
+    if (!googleCombo) {
+      return;
+    }
+    const targetValue = value || '';
+    if (googleCombo.value !== targetValue) {
+      googleCombo.value = targetValue;
+    }
+    googleCombo.dispatchEvent(new Event('change'));
+  };
+
+  const storedValue = readStoredGoogleTarget();
+  if (storedValue && languages.includes(storedValue)) {
+    select.value = storedValue;
+    updateNote(storedValue);
+  } else {
+    select.value = '';
+    updateNote('');
+    if (storedValue) {
+      storeGoogleTarget('');
+    }
+  }
+
+  const loadPromise = loadGoogleTranslateElement({
+    defaultLanguage,
+    languages,
+    containerId: 'facodi-google-translate-container',
+  })
+    .then(() => {
+      googleCombo =
+        container.querySelector('select.goog-te-combo') || document.getElementById('goog-te-combo');
+
+      if (googleCombo) {
+        googleCombo.setAttribute('aria-hidden', 'true');
+        googleCombo.tabIndex = -1;
+      }
+
+      const initial = select.value && languages.includes(select.value) ? select.value : '';
+      if (initial !== select.value) {
+        select.value = initial;
+      }
+      updateNote(initial);
+      applySelection(initial);
+    })
+    .catch((error) => {
+      if (note) {
+        note.textContent = errorMessage || defaultNote;
+        note.classList.remove('facodi-navbar__note--active');
+        note.classList.add('facodi-navbar__note--error');
+      }
+      select.setAttribute('disabled', 'true');
+      select.setAttribute('aria-disabled', 'true');
+      storeGoogleTarget('');
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('FACODI Google Translate failed to initialise.', error);
+      }
+    });
+
+  select.addEventListener('change', (event) => {
+    const value = event.target.value;
+    const normalized = value && languages.includes(value) ? value : '';
+    if (normalized !== value) {
+      select.value = normalized;
+    }
+    storeGoogleTarget(normalized);
+    updateNote(normalized);
+    loadPromise
+      .then(() => {
+        applySelection(normalized);
+      })
+      .catch(() => {
+        // Error already handled when loading the Google Translate script.
+      });
+  });
+}
+
 function initLanguageSwitcher() {
   const select = document.querySelector('[data-facodi-language-select]');
   if (!select) {
@@ -73,4 +290,5 @@ function initLanguageSwitcher() {
 window.addEventListener('DOMContentLoaded', () => {
   initTheme();
   initLanguageSwitcher();
+  initGoogleTranslate();
 });

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -3,6 +3,7 @@
 body {
   background: var(--facodi-body-bg);
   color: var(--facodi-body-color);
+  top: 0 !important;
 }
 
 a {
@@ -125,6 +126,44 @@ a {
   align-items: center;
 }
 
+.facodi-navbar__language--machine {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.facodi-navbar__language--machine .facodi-navbar__select {
+  width: 100%;
+}
+
+@include media-breakpoint-up(sm) {
+  .facodi-navbar__language--machine {
+    width: auto;
+    min-width: 220px;
+  }
+}
+
+.facodi-navbar__note {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--facodi-text-muted);
+  text-align: center;
+  line-height: 1.2;
+}
+
+.facodi-navbar__note--active {
+  color: var(--facodi-heading-color);
+}
+
+.facodi-navbar__note--error {
+  color: #e03131;
+}
+
+html[data-theme="dark"] .facodi-navbar__note--error {
+  color: #ff6b6b;
+}
+
 .facodi-navbar__select {
   appearance: none;
   background-color: var(--facodi-navbar-select-bg);
@@ -151,6 +190,11 @@ a {
   outline: none;
   background-color: var(--facodi-navbar-select-hover-bg);
   box-shadow: 0 0 0 3px rgba(93, 199, 255, 0.25), var(--facodi-navbar-select-shadow);
+}
+
+.facodi-navbar__select:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 html[data-theme="dark"] .facodi-navbar__select {
@@ -198,6 +242,18 @@ html[data-theme="dark"] .facodi-theme-icon--dark {
 
 html[data-theme="dark"] .facodi-theme-icon--light {
   display: none;
+}
+
+.facodi-google-translate-container {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+body .goog-te-banner-frame.skiptranslate {
+  display: none !important;
 }
 
 .facodi-navbar__icon {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,11 @@
   { "id": "nav.themeToggle", "translation": "Toggle color theme" },
   { "id": "nav.github", "translation": "Open Monynha Softwares repository on GitHub" },
   { "id": "nav.viewTracks", "translation": "Explore tracks" },
+  { "id": "nav.machineTranslationLabel", "translation": "Translate content automatically" },
+  { "id": "nav.machineTranslationOriginal", "translation": "Portuguese (original)" },
+  { "id": "nav.machineTranslationNote", "translation": "Automatic translation provided by Google Translate." },
+  { "id": "nav.machineTranslationActivePrefix", "translation": "Automatically translated to" },
+  { "id": "nav.machineTranslationError", "translation": "We could not load Google Translate. Please try again later." },
 
   { "id": "home.ecosystemCta", "translation": "Discover the Monynha Softwares ecosystem" },
   { "id": "home.viewAllCourses", "translation": "View all courses" },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -6,6 +6,11 @@
   { "id": "nav.themeToggle", "translation": "Cambiar tema" },
   { "id": "nav.github", "translation": "Abrir el repositorio de Monynha Softwares en GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorar rutas" },
+  { "id": "nav.machineTranslationLabel", "translation": "Traducir contenido automáticamente" },
+  { "id": "nav.machineTranslationOriginal", "translation": "Portugués (original)" },
+  { "id": "nav.machineTranslationNote", "translation": "Traducción automática con Google Traductor." },
+  { "id": "nav.machineTranslationActivePrefix", "translation": "Traducido automáticamente a" },
+  { "id": "nav.machineTranslationError", "translation": "No fue posible cargar Google Traductor. Inténtalo de nuevo más tarde." },
 
   { "id": "home.ecosystemCta", "translation": "Conoce el ecosistema Monynha Softwares" },
   { "id": "home.viewAllCourses", "translation": "Ver todos los cursos" },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -6,6 +6,11 @@
   { "id": "nav.themeToggle", "translation": "Basculer le thème" },
   { "id": "nav.github", "translation": "Ouvrir le dépôt Monynha Softwares sur GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorer les parcours" },
+  { "id": "nav.machineTranslationLabel", "translation": "Traduire le contenu automatiquement" },
+  { "id": "nav.machineTranslationOriginal", "translation": "Portugais (original)" },
+  { "id": "nav.machineTranslationNote", "translation": "Traduction automatique via Google Traduction." },
+  { "id": "nav.machineTranslationActivePrefix", "translation": "Traduit automatiquement vers" },
+  { "id": "nav.machineTranslationError", "translation": "Impossible de charger Google Traduction. Réessayez plus tard." },
 
   { "id": "home.ecosystemCta", "translation": "Découvrir l’écosystème Monynha Softwares" },
   { "id": "home.viewAllCourses", "translation": "Voir tous les cours" },

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -6,6 +6,11 @@
   { "id": "nav.themeToggle", "translation": "Alternar tema" },
   { "id": "nav.github", "translation": "Abrir repositório da Monynha Softwares no GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorar trilhas" },
+  { "id": "nav.machineTranslationLabel", "translation": "Traduzir conteúdo automaticamente" },
+  { "id": "nav.machineTranslationOriginal", "translation": "Português (original)" },
+  { "id": "nav.machineTranslationNote", "translation": "Tradução automática com Google Tradutor." },
+  { "id": "nav.machineTranslationActivePrefix", "translation": "Traduzido automaticamente para" },
+  { "id": "nav.machineTranslationError", "translation": "Não foi possível carregar o Google Tradutor. Tente novamente mais tarde." },
 
   { "id": "home.ecosystemCta", "translation": "Conheça o ecossistema Monynha Softwares" },
   { "id": "home.viewAllCourses", "translation": "Ver todos os cursos" },

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -98,6 +98,13 @@
             {{ end }}
           {{ end }}
           {{ $defaultLang := site.Params.facodi.defaultLocale | default site.Language.Lang }}
+          {{ $googleLangs := slice }}
+          {{ range site.Languages }}
+            {{ if ne .Lang $defaultLang }}
+              {{ $googleLangs = $googleLangs | append .Lang }}
+            {{ end }}
+          {{ end }}
+          {{ $googleLangsAttr := delimit $googleLangs "," }}
           <div class="facodi-navbar__language">
             <label class="visually-hidden" for="facodi-language-select">{{ i18n "nav.languageLabel" }}</label>
             <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select aria-label="{{ i18n "nav.languageLabel" }}">
@@ -117,6 +124,32 @@
               {{ end }}
             </select>
           </div>
+          {{ if gt (len $googleLangs) 0 }}
+            <div class="facodi-navbar__language facodi-navbar__language--machine">
+              <label class="visually-hidden" id="facodi-google-translate-label" for="facodi-google-translate-select">{{ i18n "nav.machineTranslationLabel" }}</label>
+              <select
+                id="facodi-google-translate-select"
+                class="facodi-navbar__select"
+                data-facodi-google-translate-select
+                data-default-lang="{{ $defaultLang }}"
+                data-google-translate-languages="{{ $googleLangsAttr }}"
+                data-note-default="{{ i18n "nav.machineTranslationNote" }}"
+                data-note-prefix="{{ i18n "nav.machineTranslationActivePrefix" }}"
+                data-error-message="{{ i18n "nav.machineTranslationError" }}"
+                aria-labelledby="facodi-google-translate-label"
+                aria-describedby="facodi-google-translate-note"
+              >
+                <option value="" selected>{{ i18n "nav.machineTranslationOriginal" }}</option>
+                {{ range site.Languages }}
+                  {{ if ne .Lang $defaultLang }}
+                    <option value="{{ .Lang }}">{{ .LanguageName }}</option>
+                  {{ end }}
+                {{ end }}
+              </select>
+              <span id="facodi-google-translate-note" class="facodi-navbar__note" aria-live="polite">{{ i18n "nav.machineTranslationNote" }}</span>
+            </div>
+            <div id="facodi-google-translate-container" class="facodi-google-translate-container" aria-hidden="true"></div>
+          {{ end }}
           <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}">
             <span class="facodi-theme-icon facodi-theme-icon--light" aria-hidden="true">☀️</span>
             <span class="facodi-theme-icon facodi-theme-icon--dark" aria-hidden="true">🌙</span>


### PR DESCRIPTION
## Summary
- add a Google Translate selector with helper note to the navbar
- load the Google Translate widget on demand and persist the selected language
- style the selector/note and localize the new strings in PT, EN, ES and FR

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d031357c80832289e3388919b5e14a