### PR TITLE
Add Google Translate integration to FACODI navigation

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -70,7 +70,89 @@ function initLanguageSwitcher() {
   });
 }
 
+function initGoogleTranslate() {
+  const wrapper = document.querySelector('[data-facodi-google-translate]');
+  if (!wrapper) {
+    return;
+  }
+
+  const scriptId = 'facodi-google-translate-script';
+  if (document.getElementById(scriptId)) {
+    return;
+  }
+
+  const labelElement = wrapper.querySelector('[data-facodi-google-translate-label]');
+  const labelText = labelElement ? labelElement.textContent.trim() : '';
+  const labelId = labelElement ? labelElement.id : '';
+
+  const applyStyling = () => {
+    const gadget = wrapper.querySelector('.goog-te-gadget');
+    if (!gadget) {
+      return false;
+    }
+
+    gadget.classList.add('facodi-translate__gadget');
+
+    const icon = gadget.querySelector('.goog-te-gadget-icon');
+    if (icon) {
+      icon.remove();
+    }
+
+    gadget.querySelectorAll('span').forEach((span) => {
+      span.style.display = 'none';
+      span.setAttribute('aria-hidden', 'true');
+    });
+
+    const select = gadget.querySelector('select.goog-te-combo');
+    if (!select) {
+      return false;
+    }
+
+    select.classList.add('facodi-navbar__select', 'facodi-navbar__select--translator');
+    if (labelText) {
+      select.setAttribute('aria-label', labelText);
+    }
+    if (labelId) {
+      select.setAttribute('aria-labelledby', labelId);
+    }
+
+    return true;
+  };
+
+  window.googleTranslateElementInit = () => {
+    if (!window.google || !window.google.translate) {
+      return;
+    }
+
+    new window.google.translate.TranslateElement(
+      {
+        pageLanguage: 'pt',
+        includedLanguages: 'en,es,fr',
+        layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+        autoDisplay: false,
+      },
+      'facodi-google-translate',
+    );
+
+    const observer = new MutationObserver(() => {
+      if (applyStyling()) {
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(wrapper, { childList: true, subtree: true });
+    applyStyling();
+  };
+
+  const script = document.createElement('script');
+  script.id = scriptId;
+  script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+  script.defer = true;
+  document.head.appendChild(script);
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   initTheme();
   initLanguageSwitcher();
+  initGoogleTranslate();
 });

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -125,6 +125,45 @@ a {
   align-items: center;
 }
 
+.facodi-navbar__translator {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+
+  @include media-breakpoint-up(lg) {
+    width: auto;
+  }
+}
+
+.facodi-translate {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+}
+
+.facodi-translate__gadget {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.facodi-navbar__translator .goog-te-gadget-icon,
+.facodi-navbar__translator .goog-te-gadget > a,
+.facodi-navbar__translator .goog-te-gadget > span,
+.facodi-navbar__translator .goog-te-menu-value {
+  display: none !important;
+}
+
+.facodi-navbar__translator select.goog-te-combo {
+  margin: 0;
+  width: 100%;
+}
+
+.facodi-navbar__select--translator {
+  min-width: 9.5rem;
+}
+
 .facodi-navbar__select {
   appearance: none;
   background-color: var(--facodi-navbar-select-bg);
@@ -155,6 +194,14 @@ a {
 
 html[data-theme="dark"] .facodi-navbar__select {
   background-image: url('data:image/svg+xml;utf8,<svg fill="none" stroke="%239ab9ff" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/></svg>');
+}
+
+.goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+
+body.skiptranslate {
+  top: 0 !important;
 }
 
 .facodi-navbar__theme-toggle {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,6 +3,7 @@
   { "id": "nav.openMenu", "translation": "Open menu" },
   { "id": "nav.closeMenu", "translation": "Close menu" },
   { "id": "nav.languageLabel", "translation": "Select language" },
+  { "id": "nav.translateLabel", "translation": "Translate content" },
   { "id": "nav.themeToggle", "translation": "Toggle color theme" },
   { "id": "nav.github", "translation": "Open Monynha Softwares repository on GitHub" },
   { "id": "nav.viewTracks", "translation": "Explore tracks" },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -3,6 +3,7 @@
   { "id": "nav.openMenu", "translation": "Abrir menú" },
   { "id": "nav.closeMenu", "translation": "Cerrar menú" },
   { "id": "nav.languageLabel", "translation": "Seleccionar idioma" },
+  { "id": "nav.translateLabel", "translation": "Traducir contenido" },
   { "id": "nav.themeToggle", "translation": "Cambiar tema" },
   { "id": "nav.github", "translation": "Abrir el repositorio de Monynha Softwares en GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorar rutas" },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3,6 +3,7 @@
   { "id": "nav.openMenu", "translation": "Ouvrir le menu" },
   { "id": "nav.closeMenu", "translation": "Fermer le menu" },
   { "id": "nav.languageLabel", "translation": "Sélectionner la langue" },
+  { "id": "nav.translateLabel", "translation": "Traduire le contenu" },
   { "id": "nav.themeToggle", "translation": "Basculer le thème" },
   { "id": "nav.github", "translation": "Ouvrir le dépôt Monynha Softwares sur GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorer les parcours" },

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -3,6 +3,7 @@
   { "id": "nav.openMenu", "translation": "Abrir menu" },
   { "id": "nav.closeMenu", "translation": "Fechar menu" },
   { "id": "nav.languageLabel", "translation": "Selecionar idioma" },
+  { "id": "nav.translateLabel", "translation": "Traduzir conteúdo" },
   { "id": "nav.themeToggle", "translation": "Alternar tema" },
   { "id": "nav.github", "translation": "Abrir repositório da Monynha Softwares no GitHub" },
   { "id": "nav.viewTracks", "translation": "Explorar trilhas" },

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -90,6 +90,10 @@
           {{ end -}}
         </ul>
         <div class="facodi-navbar__actions d-flex flex-column flex-sm-row align-items-stretch align-items-lg-center gap-3 ms-lg-auto">
+          <div class="facodi-navbar__translator" data-facodi-google-translate>
+            <span id="facodi-google-translate-label" class="visually-hidden" data-facodi-google-translate-label>{{ i18n "nav.translateLabel" }}</span>
+            <div id="facodi-google-translate" class="facodi-translate" role="group" aria-labelledby="facodi-google-translate-label"></div>
+          </div>
           {{ $currentRel := .RelPermalink }}
           {{ $path := $currentRel }}
           {{ range site.Languages }}


### PR DESCRIPTION
## Summary
- add a Google Translate widget to the site header with accessible labeling
- style the translator control to match existing navigation buttons in both themes
- load and initialize the Google Translate script with safe fallbacks and new i18n strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d031357c80832289e3388919b5e14a