### PR TITLE
Align Hugo layouts with multilingual content and taxonomy templates

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,0 +1,39 @@
+---
+title: "FACODI — Community Digital College"
+description: "Community-led platform that maps official curricula and connects them with open playlists so anyone can study."
+lead: "We curate official degree plans and enrich every course with open playlists so that everybody can study, share and shine with the community."
+date: 2024-05-20T00:00:00+00:00
+lastmod: 2024-05-20T00:00:00+00:00
+draft: false
+translationKey: "home"
+seo:
+  title: "FACODI — Community Digital College"
+  description: "Official curricula with open playlists, community progress tracking and Monynha Softwares pride."
+  canonical: ""
+---
+FACODI (Community Digital College) is a free initiative from Monynha Softwares, inspired by open universities and adapted to the digital education realities of Brazil. Our mission is clear: organize official curricula from degrees and related areas and fill each course unit with YouTube playlists and public materials, weaving a learning journey that is structured, accessible and collective. Come along, because good knowledge is that which everyone can reach.
+
+### Purpose and values that guide FACODI
+
+- **Free access:** every piece of content stays open, without financial barriers or fine print.
+- **Community:** students, teachers and volunteers curate the material collectively.
+- **Transparency:** each track is tied to the official curriculum, ensuring credibility.
+- **Inclusion and diversity:** clear language, digital accessibility and pride in our cultures.
+- **Sustainability:** we reuse existing public content and keep production costs low.
+
+### Who is this for
+
+* University students who want to review or deepen course units with autonomy.
+* People interested in open learning who seek well-structured academic paths without needing to enroll.
+* Educators and tutors who need curated collections to enrich their classes.
+* Everyone who believes open education is a tool for social transformation.
+
+### What you will find here
+
+1. **Course catalog** based on official curricula from degrees and related fields.
+2. **Detailed course units** with modules, topics, playlists and open materials.
+3. **Interactive curricular map** to browse courses, semesters and disciplines without getting lost.
+4. **Progress tracking** to follow what has already been studied.
+5. **Version history** to register every update and guarantee academic traceability.
+
+FACODI is technology with purpose: free, open, proudly community-driven and with the inclusive sparkle of Monynha Softwares. Let’s learn together!

--- a/content/_index.es.md
+++ b/content/_index.es.md
@@ -1,0 +1,39 @@
+---
+title: "FACODI — Facultad Comunitaria Digital"
+description: "Plataforma comunitaria que organiza planes de estudio oficiales y los conecta con playlists abiertas para que cualquiera pueda aprender."
+lead: "Organizamos planes oficiales y llenamos cada asignatura con playlists abiertas para que toda persona estudie, comparta y brille junto a la comunidad."
+date: 2024-05-20T00:00:00+00:00
+lastmod: 2024-05-20T00:00:00+00:00
+draft: false
+translationKey: "home"
+seo:
+  title: "FACODI — Facultad Comunitaria Digital"
+  description: "Planes oficiales con playlists abiertas, seguimiento comunitario del progreso y orgullo Monynha Softwares."
+  canonical: ""
+---
+FACODI (Facultad Comunitaria Digital) es una iniciativa gratuita de Monynha Softwares, inspirada en las universidades abiertas y adaptada a la realidad de la educación digital brasileña. Nuestra misión es clara: organizar los planes de estudio oficiales de las licenciaturas y áreas afines y nutrir cada asignatura con playlists de YouTube y materiales públicos, tejiendo una trayectoria de aprendizaje estructurada, accesible y colaborativa. Vení, porque el conocimiento bueno es aquel al que todas las personas acceden.
+
+### Propósito y valores que guían a FACODI
+
+- **Acceso gratuito:** todo el contenido permanece abierto, sin barreras financieras ni letra chica.
+- **Comunidad:** estudiantes, docentes y personas voluntarias curan el material colectivamente.
+- **Transparencia:** cada ruta está ligada al plan oficial, garantizando credibilidad.
+- **Inclusión y diversidad:** lenguaje claro, accesibilidad digital y orgullo de nuestras culturas.
+- **Sostenibilidad:** aprovechamos contenidos públicos existentes y reducimos costos de producción.
+
+### Para quién es este espacio
+
+* Estudiantes universitarios que desean repasar o profundizar en las asignaturas con autonomía.
+* Personas interesadas en la formación libre que buscan caminos académicos bien estructurados sin necesidad de inscribirse.
+* Educadoras, educadores y tutores que necesitan acervos curados para potenciar sus clases.
+* Toda la comunidad que cree en la educación abierta como herramienta de transformación social.
+
+### Qué vas a encontrar aquí
+
+1. **Catálogo de cursos** basado en planes oficiales de licenciaturas y áreas relacionadas.
+2. **Asignaturas detalladas** con módulos, temas, playlists y materiales abiertos.
+3. **Mapa curricular interactivo** para recorrer cursos, semestres y disciplinas sin perderse.
+4. **Seguimiento de progreso** para acompañar lo que ya fue estudiado.
+5. **Historial de versiones** para registrar cada actualización y asegurar trazabilidad académica.
+
+FACODI es tecnología con propósito: gratuita, abierta, orgullosamente comunitaria y con el brillo inclusivo de Monynha Softwares. ¡Vamos a aprender en conjunto!

--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -1,0 +1,39 @@
+---
+title: "FACODI — Faculté Communautaire Numérique"
+description: "Plateforme communautaire qui organise les plans d’études officiels et les relie à des playlists ouvertes pour que chacun puisse apprendre."
+lead: "Nous organisons des plans officiels et nourrissons chaque unité d’enseignement avec des playlists ouvertes pour que tout le monde puisse étudier, partager et briller avec la communauté."
+date: 2024-05-20T00:00:00+00:00
+lastmod: 2024-05-20T00:00:00+00:00
+draft: false
+translationKey: "home"
+seo:
+  title: "FACODI — Faculté Communautaire Numérique"
+  description: "Plans officiels avec playlists ouvertes, suivi communautaire des progrès et fierté Monynha Softwares."
+  canonical: ""
+---
+FACODI (Faculté Communautaire Numérique) est une initiative gratuite de Monynha Softwares, inspirée des universités ouvertes et adaptée à la réalité de l’éducation numérique brésilienne. Notre mission est claire : organiser les plans d’études officiels des licences et domaines associés et enrichir chaque unité d’enseignement avec des playlists YouTube et des matériaux publics, afin de créer un parcours d’apprentissage structuré, accessible et collectif. Rejoins-nous, car le bon savoir est celui qui arrive à tout le monde.
+
+### Objectifs et valeurs qui guident FACODI
+
+- **Accès gratuit :** tout le contenu reste ouvert, sans barrières financières ni mauvaises surprises.
+- **Communauté :** étudiantes, étudiants, enseignantes, enseignants et bénévoles sélectionnent le matériel collectivement.
+- **Transparence :** chaque parcours est lié au plan officiel, garantissant crédibilité et confiance.
+- **Inclusion et diversité :** langage clair, accessibilité numérique et fierté de nos cultures.
+- **Durabilité :** nous réutilisons des contenus publics existants et réduisons les coûts de production.
+
+### Pour qui est cet espace
+
+* Étudiantes et étudiants universitaires qui souhaitent revoir ou approfondir les unités d’enseignement en autonomie.
+* Personnes intéressées par la formation libre qui recherchent des parcours académiques bien structurés sans devoir s’inscrire.
+* Enseignantes, enseignants et tutrices qui ont besoin de ressources sélectionnées pour enrichir leurs cours.
+* Toute personne qui croit que l’éducation ouverte est un outil de transformation sociale.
+
+### Ce que vous trouverez ici
+
+1. **Catalogue de cours** basé sur les plans officiels de licences et domaines associés.
+2. **Unités d’enseignement détaillées** avec modules, thèmes, playlists et ressources ouvertes.
+3. **Carte curriculaire interactive** pour parcourir cours, semestres et disciplines sans se perdre.
+4. **Suivi de progression** pour accompagner ce qui a déjà été étudié.
+5. **Historique des versions** pour enregistrer chaque mise à jour et assurer la traçabilité académique.
+
+FACODI est une technologie engagée : gratuite, ouverte, fièrement communautaire et avec l’éclat inclusif de Monynha Softwares. Apprenons ensemble !

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,6 +5,7 @@ lead: "Organizamos currículos de licenciaturas e recheamos cada unidade com pla
 date: 2024-05-20T00:00:00+00:00
 lastmod: 2024-05-20T00:00:00+00:00
 draft: false
+translationKey: "home"
 seo:
   title: "FACODI — Faculdade Comunitária Digital"
   description: "Currículos oficiais com playlists abertas, progresso comunitário e orgulho Monynha Softwares."

--- a/content/courses/_index.en.md
+++ b/content/courses/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Course Catalog"
+lead: "Pick a course and walk the FACODI journey with official curricula, open playlists and plenty of community care."
+layout: "catalog"
+contributors: []
+translationKey: "courses-index"
+---
+FACODI curates courses using official curricular plans, respecting versions, semesters and the expected competencies. Each course receives dedicated attention: detailed units, related topics, prioritized playlists and space for the community to suggest new materials. Join us — the academic path is open, transparent and made to be shared.

--- a/content/courses/_index.es.md
+++ b/content/courses/_index.es.md
@@ -1,0 +1,8 @@
+---
+title: "Catálogo de Cursos"
+lead: "Elegí un curso y recorré la FACODI con plan oficial, playlists abiertas y mucho cariño comunitario."
+layout: "catalog"
+contributors: []
+translationKey: "courses-index"
+---
+FACODI organiza los cursos a partir de planes curriculares oficiales, respetando versiones, semestres y competencias previstas. Cada curso recibe un cuidado especial: unidades detalladas, temas asociados, playlists priorizadas y espacio para que la comunidad sugiera nuevos materiales. Sumate, porque el camino académico aquí es abierto, transparente y pensado para compartir.

--- a/content/courses/_index.fr.md
+++ b/content/courses/_index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Catalogue des cours"
+lead: "Choisis un cours et parcours la FACODI avec plan officiel, playlists ouvertes et beaucoup d’attention communautaire."
+layout: "catalog"
+contributors: []
+translationKey: "courses-index"
+---
+FACODI organise les cours à partir de plans curriculaires officiels, en respectant les versions, les semestres et les compétences prévues. Chaque cours reçoit un soin particulier : unités détaillées, thèmes associés, playlists prioritaires et espace pour que la communauté suggère de nouvelles ressources. Rejoins-nous : ici le parcours académique est ouvert, transparent et pensé pour être partagé.

--- a/content/courses/_index.md
+++ b/content/courses/_index.md
@@ -3,6 +3,7 @@ title: "Catálogo de Cursos"
 lead: "Escolha um curso e bora trilhar a FACODI com currículo oficial, playlists abertas e muito afeto comunitário."
 layout: "catalog"
 contributors: []
+translationKey: "courses-index"
 ---
 
 A FACODI organiza os cursos a partir de planos curriculares oficiais, respeitando versões, semestres e competências previstas. Cada curso recebe um tratamento carinhoso: unidades curriculares detalhadas, tópicos associados, playlists priorizadas e espaço para a comunidade sugerir novos materiais. Chega junto, mona, porque aqui a jornada acadêmica é aberta, transparente e feita para compartilhar.

--- a/content/courses/lesti/_index.en.md
+++ b/content/courses/lesti/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Licenciatura em Engenharia de Sistemas e Tecnologias da Informação"
+title: "Bachelor in Information Systems and Technologies Engineering"
 code: "LESTI"
 plan_version: "2025/2026"
 degree: "bachelor"
@@ -8,7 +8,7 @@ duration_semesters: 6
 institution: "Universidade do Algarve"
 school: "Escola Superior de Tecnologia"
 language: "pt"
-summary: "Plano 2025/2026 com formação sólida em matemática, computação, engenharia de software e projetos aplicados."
+summary: "2025/2026 curriculum with strong foundations in mathematics, computing, software engineering and applied projects."
 layout: "course"
 ucs:
   - code: "19411003"
@@ -100,7 +100,6 @@ ucs:
 contributors: []
 translationKey: "course-lesti"
 ---
+The LESTI degree structures the 2025/2026 plan into six semesters that balance scientific foundations (mathematics, physics and probability) with core computing skills (programming, operating systems, networks, databases, artificial intelligence and data science).
 
-A licenciatura LESTI estrutura o plano 2025/2026 em seis semestres que equilibram bases científicas (matemática, física e probabilidade) com competências nucleares de computação (programação, sistemas operativos, redes, bases de dados, inteligência artificial e ciência de dados).
-
-Ao longo do curso, as unidades optativas permitem direcionar a formação para eletrónica/energia ou ciências informáticas, enquanto projetos em empresa e o estágio/projeto final consolidam a aplicação prática do conhecimento em contextos reais.
+Throughout the program, optional units allow the journey to lean into electronics/energy or computer science, while in-company projects and the final internship/project ensure the knowledge is applied in real contexts.

--- a/content/courses/lesti/_index.es.md
+++ b/content/courses/lesti/_index.es.md
@@ -1,5 +1,5 @@
 ---
-title: "Licenciatura em Engenharia de Sistemas e Tecnologias da Informação"
+title: "Licenciatura en Ingeniería de Sistemas y Tecnologías de la Información"
 code: "LESTI"
 plan_version: "2025/2026"
 degree: "bachelor"
@@ -8,7 +8,7 @@ duration_semesters: 6
 institution: "Universidade do Algarve"
 school: "Escola Superior de Tecnologia"
 language: "pt"
-summary: "Plano 2025/2026 com formação sólida em matemática, computação, engenharia de software e projetos aplicados."
+summary: "Plan 2025/2026 con formación sólida en matemáticas, computación, ingeniería de software y proyectos aplicados."
 layout: "course"
 ucs:
   - code: "19411003"
@@ -100,7 +100,6 @@ ucs:
 contributors: []
 translationKey: "course-lesti"
 ---
+La licenciatura LESTI estructura el plan 2025/2026 en seis semestres que equilibran bases científicas (matemática, física y probabilidad) con competencias nucleares de computación (programación, sistemas operativos, redes, bases de datos, inteligencia artificial y ciencia de datos).
 
-A licenciatura LESTI estrutura o plano 2025/2026 em seis semestres que equilibram bases científicas (matemática, física e probabilidade) com competências nucleares de computação (programação, sistemas operativos, redes, bases de dados, inteligência artificial e ciência de dados).
-
-Ao longo do curso, as unidades optativas permitem direcionar a formação para eletrónica/energia ou ciências informáticas, enquanto projetos em empresa e o estágio/projeto final consolidam a aplicação prática do conhecimento em contextos reais.
+A lo largo del curso, las asignaturas optativas permiten orientar la formación hacia electrónica/energía o ciencias informáticas, mientras los proyectos en empresas y el trabajo final aseguran la aplicación práctica del conocimiento en contextos reales.

--- a/content/courses/lesti/_index.fr.md
+++ b/content/courses/lesti/_index.fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Licenciatura em Engenharia de Sistemas e Tecnologias da Informação"
+title: "Licence en Ingénierie des Systèmes et Technologies de l’Information"
 code: "LESTI"
 plan_version: "2025/2026"
 degree: "bachelor"
@@ -8,7 +8,7 @@ duration_semesters: 6
 institution: "Universidade do Algarve"
 school: "Escola Superior de Tecnologia"
 language: "pt"
-summary: "Plano 2025/2026 com formação sólida em matemática, computação, engenharia de software e projetos aplicados."
+summary: "Programme 2025/2026 avec bases solides en mathématiques, informatique, ingénierie logicielle et projets appliqués."
 layout: "course"
 ucs:
   - code: "19411003"
@@ -100,7 +100,6 @@ ucs:
 contributors: []
 translationKey: "course-lesti"
 ---
+La licence LESTI organise le programme 2025/2026 en six semestres qui équilibrent les bases scientifiques (mathématiques, physique et probabilité) avec les compétences fondamentales en informatique (programmation, systèmes d’exploitation, réseaux, bases de données, intelligence artificielle et science des données).
 
-A licenciatura LESTI estrutura o plano 2025/2026 em seis semestres que equilibram bases científicas (matemática, física e probabilidade) com competências nucleares de computação (programação, sistemas operativos, redes, bases de dados, inteligência artificial e ciência de dados).
-
-Ao longo do curso, as unidades optativas permitem direcionar a formação para eletrónica/energia ou ciências informáticas, enquanto projetos em empresa e o estágio/projeto final consolidam a aplicação prática do conhecimento em contextos reais.
+Tout au long du cursus, les unités optionnelles permettent d’orienter la formation vers l’électronique/énergie ou l’informatique, tandis que les projets en entreprise et le stage ou projet final garantissent l’application pratique des connaissances dans des contextes réels.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -49,5 +49,21 @@
   { "id": "uc.playlists", "translation": "Playlists" },
   { "id": "uc.noPlaylists", "translation": "No playlists registered yet. How about suggesting one in the FACODI channels?" },
   { "id": "uc.learningOutcomes", "translation": "Learning outcomes" },
-  { "id": "uc.noLearningOutcomes", "translation": "We are still building the learning outcomes for this unit with the community." }
+  { "id": "uc.noLearningOutcomes", "translation": "We are still building the learning outcomes for this unit with the community." },
+
+  { "id": "list.noPages", "translation": "There are no published pages yet." },
+  { "id": "list.readMore", "translation": "Read more" },
+  { "id": "list.pageSingular", "translation": "page" },
+  { "id": "list.pagePlural", "translation": "pages" },
+
+  { "id": "taxonomy.tag", "translation": "Tag" },
+  { "id": "taxonomy.tagPlural", "translation": "Tags" },
+  { "id": "taxonomy.category", "translation": "Category" },
+  { "id": "taxonomy.categoryPlural", "translation": "Categories" },
+  { "id": "taxonomy.contributor", "translation": "Contributor" },
+  { "id": "taxonomy.contributorPlural", "translation": "Contributors" },
+  { "id": "taxonomy.termHeading", "translation": "{{ .Label }}: {{ .Term }}" },
+  { "id": "taxonomy.termsTitle", "translation": "All {{ .Label }}" },
+  { "id": "taxonomy.noTerms", "translation": "No terms published yet." },
+  { "id": "taxonomy.noPages", "translation": "No content has been published under this term yet." }
 ]

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -49,5 +49,21 @@
   { "id": "uc.playlists", "translation": "Playlists" },
   { "id": "uc.noPlaylists", "translation": "Ninguna playlist registrada por ahora. ¿Qué tal sugerir una en los canales de FACODI?" },
   { "id": "uc.learningOutcomes", "translation": "Resultados de aprendizaje" },
-  { "id": "uc.noLearningOutcomes", "translation": "Todavía estamos construyendo los resultados de aprendizaje de esta unidad con la comunidad." }
+  { "id": "uc.noLearningOutcomes", "translation": "Todavía estamos construyendo los resultados de aprendizaje de esta unidad con la comunidad." },
+
+  { "id": "list.noPages", "translation": "Todavía no hay páginas publicadas." },
+  { "id": "list.readMore", "translation": "Leer más" },
+  { "id": "list.pageSingular", "translation": "página" },
+  { "id": "list.pagePlural", "translation": "páginas" },
+
+  { "id": "taxonomy.tag", "translation": "Etiqueta" },
+  { "id": "taxonomy.tagPlural", "translation": "Etiquetas" },
+  { "id": "taxonomy.category", "translation": "Categoría" },
+  { "id": "taxonomy.categoryPlural", "translation": "Categorías" },
+  { "id": "taxonomy.contributor", "translation": "Persona colaboradora" },
+  { "id": "taxonomy.contributorPlural", "translation": "Personas colaboradoras" },
+  { "id": "taxonomy.termHeading", "translation": "{{ .Label }}: {{ .Term }}" },
+  { "id": "taxonomy.termsTitle", "translation": "Todas las {{ .Label }}" },
+  { "id": "taxonomy.noTerms", "translation": "Todavía no publicamos términos." },
+  { "id": "taxonomy.noPages", "translation": "Todavía no hay contenidos publicados para este término." }
 ]

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -49,5 +49,21 @@
   { "id": "uc.playlists", "translation": "Playlists" },
   { "id": "uc.noPlaylists", "translation": "Aucune playlist enregistrée pour l’instant. Pourquoi ne pas en proposer une sur les canaux FACODI ?" },
   { "id": "uc.learningOutcomes", "translation": "Résultats d’apprentissage" },
-  { "id": "uc.noLearningOutcomes", "translation": "Nous construisons encore les résultats d’apprentissage de cette unité avec la communauté." }
+  { "id": "uc.noLearningOutcomes", "translation": "Nous construisons encore les résultats d’apprentissage de cette unité avec la communauté." },
+
+  { "id": "list.noPages", "translation": "Aucune page publiée pour le moment." },
+  { "id": "list.readMore", "translation": "En savoir plus" },
+  { "id": "list.pageSingular", "translation": "page" },
+  { "id": "list.pagePlural", "translation": "pages" },
+
+  { "id": "taxonomy.tag", "translation": "Étiquette" },
+  { "id": "taxonomy.tagPlural", "translation": "Étiquettes" },
+  { "id": "taxonomy.category", "translation": "Catégorie" },
+  { "id": "taxonomy.categoryPlural", "translation": "Catégories" },
+  { "id": "taxonomy.contributor", "translation": "Contributrice ou contributeur" },
+  { "id": "taxonomy.contributorPlural", "translation": "Contributrices et contributeurs" },
+  { "id": "taxonomy.termHeading", "translation": "{{ .Label }} : {{ .Term }}" },
+  { "id": "taxonomy.termsTitle", "translation": "Toutes les {{ .Label }}" },
+  { "id": "taxonomy.noTerms", "translation": "Aucun terme publié pour le moment." },
+  { "id": "taxonomy.noPages", "translation": "Aucun contenu publié pour ce terme pour le moment." }
 ]

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -49,5 +49,21 @@
   { "id": "uc.playlists", "translation": "Playlists" },
   { "id": "uc.noPlaylists", "translation": "Nenhuma playlist cadastrada por enquanto. Que tal sugerir uma nos canais da FACODI?" },
   { "id": "uc.learningOutcomes", "translation": "Resultados de Aprendizagem" },
-  { "id": "uc.noLearningOutcomes", "translation": "Ainda estamos construindo os resultados de aprendizagem desta UC com a comunidade." }
+  { "id": "uc.noLearningOutcomes", "translation": "Ainda estamos construindo os resultados de aprendizagem desta UC com a comunidade." },
+
+  { "id": "list.noPages", "translation": "Ainda não há páginas publicadas." },
+  { "id": "list.readMore", "translation": "Ler mais" },
+  { "id": "list.pageSingular", "translation": "página" },
+  { "id": "list.pagePlural", "translation": "páginas" },
+
+  { "id": "taxonomy.tag", "translation": "Etiqueta" },
+  { "id": "taxonomy.tagPlural", "translation": "Etiquetas" },
+  { "id": "taxonomy.category", "translation": "Categoria" },
+  { "id": "taxonomy.categoryPlural", "translation": "Categorias" },
+  { "id": "taxonomy.contributor", "translation": "Contribuinte" },
+  { "id": "taxonomy.contributorPlural", "translation": "Contribuintes" },
+  { "id": "taxonomy.termHeading", "translation": "{{ .Label }}: {{ .Term }}" },
+  { "id": "taxonomy.termsTitle", "translation": "Todas as {{ .Label }}" },
+  { "id": "taxonomy.noTerms", "translation": "Ainda não publicamos termos." },
+  { "id": "taxonomy.noPages", "translation": "Ainda não existe conteúdo publicado para este termo." }
 ]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,46 @@
+{{ define "main" }}
+<section class="section container py-5">
+  <div class="row justify-content-center mb-5">
+    <div class="col-lg-8 text-center">
+      <h1 class="mb-3">{{ .Title }}</h1>
+      {{ with .Params.lead }}<p class="lead">{{ . }}</p>{{ end }}
+      {{ with .Content }}<div class="content text-start">{{ . }}</div>{{ end }}
+    </div>
+  </div>
+  {{ $pages := .RegularPagesRecursive }}
+  {{ if not (len $pages) }}
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="alert alert-info" role="alert">{{ i18n "list.noPages" }}</div>
+    </div>
+  </div>
+  {{ else }}
+  {{ $paginator := .Paginate $pages }}
+  <div class="row g-4">
+    {{ range $paginator.Pages }}
+    <div class="col-md-6 col-xl-4">
+      <article class="card h-100 border-0 shadow-sm">
+        <div class="card-body d-flex flex-column">
+          <h2 class="h5 mb-2"><a class="stretched-link" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+          {{ with .Summary }}<p class="text-muted small">{{ . }}</p>{{ end }}
+          <div class="mt-auto d-flex align-items-center justify-content-between">
+            {{ if not .Date.IsZero }}
+            <time class="text-muted small" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "02 MMM 2006" }}</time>
+            {{ end }}
+            <span class="text-primary fw-semibold small">{{ i18n "list.readMore" }}</span>
+          </div>
+        </div>
+      </article>
+    </div>
+    {{ end }}
+  </div>
+  {{ if gt $paginator.TotalPages 1 }}
+  <div class="row mt-4">
+    <div class="col">
+      {{ template "_internal/pagination.html" . }}
+    </div>
+  </div>
+  {{ end }}
+  {{ end }}
+</section>
+{{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,50 @@
+{{ define "main" }}
+{{ $labelKey := printf "taxonomy.%s" .Data.Singular }}
+{{ $label := i18n $labelKey }}
+<section class="section container py-5">
+  <div class="row justify-content-center mb-5">
+    <div class="col-lg-8 text-center">
+      <span class="badge bg-primary-subtle text-primary">{{ $label }}</span>
+      <h1 class="display-6 mt-3">{{ i18n "taxonomy.termHeading" (dict "Label" $label "Term" .Title) }}</h1>
+      {{ with .Content }}<div class="content text-start mt-4">{{ . }}</div>{{ end }}
+      {{ $count := len .Pages }}
+      <p class="text-muted small mt-3">{{ $count }} {{ if eq $count 1 }}{{ i18n "list.pageSingular" }}{{ else }}{{ i18n "list.pagePlural" }}{{ end }}</p>
+    </div>
+  </div>
+  {{ $pages := .RegularPages }}
+  {{ if not (len $pages) }}
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="alert alert-info" role="alert">{{ i18n "taxonomy.noPages" }}</div>
+    </div>
+  </div>
+  {{ else }}
+  {{ $paginator := .Paginate $pages }}
+  <div class="row g-4">
+    {{ range $paginator.Pages }}
+    <div class="col-md-6 col-xl-4">
+      <article class="card h-100 border-0 shadow-sm">
+        <div class="card-body d-flex flex-column">
+          <h2 class="h5 mb-2"><a class="stretched-link" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+          {{ with .Summary }}<p class="text-muted small">{{ . }}</p>{{ end }}
+          <div class="mt-auto d-flex align-items-center justify-content-between">
+            {{ if not .Date.IsZero }}
+            <time class="text-muted small" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "02 MMM 2006" }}</time>
+            {{ end }}
+            <span class="text-primary fw-semibold small">{{ i18n "list.readMore" }}</span>
+          </div>
+        </div>
+      </article>
+    </div>
+    {{ end }}
+  </div>
+  {{ if gt $paginator.TotalPages 1 }}
+  <div class="row mt-4">
+    <div class="col">
+      {{ template "_internal/pagination.html" . }}
+    </div>
+  </div>
+  {{ end }}
+  {{ end }}
+</section>
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,33 @@
+{{ define "main" }}
+{{ $labelPlural := i18n (printf "taxonomy.%sPlural" .Data.Plural) }}
+<section class="section container py-5">
+  <div class="row justify-content-center mb-5">
+    <div class="col-lg-8 text-center">
+      <h1 class="mb-3">{{ i18n "taxonomy.termsTitle" (dict "Label" $labelPlural) }}</h1>
+      {{ with .Content }}<div class="content text-start">{{ . }}</div>{{ end }}
+    </div>
+  </div>
+  {{ $terms := .Data.Terms }}
+  {{ if not $terms }}
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="alert alert-info" role="alert">{{ i18n "taxonomy.noTerms" }}</div>
+    </div>
+  </div>
+  {{ else }}
+  <div class="row g-4">
+    {{ range sort $terms "Page.Title" }}
+    <div class="col-md-6 col-xl-4">
+      <a class="card h-100 border-0 shadow-sm text-reset text-decoration-none" href="{{ .Page.RelPermalink }}">
+        <div class="card-body d-flex flex-column">
+          <h2 class="h5 mb-1">{{ .Page.Title }}</h2>
+          {{ $count := .Count }}
+          <p class="text-muted small mb-0">{{ $count }} {{ if eq $count 1 }}{{ i18n "list.pageSingular" }}{{ else }}{{ i18n "list.pagePlural" }}{{ end }}</p>
+        </div>
+      </a>
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+</section>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,7 @@
             <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
           </div>
           <div class="facodi-hero__actions">
-            <a class="facodi-hero__cta" href="/courses/" role="button">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-hero__cta" href="{{ relLangURL "courses/" }}" role="button">{{ i18n "nav.viewTracks" }}</a>
             <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.ecosystemCta" }}</a>
           </div>
           <div class="facodi-hero__meta">
@@ -95,7 +95,7 @@
           <p class="facodi-section__subtitle">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
         </div>
         <div class="facodi-section__cta">
-          <a class="facodi-link facodi-link--cta" href="/courses/">{{ i18n "home.viewAllCourses" }}</a>
+          <a class="facodi-link facodi-link--cta" href="{{ relLangURL "courses/" }}">{{ i18n "home.viewAllCourses" }}</a>
         </div>
       </div>
       <div class="facodi-grid facodi-grid--courses">
@@ -167,7 +167,7 @@
       <h2 class="section-title facodi-cta__title">Bora colar com a FACODI?</h2>
       <p class="facodi-cta__description">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
       <div class="facodi-cta__actions">
-        <a class="facodi-hero__cta" href="/courses/">{{ i18n "home.viewCurricula" }}</a>
+        <a class="facodi-hero__cta" href="{{ relLangURL "courses/" }}">{{ i18n "home.viewCurricula" }}</a>
         <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.contactMonynha" }}</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the custom home layout to `layouts/index.html` and ensure internal CTAs use Hugo's language-aware links
- add reusable `_default` list, taxonomy and terms templates to match Hugo lookup rules and surface localized messaging
- translate the home, course catalog and LESTI course pages into EN/ES/FR and extend the i18n dictionaries for shared strings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d031af3c188322a2386724aed921b3