### PR TITLE
Finalize client-side i18n setup

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,33 @@
 const THEME_STORAGE_KEY = 'facodi-theme-preference';
+const LANGUAGE_STORAGE_KEY = 'facodi-language-preference';
 const root = document.documentElement;
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const defaultLocale = (root.dataset.defaultLocale || root.lang || 'pt').toLowerCase();
+
+function decodeHtml(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const div = document.createElement('div');
+  div.innerHTML = value;
+  return div.textContent;
+}
+
+function parseJsonScript(id) {
+  const element = document.getElementById(id);
+  if (!element) {
+    return null;
+  }
+  try {
+    return JSON.parse(element.textContent || 'null');
+  } catch (error) {
+    return null;
+  }
+}
+
+const translations = parseJsonScript('facodi-i18n') || {};
+const localeConfig = parseJsonScript('facodi-language-config') || [];
+window.facodiTranslationsData = translations;
 
 function readStoredTheme() {
   try {
@@ -30,6 +57,223 @@ function applyTheme(value, persist = true) {
   }
 }
 
+function normalizeLanguage(value) {
+  if (!value && value !== 0) {
+    return '';
+  }
+  return String(value).trim().toLowerCase();
+}
+
+function readStoredLanguage() {
+  try {
+    return normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY));
+  } catch (error) {
+    return '';
+  }
+}
+
+function storeLanguage(value) {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, value);
+  } catch (error) {
+    // Ignore storage errors.
+  }
+}
+
+function getAvailableLocales() {
+  if (Array.isArray(localeConfig) && localeConfig.length) {
+    return localeConfig;
+  }
+  const code = root.lang || defaultLocale;
+  return [{ code: normalizeLanguage(code), label: code.toUpperCase() }];
+}
+
+function getDefaultLanguage() {
+  const locales = getAvailableLocales();
+  const preferred = locales.find((item) => item && (item.default || item.isDefault));
+  if (preferred) {
+    return normalizeLanguage(preferred.code || preferred.Code);
+  }
+  return defaultLocale;
+}
+
+function getSupportedLanguage(value) {
+  const lang = normalizeLanguage(value);
+  if (lang && translations[lang]) {
+    return lang;
+  }
+  const short = lang.split('-')[0];
+  if (short && translations[short]) {
+    return short;
+  }
+  return '';
+}
+
+function getInitialLanguage() {
+  const params = new URLSearchParams(window.location.search || '');
+  const queryLang = getSupportedLanguage(params.get('lang'));
+  if (queryLang) {
+    return queryLang;
+  }
+  const stored = getSupportedLanguage(readStoredLanguage());
+  if (stored) {
+    return stored;
+  }
+  const navigatorLang = getSupportedLanguage((navigator.language || navigator.userLanguage || '').toLowerCase());
+  if (navigatorLang) {
+    return navigatorLang;
+  }
+  return getSupportedLanguage(defaultLocale) || Object.keys(translations)[0] || defaultLocale;
+}
+
+function getTranslationMap(language) {
+  const lang = normalizeLanguage(language);
+  if (translations[lang]) {
+    return translations[lang];
+  }
+  const short = lang.split('-')[0];
+  if (translations[short]) {
+    return translations[short];
+  }
+  return translations[defaultLocale] || {};
+}
+
+function replacePlaceholders(template, options) {
+  if (typeof template !== 'string') {
+    return template;
+  }
+  const values = options || {};
+  return template.replace(/\{\{\s*\.?([A-Za-z0-9_]+)\s*\}\}/g, (match, key) => {
+    if (Object.prototype.hasOwnProperty.call(values, key)) {
+      return String(values[key]);
+    }
+    return match;
+  });
+}
+
+function parseOptions(attributeValue) {
+  if (!attributeValue) {
+    return {};
+  }
+  try {
+    const decoded = decodeHtml(attributeValue);
+    return JSON.parse(decoded);
+  } catch (error) {
+    return {};
+  }
+}
+
+function renderTranslation(key, language, options) {
+  if (!key) {
+    return null;
+  }
+  const map = getTranslationMap(language);
+  const fallbackMap = getTranslationMap(defaultLocale);
+  let value = map[key];
+  if (value === undefined) {
+    value = fallbackMap[key];
+  }
+  if (value === undefined) {
+    return null;
+  }
+  return replacePlaceholders(value, options);
+}
+
+function applyElementTranslation(element, language) {
+  const key = element.getAttribute('data-i18n');
+  if (!key) {
+    return;
+  }
+  const options = parseOptions(element.getAttribute('data-i18n-options'));
+  const isHtml = element.hasAttribute('data-i18n-html');
+  const value = renderTranslation(key, language, options);
+  if (value === null) {
+    return;
+  }
+  if (isHtml) {
+    element.innerHTML = value;
+  } else {
+    element.textContent = value;
+  }
+}
+
+function applyAttributeTranslations(element, language) {
+  const spec = element.getAttribute('data-i18n-attr');
+  if (!spec) {
+    return;
+  }
+  const options = parseOptions(element.getAttribute('data-i18n-options'));
+  const parts = spec.split(',');
+  parts.forEach((entry) => {
+    const [attrNameRaw, keyRaw] = entry.split(':');
+    const attrName = attrNameRaw ? attrNameRaw.trim() : '';
+    const key = keyRaw ? keyRaw.trim() : '';
+    if (!attrName || !key) {
+      return;
+    }
+    const value = renderTranslation(key, language, options);
+    if (value !== null) {
+      element.setAttribute(attrName, value);
+    }
+  });
+}
+
+function setDocumentLanguage(language) {
+  const lang = normalizeLanguage(language) || defaultLocale;
+  root.lang = lang;
+  root.dataset.locale = lang;
+  const body = document.body;
+  if (body) {
+    body.dataset.lang = lang;
+  }
+  window.facodiCurrentLocale = lang;
+}
+
+function applyTranslations(language) {
+  const lang = normalizeLanguage(language) || defaultLocale;
+  const elements = document.querySelectorAll('[data-i18n]');
+  elements.forEach((element) => applyElementTranslation(element, lang));
+
+  const attrElements = document.querySelectorAll('[data-i18n-attr]');
+  attrElements.forEach((element) => applyAttributeTranslations(element, lang));
+
+  const select = document.querySelector('[data-facodi-language-select]');
+  if (select && normalizeLanguage(select.value) !== lang) {
+    select.value = lang;
+  }
+
+  setDocumentLanguage(lang);
+  document.dispatchEvent(new CustomEvent('facodi:language-change', { detail: { language: lang } }));
+}
+
+function setLanguage(language, { persist = true } = {}) {
+  const supported = getSupportedLanguage(language) || getDefaultLanguage();
+  applyTranslations(supported);
+  if (persist) {
+    storeLanguage(supported);
+  }
+}
+
+function initLanguageSystem() {
+  const select = document.querySelector('[data-facodi-language-select]');
+  const initial = getInitialLanguage();
+  setLanguage(initial, { persist: false });
+
+  if (select) {
+    const locales = getAvailableLocales();
+    const hasOption = locales.some((item) => normalizeLanguage(item.code || item.Code) === normalizeLanguage(select.value));
+    if (!hasOption && locales.length) {
+      select.value = normalizeLanguage(locales[0].code || locales[0].Code || defaultLocale);
+    }
+    select.addEventListener('change', (event) => {
+      const target = normalizeLanguage(event.target.value);
+      if (target) {
+        setLanguage(target);
+      }
+    });
+  }
+}
+
 function initTheme() {
   const stored = readStoredTheme();
   const initial = stored || root.dataset.theme || (prefersDark.matches ? 'dark' : 'light');
@@ -56,21 +300,26 @@ function initTheme() {
   }
 }
 
-function initLanguageSwitcher() {
-  const select = document.querySelector('[data-facodi-language-select]');
-  if (!select) {
+function refreshDynamicContent() {
+  if (!window.facodiLoaders) {
     return;
   }
-
-  select.addEventListener('change', (event) => {
-    const target = event.target.value;
-    if (target && typeof target === 'string') {
-      window.location.assign(target);
-    }
-  });
+  const body = document.body || {};
+  const dataset = body.dataset || {};
+  const context = Object.assign({}, dataset, window.facodiPageContext || {});
+  if (context.course) {
+    window.facodiLoaders.loadCoursePage(context.course, context.plan || context.planVersion);
+  }
+  if (context.uc) {
+    window.facodiLoaders.loadUCPage(context.uc);
+  }
+  if (context.topic) {
+    window.facodiLoaders.loadTopicPage(context.topic);
+  }
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  initLanguageSystem();
   initTheme();
-  initLanguageSwitcher();
+  document.addEventListener('facodi:language-change', refreshDynamicContent);
 });

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -5,27 +5,3 @@
   [pt.params]
     languageISO = "PT"
     languageTag = "pt-PT"
-
-[en]
-  languageName = "English"
-  contentDir = "content"
-  weight = 5
-  [en.params]
-    languageISO = "EN"
-    languageTag = "en-US"
-
-[fr]
-  languageName = "Français"
-  contentDir = "content"
-  weight = 10
-  [fr.params]
-    languageISO = "FR"
-    languageTag = "fr-FR"
-
-[es]
-  languageName = "Español"
-  contentDir = "content"
-  weight = 15
-  [es.params]
-    languageISO = "ES"
-    languageTag = "es-ES"

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Home"
+  identifier = "home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Courses"
+  identifier = "courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Roadmap"
+  identifier = "roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Privacy Policy"
+  identifier = "privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.es.toml
+++ b/config/_default/menus/menus.es.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Inicio"
+  identifier = "home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cursos"
+  identifier = "courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Hoja de ruta"
+  identifier = "roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Política de privacidad"
+  identifier = "privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.fr.toml
+++ b/config/_default/menus/menus.fr.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Accueil"
+  identifier = "home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cours"
+  identifier = "courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Feuille de route"
+  identifier = "roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Politique de confidentialité"
+  identifier = "privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.pt.toml
+++ b/config/_default/menus/menus.pt.toml
@@ -18,16 +18,19 @@
 
 [[main]]
   name = "Início"
+  identifier = "home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cursos"
+  identifier = "courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Roadmap"
+  identifier = "roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
@@ -67,6 +70,7 @@
 
 [[footer]]
   name = "Política de Privacidade"
+  identifier = "privacy"
   url = "/privacy/"
   weight = 10
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -7,6 +7,19 @@ images = ["cover.png"]
   supabaseUrl = ""
   supabaseAnonKey = ""
   defaultLocale = "pt"
+  [[facodi.locales]]
+    code = "pt"
+    label = "Português"
+    default = true
+  [[facodi.locales]]
+    code = "en"
+    label = "English"
+  [[facodi.locales]]
+    code = "fr"
+    label = "Français"
+  [[facodi.locales]]
+    code = "es"
+    label = "Español"
 
 # mainSections
 mainSections = ["docs"]
@@ -56,7 +69,7 @@ mainSections = ["docs"]
   scrollSpy = true # true (default) or false
 
   # Multilingual
-  multilingualMode = true # false (default) or true
+  multilingualMode = false # false (default) or true
   showMissingLanguages = true # whether or not to show untranslated languages in the language menu; true (default) or false
 
   # Versioning

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -108,12 +108,164 @@
     "translation": "Navigation"
   },
   {
+    "id": "footer.tagline",
+    "translation": "Official curricula, open playlists, and community tech for everyone who believes in open education."
+  },
+  {
     "id": "home.contactMonynha",
     "translation": "Talk to Monynha and suggest resources"
   },
   {
+    "id": "home.courses.eyebrow",
+    "translation": "Available tracks"
+  },
+  {
+    "id": "home.courses.subtitle",
+    "translation": "Discover the degrees that already have open playlists and plans."
+  },
+  {
+    "id": "home.courses.title",
+    "translation": "Explore the catalogued courses"
+  },
+  {
+    "id": "home.courses.ucFoot",
+    "translation": "{{ .Count }} curricular units in this track"
+  },
+  {
+    "id": "home.cta.description",
+    "translation": "Join the curation, suggest playlists, and strengthen the community digital university."
+  },
+  {
+    "id": "home.cta.title",
+    "translation": "Shall we build FACODI together?"
+  },
+  {
     "id": "home.ecosystemCta",
     "translation": "Discover the Monynha Softwares ecosystem"
+  },
+  {
+    "id": "home.features.community.description",
+    "translation": "We co-create an inclusive, accessible collection filled with Monynha pride."
+  },
+  {
+    "id": "home.features.community.title",
+    "translation": "Diverse community"
+  },
+  {
+    "id": "home.features.curriculum.description",
+    "translation": "Each track starts from an accredited course plan from Brazilian universities."
+  },
+  {
+    "id": "home.features.curriculum.title",
+    "translation": "Official curricula"
+  },
+  {
+    "id": "home.features.eyebrow",
+    "translation": "Why FACODI matters"
+  },
+  {
+    "id": "home.features.playlists.description",
+    "translation": "We map videos, podcasts, and open materials to cover every curricular unit."
+  },
+  {
+    "id": "home.features.playlists.title",
+    "translation": "Open playlists"
+  },
+  {
+    "id": "home.features.progress.description",
+    "translation": "Follow what you have already studied and see contributions from the collective."
+  },
+  {
+    "id": "home.features.progress.title",
+    "translation": "Community progress"
+  },
+  {
+    "id": "home.features.subtitle",
+    "translation": "We organise real curricula and connect open resources so you can learn with autonomy."
+  },
+  {
+    "id": "home.features.title",
+    "translation": "A portal built for community-driven study"
+  },
+  {
+    "id": "home.hero.badge",
+    "translation": "Community-powered learning"
+  },
+  {
+    "id": "home.hero.cardFoot",
+    "translation": "Data curated collectively by the FACODI community."
+  },
+  {
+    "id": "home.hero.cardItemCourses",
+    "translation": "{{ .Count }} published courses"
+  },
+  {
+    "id": "home.hero.cardItemUcs",
+    "translation": "{{ .Count }} mapped curricular units"
+  },
+  {
+    "id": "home.hero.cardItemVersions",
+    "translation": "Public record of curriculum versions"
+  },
+  {
+    "id": "home.hero.cardLabel",
+    "translation": "What is available so far"
+  },
+  {
+    "id": "home.hero.metaPrimary.text",
+    "translation": "Every track is linked to real undergraduate curricula."
+  },
+  {
+    "id": "home.hero.metaPrimary.title",
+    "translation": "Official plans"
+  },
+  {
+    "id": "home.hero.metaSecondary.text",
+    "translation": "Playlists, materials, and tools you can access without barriers."
+  },
+  {
+    "id": "home.hero.metaSecondary.title",
+    "translation": "Open resources"
+  },
+  {
+    "id": "home.hero.title",
+    "translation": "Official curricula, open playlists, community care"
+  },
+  {
+    "id": "home.journey.eyebrow",
+    "translation": "How it works"
+  },
+  {
+    "id": "home.journey.steps.one",
+    "translation": "Choose a course and understand how the curriculum is organised."
+  },
+  {
+    "id": "home.journey.steps.three",
+    "translation": "Share new resources and help update the plan."
+  },
+  {
+    "id": "home.journey.steps.two",
+    "translation": "Open the playlists and open resources recommended by the community."
+  },
+  {
+    "id": "home.journey.subtitle",
+    "translation": "Three simple steps to learn with the community."
+  },
+  {
+    "id": "home.journey.title",
+    "translation": "Your journey with FACODI"
+  },
+  {
+    "id": "home.manifesto.description",
+    "translation": "We stand for free access, diversity, and collaboration so everyone can learn together."
+  },
+  {
+    "id": "home.manifesto.eyebrow",
+    "translation": "FACODI manifesto"
+  },
+  {
+    "id": "home.manifesto.title",
+    "translation": "Open education with a community heartbeat"
   },
   {
     "id": "home.readManifesto",
@@ -158,6 +310,22 @@
   {
     "id": "nav.languageLabel",
     "translation": "Select language"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Courses"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Home"
+  },
+  {
+    "id": "nav.menu.privacy",
+    "translation": "Privacy Policy"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Roadmap"
   },
   {
     "id": "nav.openMainMenu",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -108,12 +108,164 @@
     "translation": "Navegación"
   },
   {
+    "id": "footer.tagline",
+    "translation": "Currículos oficiales, playlists libres y tecnología comunitaria para quienes creen en la educación abierta."
+  },
+  {
     "id": "home.contactMonynha",
     "translation": "Habla con Monynha y sugiere materiales"
   },
   {
+    "id": "home.courses.eyebrow",
+    "translation": "Rutas disponibles"
+  },
+  {
+    "id": "home.courses.subtitle",
+    "translation": "Conoce las licenciaturas que ya cuentan con playlists y planes abiertos."
+  },
+  {
+    "id": "home.courses.title",
+    "translation": "Explora los cursos catalogados"
+  },
+  {
+    "id": "home.courses.ucFoot",
+    "translation": "{{ .Count }} unidades curriculares en esta ruta"
+  },
+  {
+    "id": "home.cta.description",
+    "translation": "Súmate a la curaduría, sugiere playlists y fortalece la universidad digital comunitaria."
+  },
+  {
+    "id": "home.cta.title",
+    "translation": "¿Construimos FACODI juntas/os?"
+  },
+  {
     "id": "home.ecosystemCta",
     "translation": "Conoce el ecosistema Monynha Softwares"
+  },
+  {
+    "id": "home.features.community.description",
+    "translation": "Construimos juntas/os un acervo inclusivo, accesible y con orgullo Monynha."
+  },
+  {
+    "id": "home.features.community.title",
+    "translation": "Comunidad diversa"
+  },
+  {
+    "id": "home.features.curriculum.description",
+    "translation": "Cada ruta nace de un plan de curso aprobado por universidades brasileñas."
+  },
+  {
+    "id": "home.features.curriculum.title",
+    "translation": "Currículos oficiales"
+  },
+  {
+    "id": "home.features.eyebrow",
+    "translation": "Por qué existe FACODI"
+  },
+  {
+    "id": "home.features.playlists.description",
+    "translation": "Mapeamos videos, pódcasts y materiales libres para cubrir cada unidad curricular."
+  },
+  {
+    "id": "home.features.playlists.title",
+    "translation": "Playlists abiertas"
+  },
+  {
+    "id": "home.features.progress.description",
+    "translation": "Sigue lo que ya estudiaste y descubre los aportes de la comunidad en cada etapa."
+  },
+  {
+    "id": "home.features.progress.title",
+    "translation": "Progreso comunitario"
+  },
+  {
+    "id": "home.features.subtitle",
+    "translation": "Organizamos currículos reales y conectamos recursos abiertos para que aprendas con autonomía."
+  },
+  {
+    "id": "home.features.title",
+    "translation": "Un portal creado para estudiar en comunidad"
+  },
+  {
+    "id": "home.hero.badge",
+    "translation": "Aprendizaje comunitario"
+  },
+  {
+    "id": "home.hero.cardFoot",
+    "translation": "Datos curados colectivamente por la comunidad FACODI."
+  },
+  {
+    "id": "home.hero.cardItemCourses",
+    "translation": "{{ .Count }} cursos publicados"
+  },
+  {
+    "id": "home.hero.cardItemUcs",
+    "translation": "{{ .Count }} unidades curriculares mapeadas"
+  },
+  {
+    "id": "home.hero.cardItemVersions",
+    "translation": "Historial público de versiones del plan"
+  },
+  {
+    "id": "home.hero.cardLabel",
+    "translation": "Lo que ya está disponible"
+  },
+  {
+    "id": "home.hero.metaPrimary.text",
+    "translation": "Conectamos cada ruta con planes reales de licenciatura."
+  },
+  {
+    "id": "home.hero.metaPrimary.title",
+    "translation": "Planes oficiales"
+  },
+  {
+    "id": "home.hero.metaSecondary.text",
+    "translation": "Playlists, materiales y herramientas libres para estudiar sin barreras."
+  },
+  {
+    "id": "home.hero.metaSecondary.title",
+    "translation": "Recursos abiertos"
+  },
+  {
+    "id": "home.hero.title",
+    "translation": "Currículos oficiales, playlists abiertas y cuidado colectivo"
+  },
+  {
+    "id": "home.journey.eyebrow",
+    "translation": "Cómo funciona"
+  },
+  {
+    "id": "home.journey.steps.one",
+    "translation": "Elige un curso y mira cómo está organizado el currículo."
+  },
+  {
+    "id": "home.journey.steps.three",
+    "translation": "Comparte nuevos recursos y ayuda a actualizar el plan."
+  },
+  {
+    "id": "home.journey.steps.two",
+    "translation": "Abre las playlists y recursos abiertos recomendados por la comunidad."
+  },
+  {
+    "id": "home.journey.subtitle",
+    "translation": "Tres pasos simples para aprender con la comunidad."
+  },
+  {
+    "id": "home.journey.title",
+    "translation": "Tu recorrido en FACODI"
+  },
+  {
+    "id": "home.manifesto.description",
+    "translation": "Defendemos el acceso gratuito, la diversidad y la colaboración para que todas las personas aprendan juntas."
+  },
+  {
+    "id": "home.manifesto.eyebrow",
+    "translation": "Manifiesto FACODI"
+  },
+  {
+    "id": "home.manifesto.title",
+    "translation": "Educación abierta con corazón comunitario"
   },
   {
     "id": "home.readManifesto",
@@ -158,6 +310,22 @@
   {
     "id": "nav.languageLabel",
     "translation": "Seleccionar idioma"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cursos"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Inicio"
+  },
+  {
+    "id": "nav.menu.privacy",
+    "translation": "Política de privacidad"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Hoja de ruta"
   },
   {
     "id": "nav.openMainMenu",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -108,12 +108,164 @@
     "translation": "Navigation"
   },
   {
+    "id": "footer.tagline",
+    "translation": "Programmes officiels, playlists ouvertes et technologie communautaire pour celles et ceux qui croient à l’éducation ouverte."
+  },
+  {
     "id": "home.contactMonynha",
     "translation": "Contacter Monynha et suggérer des ressources"
   },
   {
+    "id": "home.courses.eyebrow",
+    "translation": "Parcours disponibles"
+  },
+  {
+    "id": "home.courses.subtitle",
+    "translation": "Découvrez les licences qui possèdent déjà des playlists et plans ouverts."
+  },
+  {
+    "id": "home.courses.title",
+    "translation": "Explorez les formations répertoriées"
+  },
+  {
+    "id": "home.courses.ucFoot",
+    "translation": "{{ .Count }} unités curriculaires dans ce parcours"
+  },
+  {
+    "id": "home.cta.description",
+    "translation": "Rejoignez la curation, proposez des playlists et renforcez l’université numérique communautaire."
+  },
+  {
+    "id": "home.cta.title",
+    "translation": "On construit FACODI ensemble ?"
+  },
+  {
     "id": "home.ecosystemCta",
     "translation": "Découvrir l’écosystème Monynha Softwares"
+  },
+  {
+    "id": "home.features.community.description",
+    "translation": "Nous construisons ensemble un corpus inclusif, accessible et fier de Monynha."
+  },
+  {
+    "id": "home.features.community.title",
+    "translation": "Communauté diverse"
+  },
+  {
+    "id": "home.features.curriculum.description",
+    "translation": "Chaque parcours provient d’un plan de cours reconnu par des universités brésiliennes."
+  },
+  {
+    "id": "home.features.curriculum.title",
+    "translation": "Programmes officiels"
+  },
+  {
+    "id": "home.features.eyebrow",
+    "translation": "Pourquoi FACODI existe"
+  },
+  {
+    "id": "home.features.playlists.description",
+    "translation": "Nous répertorions vidéos, podcasts et ressources libres pour couvrir chaque unité curriculaire."
+  },
+  {
+    "id": "home.features.playlists.title",
+    "translation": "Playlists ouvertes"
+  },
+  {
+    "id": "home.features.progress.description",
+    "translation": "Suivez ce que vous avez déjà étudié et les contributions de la communauté."
+  },
+  {
+    "id": "home.features.progress.title",
+    "translation": "Progrès communautaire"
+  },
+  {
+    "id": "home.features.subtitle",
+    "translation": "Nous organisons de vrais programmes et connectons des ressources libres pour apprendre en autonomie."
+  },
+  {
+    "id": "home.features.title",
+    "translation": "Un portail créé pour apprendre en communauté"
+  },
+  {
+    "id": "home.hero.badge",
+    "translation": "Apprentissage communautaire"
+  },
+  {
+    "id": "home.hero.cardFoot",
+    "translation": "Données co-curées par la communauté FACODI."
+  },
+  {
+    "id": "home.hero.cardItemCourses",
+    "translation": "{{ .Count }} formations publiées"
+  },
+  {
+    "id": "home.hero.cardItemUcs",
+    "translation": "{{ .Count }} unités curriculaires cartographiées"
+  },
+  {
+    "id": "home.hero.cardItemVersions",
+    "translation": "Historique public des versions du programme"
+  },
+  {
+    "id": "home.hero.cardLabel",
+    "translation": "Ce qui est déjà disponible"
+  },
+  {
+    "id": "home.hero.metaPrimary.text",
+    "translation": "Chaque parcours est relié à de vrais plans de licence."
+  },
+  {
+    "id": "home.hero.metaPrimary.title",
+    "translation": "Programmes officiels"
+  },
+  {
+    "id": "home.hero.metaSecondary.text",
+    "translation": "Playlists, supports et outils libres pour étudier sans barrières."
+  },
+  {
+    "id": "home.hero.metaSecondary.title",
+    "translation": "Ressources ouvertes"
+  },
+  {
+    "id": "home.hero.title",
+    "translation": "Programmes officiels, playlists ouvertes et soin collectif"
+  },
+  {
+    "id": "home.journey.eyebrow",
+    "translation": "Comment ça marche"
+  },
+  {
+    "id": "home.journey.steps.one",
+    "translation": "Choisissez une formation et voyez comment le programme est structuré."
+  },
+  {
+    "id": "home.journey.steps.three",
+    "translation": "Partagez de nouvelles ressources et contribuez à mettre le plan à jour."
+  },
+  {
+    "id": "home.journey.steps.two",
+    "translation": "Ouvrez les playlists et ressources libres recommandées par la communauté."
+  },
+  {
+    "id": "home.journey.subtitle",
+    "translation": "Trois étapes simples pour apprendre avec la communauté."
+  },
+  {
+    "id": "home.journey.title",
+    "translation": "Votre parcours avec FACODI"
+  },
+  {
+    "id": "home.manifesto.description",
+    "translation": "Nous défendons l’accès libre, la diversité et la collaboration pour que tout le monde apprenne ensemble."
+  },
+  {
+    "id": "home.manifesto.eyebrow",
+    "translation": "Manifeste FACODI"
+  },
+  {
+    "id": "home.manifesto.title",
+    "translation": "Éducation ouverte au rythme de la communauté"
   },
   {
     "id": "home.readManifesto",
@@ -158,6 +310,22 @@
   {
     "id": "nav.languageLabel",
     "translation": "Sélectionner la langue"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cours"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Accueil"
+  },
+  {
+    "id": "nav.menu.privacy",
+    "translation": "Politique de confidentialité"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Feuille de route"
   },
   {
     "id": "nav.openMainMenu",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -108,12 +108,164 @@
     "translation": "Navegação"
   },
   {
+    "id": "footer.tagline",
+    "translation": "Currículos oficiais, playlists livres e tecnologia comunitária para quem acredita em educação aberta."
+  },
+  {
     "id": "home.contactMonynha",
     "translation": "Falar com a Monynha e sugerir materiais"
   },
   {
+    "id": "home.courses.eyebrow",
+    "translation": "Trilhas disponíveis"
+  },
+  {
+    "id": "home.courses.subtitle",
+    "translation": "Conheça as licenciaturas que já estão com playlists e planos abertos."
+  },
+  {
+    "id": "home.courses.title",
+    "translation": "Explore os cursos catalogados"
+  },
+  {
+    "id": "home.courses.ucFoot",
+    "translation": "{{ .Count }} unidades curriculares nesta trilha"
+  },
+  {
+    "id": "home.cta.description",
+    "translation": "Faça parte da curadoria, indique playlists e fortaleça a universidade comunitária digital."
+  },
+  {
+    "id": "home.cta.title",
+    "translation": "Bora construir a FACODI juntas(os)?"
+  },
+  {
     "id": "home.ecosystemCta",
     "translation": "Conheça o ecossistema Monynha Softwares"
+  },
+  {
+    "id": "home.features.community.description",
+    "translation": "Construímos juntas(os) um acervo inclusivo, acessível e cheio de orgulho Monynha."
+  },
+  {
+    "id": "home.features.community.title",
+    "translation": "Comunidade diversa"
+  },
+  {
+    "id": "home.features.curriculum.description",
+    "translation": "Cada trilha nasce de um plano de curso homologado por universidades brasileiras."
+  },
+  {
+    "id": "home.features.curriculum.title",
+    "translation": "Currículos oficiais"
+  },
+  {
+    "id": "home.features.eyebrow",
+    "translation": "Por que a FACODI existe"
+  },
+  {
+    "id": "home.features.playlists.description",
+    "translation": "Mapeamos vídeos, podcasts e materiais livres para cobrir cada unidade curricular."
+  },
+  {
+    "id": "home.features.playlists.title",
+    "translation": "Playlists abertas"
+  },
+  {
+    "id": "home.features.progress.description",
+    "translation": "Acompanhe o que já estudou e veja as contribuições da galera para cada etapa."
+  },
+  {
+    "id": "home.features.progress.title",
+    "translation": "Progresso comunitário"
+  },
+  {
+    "id": "home.features.subtitle",
+    "translation": "Organizamos currículos reais e conectamos recursos livres para que você aprenda com autonomia."
+  },
+  {
+    "id": "home.features.title",
+    "translation": "O portal feito para estudar em comunidade"
+  },
+  {
+    "id": "home.hero.badge",
+    "translation": "Educação aberta para todes"
+  },
+  {
+    "id": "home.hero.cardFoot",
+    "translation": "Dados curados coletivamente pela comunidade FACODI."
+  },
+  {
+    "id": "home.hero.cardItemCourses",
+    "translation": "{{ .Count }} cursos publicados"
+  },
+  {
+    "id": "home.hero.cardItemUcs",
+    "translation": "{{ .Count }} unidades curriculares mapeadas"
+  },
+  {
+    "id": "home.hero.cardItemVersions",
+    "translation": "Versões públicas dos planos registradas"
+  },
+  {
+    "id": "home.hero.cardLabel",
+    "translation": "O que já está disponível"
+  },
+  {
+    "id": "home.hero.metaPrimary.text",
+    "translation": "Ligamos cada trilha aos planos curriculares das licenciaturas."
+  },
+  {
+    "id": "home.hero.metaPrimary.title",
+    "translation": "Planos oficiais"
+  },
+  {
+    "id": "home.hero.metaSecondary.text",
+    "translation": "Playlists, materiais e ferramentas livres para estudar sem barreiras."
+  },
+  {
+    "id": "home.hero.metaSecondary.title",
+    "translation": "Recursos abertos"
+  },
+  {
+    "id": "home.hero.title",
+    "translation": "Currículos oficiais, playlists livres e cuidado comunitário"
+  },
+  {
+    "id": "home.journey.eyebrow",
+    "translation": "Como funciona"
+  },
+  {
+    "id": "home.journey.steps.one",
+    "translation": "Escolha um curso e veja como o currículo está organizado."
+  },
+  {
+    "id": "home.journey.steps.three",
+    "translation": "Compartilhe novos recursos e ajude a atualizar o plano."
+  },
+  {
+    "id": "home.journey.steps.two",
+    "translation": "Abra as playlists e materiais abertos recomendados pela comunidade."
+  },
+  {
+    "id": "home.journey.subtitle",
+    "translation": "Três passos simples para estudar com a comunidade."
+  },
+  {
+    "id": "home.journey.title",
+    "translation": "Sua jornada na FACODI"
+  },
+  {
+    "id": "home.manifesto.description",
+    "translation": "Defendemos acesso gratuito, diversidade e colaboração para que todo mundo aprenda junto."
+  },
+  {
+    "id": "home.manifesto.eyebrow",
+    "translation": "Manifesto FACODI"
+  },
+  {
+    "id": "home.manifesto.title",
+    "translation": "Educação aberta com rosto comunitário"
   },
   {
     "id": "home.readManifesto",
@@ -158,6 +310,22 @@
   {
     "id": "nav.languageLabel",
     "translation": "Selecionar idioma"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cursos"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Início"
+  },
+  {
+    "id": "nav.menu.privacy",
+    "translation": "Política de Privacidade"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Roadmap"
   },
   {
     "id": "nav.openMainMenu",

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Lang }}" class="no-js">
+<html lang="{{ .Lang }}" class="no-js" data-default-locale="{{ site.Params.facodi.defaultLocale | default .Lang }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -98,7 +98,7 @@
     {{- end -}}
   {{- end -}}
   <body {{- if gt (len $bodyAttrs) 0 }} {{ delimit $bodyAttrs " " }}{{ end }}>
-    <a class="visually-hidden-focusable" href="#main-content">{{ i18n "common.skipToContent" }}</a>
+    <a class="visually-hidden-focusable" href="#main-content" data-i18n="common.skipToContent">{{ i18n "common.skipToContent" }}</a>
     {{ partial "header/header.html" . }}
     <main id="main-content" class="flex-fill" role="main">
       {{ block "main" . }}{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <section class="facodi-section facodi-section--list py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "list.sectionIntro" }}</span>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="list.sectionIntro">{{ i18n "list.sectionIntro" }}</span>
       <h1 class="section-title mb-3">{{ .Title }}</h1>
       {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
       {{ with .Content }}<div class="content text-start">{{ . }}</div>{{ end }}
@@ -11,7 +11,7 @@
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm" role="status">{{ i18n "list.empty" }}</div>
+      <div class="alert alert-info shadow-sm" role="status" data-i18n="list.empty">{{ i18n "list.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -29,16 +29,16 @@
               </div>
               <footer class="facodi-card__footer">
                 {{ with .PublishDate }}
-                  <span class="facodi-card__meta">{{ i18n "list.published" }} {{ .Format "02 MMMM 2006" }}</span>
+                  <span class="facodi-card__meta"><span data-i18n="list.published">{{ i18n "list.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ .RelPermalink }}">{{ i18n "list.readMore" }}</a>
+                <a class="facodi-card__cta" href="{{ .RelPermalink }}" data-i18n="list.readMore">{{ i18n "list.readMore" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}" data-i18n-attr="aria-label:list.pagination">
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,15 +8,15 @@
           {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
           {{ if or .PublishDate .Lastmod }}
             <p class="facodi-meta text-muted mb-0">
-              {{ with .PublishDate }}<span>{{ i18n "single.published" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
-              {{ with .Lastmod }}<span class="ms-3">{{ i18n "single.updated" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .PublishDate }}<span><span data-i18n="single.published">{{ i18n "single.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .Lastmod }}<span class="ms-3"><span data-i18n="single.updated">{{ i18n "single.updated" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
             </p>
           {{ end }}
         </header>
         <div class="content facodi-content">{{ .Content }}</div>
         {{ with .Params.tags }}
           <footer class="facodi-tags mt-5">
-            <h2 class="h5 mb-3">{{ i18n "single.tags" }}</h2>
+            <h2 class="h5 mb-3" data-i18n="single.tags">{{ i18n "single.tags" }}</h2>
             <div class="facodi-tag-list">
               {{ range . }}<a class="badge rounded-pill bg-light text-muted" href="{{ "tags" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end }}
             </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,15 +2,16 @@
 <section class="facodi-section facodi-section--taxonomy py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "taxonomy.termEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "taxonomy.termTitle" (dict "Term" .Data.Term "Name" .Title) }}</h1>
-      {{ with .Data.Term | humanize }}<p class="lead text-muted">{{ i18n "taxonomy.termIntro" (dict "Term" .) }}</p>{{ end }}
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="taxonomy.termEyebrow">{{ i18n "taxonomy.termEyebrow" }}</span>
+      {{ $termTitleData := dict "Term" .Data.Term "Name" .Title }}
+      <h1 class="section-title mb-3" data-i18n="taxonomy.termTitle" data-i18n-options='{{ $termTitleData | jsonify | htmlEscape }}'>{{ i18n "taxonomy.termTitle" $termTitleData }}</h1>
+      {{ with .Data.Term | humanize }}{{ $termIntroData := dict "Term" . }}<p class="lead text-muted" data-i18n="taxonomy.termIntro" data-i18n-options='{{ $termIntroData | jsonify | htmlEscape }}'>{{ i18n "taxonomy.termIntro" $termIntroData }}</p>{{ end }}
     </header>
     {{ $collection := .Pages }}
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "taxonomy.noEntries" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="taxonomy.noEntries">{{ i18n "taxonomy.noEntries" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -27,14 +28,14 @@
                     {{ range $tags }}<span class="badge bg-light text-muted">{{ . }}</span>{{ end }}
                   </div>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ .RelPermalink }}">{{ i18n "taxonomy.viewEntry" }}</a>
+                <a class="facodi-card__cta" href="{{ .RelPermalink }}" data-i18n="taxonomy.viewEntry">{{ i18n "taxonomy.viewEntry" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}" data-i18n-attr="aria-label:taxonomy.pagination">
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,13 +2,14 @@
 <section class="facodi-section facodi-section--terms py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "terms.overviewEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "terms.overviewTitle" (dict "Taxonomy" (.Title | humanize)) }}</h1>
-      <p class="lead text-muted">{{ i18n "terms.overviewIntro" }}</p>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="terms.overviewEyebrow">{{ i18n "terms.overviewEyebrow" }}</span>
+      {{ $overviewData := dict "Taxonomy" (.Title | humanize) }}
+      <h1 class="section-title mb-3" data-i18n="terms.overviewTitle" data-i18n-options="{{ $overviewData | jsonify | htmlEscape }}">{{ i18n "terms.overviewTitle" $overviewData }}</h1>
+      <p class="lead text-muted" data-i18n="terms.overviewIntro">{{ i18n "terms.overviewIntro" }}</p>
     </header>
     {{ $terms := .Data.Terms.Alphabetical }}
     {{ if not (len $terms) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "terms.empty" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="terms.empty">{{ i18n "terms.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $terms }}
@@ -16,10 +17,10 @@
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
                 <h2 class="h5 facodi-card__title"><a class="facodi-card__link" href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></h2>
-                <p class="facodi-card__meta">{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
+                <p class="facodi-card__meta">{{ $entryData := dict "Count" .Count }}<span data-i18n="terms.entryCount" data-i18n-options="{{ $entryData | jsonify | htmlEscape }}">{{ i18n "terms.entryCount" $entryData }}</span></p>
               </div>
               <footer class="facodi-card__footer">
-                <a class="facodi-card__cta" href="{{ .Page.RelPermalink }}">{{ i18n "terms.viewTerm" }}</a>
+                <a class="facodi-card__cta" href="{{ .Page.RelPermalink }}" data-i18n="terms.viewTerm">{{ i18n "terms.viewTerm" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_partials/footer/footer.html
+++ b/layouts/_partials/footer/footer.html
@@ -3,19 +3,30 @@
     <div class="row gy-4 align-items-start">
       <div class="col-lg-6">
         <h2 class="h5 text-uppercase text-muted">{{ site.Title }}</h2>
-        <p class="mb-3 text-muted">{{ site.Params.description }}</p>
-        <p class="small text-muted mb-0">{{ i18n "footer.license" }}</p>
+        <p class="mb-3 text-muted" data-i18n="footer.tagline">{{ i18n "footer.tagline" }}</p>
+        <p class="small text-muted mb-0" data-i18n="footer.license">{{ i18n "footer.license" }}</p>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.navigation" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.navigation">{{ i18n "footer.navigation" }}</h3>
         <ul class="list-unstyled mb-0">
           {{ range site.Menus.main }}
-            <li><a class="facodi-footer__link" href="{{ .URL | absLangURL }}">{{ .Name }}</a></li>
+            {{- $itemKey := "" -}}
+            {{- with .Identifier -}}
+              {{- $itemKey = printf "nav.menu.%s" . -}}
+            {{- end -}}
+            {{- $itemLabel := .Name -}}
+            {{- if $itemKey -}}
+              {{- $translated := i18n $itemKey -}}
+              {{- if $translated -}}
+                {{- $itemLabel = $translated -}}
+              {{- end -}}
+            {{- end -}}
+            <li><a class="facodi-footer__link" href="{{ .URL | absURL }}"{{ if $itemKey }} data-i18n="{{ $itemKey }}"{{ end }}>{{ $itemLabel }}</a></li>
           {{ end }}
         </ul>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.community" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.community">{{ i18n "footer.community" }}</h3>
         <ul class="list-unstyled mb-0">
           <li><a class="facodi-footer__link" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener">GitHub</a></li>
           <li><a class="facodi-footer__link" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a></li>
@@ -23,7 +34,13 @@
       </div>
     </div>
     <div class="facodi-footer__bottom mt-4 pt-4 border-top">
-      <p class="small text-muted mb-0">{{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}</p>
+      <p
+        class="small text-muted mb-0"
+        data-i18n="footer.copyright"
+        data-i18n-options='{"Year": {{ now.Year }}, "Organization": "Monynha Softwares"}'
+      >
+        {{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}
+      </p>
     </div>
   </div>
 </footer>

--- a/layouts/_partials/footer/script-footer-custom.html
+++ b/layouts/_partials/footer/script-footer-custom.html
@@ -1,33 +1,26 @@
 {{- $supabaseUrl := or (getenv "SUPABASE_URL") site.Params.facodi.supabaseUrl -}}
 {{- $supabaseAnon := or (getenv "SUPABASE_ANON_KEY") site.Params.facodi.supabaseAnonKey -}}
-{{- $translationKeys := slice
-  "course.noUcs"
-  "common.unit"
-  "common.units"
-  "common.semester"
-  "common.year"
-  "common.playlist"
-  "common.playlists"
-  "common.topic"
-  "common.topics"
-  "common.ects"
-  "common.language"
-  "uc.topics"
-  "uc.noTopics"
-  "uc.playlists"
-  "uc.noPlaylists"
-  "uc.learningOutcomes"
-  "uc.noLearningOutcomes"
-  "uc.noPrerequisites"
-  "topic.noTags"
-  "topic.relatedPlaylists"
-  "topic.noPlaylists"
--}}
-{{- $translationMap := dict -}}
-{{- range $translationKeys -}}
-  {{- $translationMap = merge $translationMap (dict . (i18n .)) -}}
+{{- $locales := site.Params.facodi.locales | default (slice (dict "code" site.Language.Lang "label" site.Language.LanguageName)) -}}
+{{- $allTranslations := dict -}}
+{{- range $locales -}}
+  {{- $code := or .code .Code -}}
+  {{- if not $code -}}
+    {{- continue -}}
+  {{- end -}}
+  {{- $filePath := printf "i18n/%s.json" $code -}}
+  {{- if not (fileExists $filePath) -}}
+    {{- continue -}}
+  {{- end -}}
+  {{- $raw := readFile $filePath -}}
+  {{- $parsed := transform.Unmarshal $raw -}}
+  {{- $entries := dict -}}
+  {{- range $parsed -}}
+    {{- $entries = merge $entries (dict .id .translation) -}}
+  {{- end -}}
+  {{- $allTranslations = merge $allTranslations (dict $code $entries) -}}
 {{- end -}}
-<script id="facodi-translations" type="application/json">{{ $translationMap | jsonify | safeHTML }}</script>
+<script id="facodi-i18n" type="application/json">{{ $allTranslations | jsonify | safeHTML }}</script>
+<script id="facodi-language-config" type="application/json">{{ $locales | jsonify | safeHTML }}</script>
 <script id="facodi-config" type="application/json">{{ dict "supabaseUrl" $supabaseUrl "supabaseAnonKey" $supabaseAnon | jsonify | safeHTML }}</script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js" integrity="sha384-AkNSQdptcXlJ0/NBZc4qGk86cDVXcCevwoWgEKIpHOEfbvlXGLlIkimQtONt8KNf" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -21,8 +21,8 @@
     <a class="navbar-brand facodi-navbar__brand" href="{{ relLangURL "" }}">{{ .Site.Title }}</a>
 
     <!-- Main navigation button -->
-    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}">
-      <span class="visually-hidden">{{ i18n "nav.openMenu" }}</span>
+    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}" data-i18n-attr="aria-label:nav.openMainMenu">
+      <span class="visually-hidden" data-i18n="nav.openMenu">{{ i18n "nav.openMenu" }}</span>
       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
         <line x1="4" y1="8" x2="20" y2="8"></line>
@@ -37,7 +37,7 @@
       {{ end -}}
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="offcanvasNavMainLabel">{{ site.Title }}</h5>
-        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}">
+        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}" data-i18n-attr="aria-label:nav.closeMenu">
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M18 6l-12 12"></path>
@@ -66,10 +66,21 @@
             {{- $active = or $active (eq .Name $current.Title) -}}
             {{- $active = or $active (eq .Name ($section | humanize)) -}}
             {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "authors")) -}}
+            {{- $menuKey := "" -}}
+            {{- with .Identifier -}}
+              {{- $menuKey = printf "nav.menu.%s" . -}}
+            {{- end -}}
+            {{- $menuLabel := .Name -}}
+            {{- if $menuKey -}}
+              {{- $translated := i18n $menuKey -}}
+              {{- if $translated -}}
+                {{- $menuLabel = $translated -}}
+              {{- end -}}
+            {{- end -}}
             {{ if .HasChildren -}}
               <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                  {{ .Name -}}
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"{{ if $menuKey }} data-i18n="{{ $menuKey }}"{{ end }}>
+                  {{ $menuLabel -}}
                   <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                     <path d="M6 9l6 6l6 -6"></path>
@@ -77,58 +88,75 @@
                 </a>
                 <ul class="dropdown-menu shadow rounded border-0">
                   {{ range .Children -}}
+                  {{- $childKey := "" -}}
+                  {{- with .Identifier -}}
+                    {{- $childKey = printf "nav.menu.%s" . -}}
+                  {{- end -}}
+                  {{- $childLabel := .Name -}}
+                  {{- if $childKey -}}
+                    {{- $translatedChild := i18n $childKey -}}
+                    {{- if $translatedChild -}}
+                      {{- $childLabel = $translatedChild -}}
+                    {{- end -}}
+                  {{- end -}}
                   {{- $active = eq .Name $current.Title -}}
-                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
+                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}{{ if $childKey }} data-i18n="{{ $childKey }}"{{ end }}>{{ $childLabel }}</a></li>
                   {{ end -}}
                 </ul>
               </li>
             {{ else -}}
               <li class="nav-item">
-                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
+                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}{{ if $menuKey }} data-i18n="{{ $menuKey }}"{{ end }}>{{ $menuLabel }}</a>
               </li>
             {{ end -}}
           {{ end -}}
         </ul>
         <div class="facodi-navbar__actions d-flex flex-column flex-sm-row align-items-stretch align-items-lg-center gap-3 ms-lg-auto">
-          {{ $currentRel := .RelPermalink }}
-          {{ $path := $currentRel }}
-          {{ range site.Languages }}
-            {{ if hasPrefix $path (printf "/%s/" .Lang) }}
-              {{ $path = strings.TrimPrefix (printf "/%s" .Lang) $path }}
-            {{ end }}
-          {{ end }}
-          {{ $defaultLang := site.Params.facodi.defaultLocale | default site.Language.Lang }}
+          {{ $locales := site.Params.facodi.locales | default (slice (dict "code" site.Language.Lang "label" site.Language.LanguageName)) }}
           <div class="facodi-navbar__language">
-            <label class="visually-hidden" for="facodi-language-select">{{ i18n "nav.languageLabel" }}</label>
-            <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select aria-label="{{ i18n "nav.languageLabel" }}">
-              {{ range site.Languages }}
-                {{ $translations := where $.AllTranslations "Lang" .Lang }}
-                {{ $target := "" }}
-                {{ if $translations }}
-                  {{ $target = (index $translations 0).RelPermalink }}
-                {{ else }}
-                  {{ $prefix := "" }}
-                  {{ if ne .Lang $defaultLang }}
-                    {{ $prefix = printf "/%s" .Lang }}
-                  {{ end }}
-                  {{ $target = printf "%s%s" $prefix $path }}
+            <label class="visually-hidden" for="facodi-language-select" data-i18n="nav.languageLabel">{{ i18n "nav.languageLabel" }}</label>
+            <select
+              id="facodi-language-select"
+              class="facodi-navbar__select"
+              data-facodi-language-select
+              aria-label="{{ i18n "nav.languageLabel" }}"
+              data-i18n-attr="aria-label:nav.languageLabel"
+            >
+              {{ range $locales }}
+                {{ $code := or .code .Code }}
+                {{ $label := or .label .Label $code }}
+                {{ if $code }}
+                  <option value="{{ $code }}">{{ $label }}</option>
                 {{ end }}
-                <option value="{{ $target }}"{{ if eq $.Lang .Lang }} selected{{ end }}>{{ .LanguageName }}</option>
               {{ end }}
             </select>
           </div>
-          <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}">
+          <button
+            type="button"
+            class="facodi-navbar__theme-toggle"
+            data-facodi-theme-toggle
+            aria-pressed="false"
+            aria-label="{{ i18n "nav.themeToggle" }}"
+            data-i18n-attr="aria-label:nav.themeToggle"
+          >
             <span class="facodi-theme-icon facodi-theme-icon--light" aria-hidden="true">☀️</span>
             <span class="facodi-theme-icon facodi-theme-icon--dark" aria-hidden="true">🌙</span>
-            <span class="visually-hidden">{{ i18n "nav.themeToggle" }}</span>
+            <span class="visually-hidden" data-i18n="nav.themeToggle">{{ i18n "nav.themeToggle" }}</span>
           </button>
-          <a class="facodi-navbar__icon" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" aria-label="{{ i18n "nav.github" }}">
+          <a
+            class="facodi-navbar__icon"
+            href="https://github.com/Monynha-Softwares/facodi.pt"
+            target="_blank"
+            rel="noopener"
+            aria-label="{{ i18n "nav.github" }}"
+            data-i18n-attr="aria-label:nav.github"
+          >
             <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" role="img">
               <path d="M12 .5a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.1c-3.3.7-4-1.6-4-1.6-.5-1.3-1.2-1.6-1.2-1.6-1-.7.1-.7.1-.7 1.1.1 1.7 1.1 1.7 1.1 1 .1.8-.8 1.7-1.1 1.5-.3 2.6.5 3 .8.1-.8.4-1.3.7-1.6-2.7-.3-5.6-1.4-5.6-6.1 0-1.3.5-2.4 1.1-3.3-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.7.9 1.1 2 1.1 3.3 0 4.7-2.9 5.8-5.6 6.1.4.3.8 1 .8 2.1v3.1c0 .3.2.7.8.6A12 12 0 0 0 12 .5Z" />
             </svg>
           </a>
           {{ if site.Params.doks.navBarButton -}}
-            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}" data-i18n="nav.viewTracks">{{ i18n "nav.viewTracks" }}</a>
           {{ end -}}
         </div>
       </div>

--- a/layouts/course/list.html
+++ b/layouts/course/list.html
@@ -13,7 +13,7 @@
         <div>
           <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
           {{ with $params.plan_version }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.plan" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
           {{ end }}
           <h1 class="display-5 mt-3">{{ .Title }}</h1>
           {{ with $params.summary }}<p class="lead text-muted mb-0" data-facodi-course-summary>{{ . }}</p>{{ end }}
@@ -21,17 +21,17 @@
         <div class="card shadow-sm border-0">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.degree" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.degree | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.ectsTotal" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.ectsTotal">{{ i18n "common.ectsTotal" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects_total | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.duration" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.duration_semesters | default "--" }} <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.institution" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.institution">{{ i18n "common.institution" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.institution | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.school" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.school">{{ i18n "common.school" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.school | default "--" }}</dd>
             </dl>
           </div>
@@ -58,12 +58,12 @@
       {{ $ucPages := $scratch.Get "ucs" }}
       {{ $ucCount := len $ucPages }}
       <div class="course-ucs__header">
-        <h2 class="section-title course-ucs__title">{{ i18n "course.curricularUnits" }}</h2>
-        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span>
+        <h2 class="section-title course-ucs__title" data-i18n="course.curricularUnits">{{ i18n "course.curricularUnits" }}</h2>
+        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} <span data-i18n="{{ if eq $ucCount 1 }}common.unit{{ else }}common.units{{ end }}">{{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span></span>
       </div>
       <div class="course-uc-groups" id="course-ucs" data-facodi-slot="course-ucs">
         {{ if not $ucCount }}
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning" role="alert" data-i18n="course.noUcs">
           {{ i18n "course.noUcs" }}
         </div>
         {{ else }}
@@ -99,27 +99,27 @@
           {{ $semesterMap := index $grouped $yearKey }}
           <section class="course-uc-year">
             <header class="course-uc-year__header">
-              <h3 class="course-uc-year__title">{{ i18n "common.year" }} {{ $year }}</h3>
+              <h3 class="course-uc-year__title"><span data-i18n="common.year">{{ i18n "common.year" }}</span> {{ $year }}</h3>
             </header>
             {{ range $sem := seq 1 2 }}
               {{ $semKey := printf "%d" $sem }}
               {{ with index $semesterMap $semKey }}
               <div class="course-uc-semester">
-                <h4 class="course-uc-semester__title">{{ i18n "common.semester" }} {{ add (mul (sub $year 1) 2) $sem }}</h4>
+                <h4 class="course-uc-semester__title"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ add (mul (sub $year 1) 2) $sem }}</h4>
                 <div class="course-uc-grid">
                   {{ range . }}
                   {{ $ucParams := .Params }}
                   <article class="course-uc-card">
                     <div class="course-uc-card__meta">
                       <span class="course-uc-card__code">{{ $ucParams.code }}</span>
-                      {{ with $ucParams.semester }}<span class="course-uc-card__semester">{{ i18n "common.semester" }} {{ . }}</span>{{ end }}
+                      {{ with $ucParams.semester }}<span class="course-uc-card__semester"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ . }}</span>{{ end }}
                     </div>
                     <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
                     {{ with $ucParams.description }}<p class="course-uc-card__summary">{{ . }}</p>{{ end }}
                     <dl class="course-uc-card__details">
-                      <dt>{{ i18n "common.ects" }}</dt>
+                      <dt data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
                       <dd>{{ $ucParams.ects | default "--" }}</dd>
-                      <dt>{{ i18n "common.language" }}</dt>
+                      <dt data-i18n="common.language">{{ i18n "common.language" }}</dt>
                       <dd>{{ $ucParams.language | default "--" }}</dd>
                     </dl>
                   </article>

--- a/layouts/courses/list.html
+++ b/layouts/courses/list.html
@@ -13,7 +13,7 @@
     {{ $courses := sort .Sections "Title" }}
     {{ if not (len $courses) }}
     <div class="col-12">
-      <div class="alert alert-warning" role="alert">
+      <div class="alert alert-warning" role="alert" data-i18n="catalog.noCourses">
         {{ i18n "catalog.noCourses" }}
       </div>
     </div>
@@ -26,7 +26,7 @@
           <div class="d-flex align-items-center justify-content-between mb-3">
             <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
             {{ with $params.plan_version }}
-            <span class="text-muted small">{{ i18n "common.plan" }} {{ . }}</span>
+            <span class="text-muted small"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
             {{ end }}
           </div>
           <h2 class="h4">{{ .Title }}</h2>
@@ -36,15 +36,15 @@
           {{ with .Summary }}<p class="text-muted">{{ . }}</p>{{ end }}
           {{ end }}
           <dl class="row small text-muted mb-4">
-            <dt class="col-5">{{ i18n "common.degree" }}</dt>
+            <dt class="col-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
             <dd class="col-7">{{ $params.degree | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.ects" }}</dt>
+            <dt class="col-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
             <dd class="col-7">{{ $params.ects_total | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.duration" }}</dt>
-            <dd class="col-7">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
+            <dt class="col-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+            <dd class="col-7">{{ $params.duration_semesters | default "--" }} <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
           </dl>
           <div class="mt-auto">
-            <a class="btn btn-outline-primary w-100" href="{{ .RelPermalink }}">{{ i18n "catalog.viewCurriculum" }}</a>
+            <a class="btn btn-outline-primary w-100" href="{{ .RelPermalink }}" data-i18n="catalog.viewCurriculum">{{ i18n "catalog.viewCurriculum" }}</a>
           </div>
         </div>
       </div>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -18,8 +18,8 @@
       <div class="facodi-hero__grid">
         <div class="facodi-hero__content">
           <div class="facodi-hero__intro">
-            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">Ensino superior acessível, aberto e comunitário</span>
-            <h1 class="facodi-hero__title">FACODI — Faculdade Comunitária Digital</h1>
+            <span class="facodi-pill facodi-pill--brand facodi-hero__badge" data-i18n="home.hero.badge">{{ i18n "home.hero.badge" }}</span>
+            <h1 class="facodi-hero__title" data-i18n="home.hero.title">{{ i18n "home.hero.title" }}</h1>
             <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
           </div>
           <div class="facodi-hero__actions">
@@ -28,23 +28,33 @@
           </div>
           <div class="facodi-hero__meta">
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--success">Aberta e gratuita</span>
-              <p>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</p>
+              <span class="facodi-pill facodi-pill--success" data-i18n="home.hero.metaPrimary.title">{{ i18n "home.hero.metaPrimary.title" }}</span>
+              <p data-i18n="home.hero.metaPrimary.text">{{ i18n "home.hero.metaPrimary.text" }}</p>
             </div>
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--outline">Comunidade Monynha</span>
-              <p>Curadoria colaborativa com orgulho, diversidade e transparência.</p>
+              <span class="facodi-pill facodi-pill--outline" data-i18n="home.hero.metaSecondary.title">{{ i18n "home.hero.metaSecondary.title" }}</span>
+              <p data-i18n="home.hero.metaSecondary.text">{{ i18n "home.hero.metaSecondary.text" }}</p>
             </div>
           </div>
         </div>
         <div class="facodi-hero__card">
-          <span class="facodi-hero__card-label">Em números comunitários</span>
+          {{ $courseCount := $scratch.Get "coursesCount" }}
+          {{ $ucCount := $scratch.Get "ucCount" }}
+          <span class="facodi-hero__card-label" data-i18n="home.hero.cardLabel">{{ i18n "home.hero.cardLabel" }}</span>
           <ul class="facodi-hero__stat-list">
-            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos oficiais organizados</li>
-            <li><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares com playlists e materiais livres</li>
-            <li>Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</li>
+            <li
+              data-i18n="home.hero.cardItemCourses"
+              data-i18n-html
+              data-i18n-options='{{ dict "Count" (printf "<strong>%d</strong>" $courseCount) | jsonify | htmlEscape }}'
+            >{{ i18n "home.hero.cardItemCourses" (dict "Count" (printf "<strong>%d</strong>" $courseCount)) | safeHTML }}</li>
+            <li
+              data-i18n="home.hero.cardItemUcs"
+              data-i18n-html
+              data-i18n-options='{{ dict "Count" (printf "<strong>%d</strong>" $ucCount) | jsonify | htmlEscape }}'
+            >{{ i18n "home.hero.cardItemUcs" (dict "Count" (printf "<strong>%d</strong>" $ucCount)) | safeHTML }}</li>
+            <li data-i18n="home.hero.cardItemVersions">{{ i18n "home.hero.cardItemVersions" }}</li>
           </ul>
-          <p class="facodi-hero__card-foot">Criado pela <a href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
+          <p class="facodi-hero__card-foot" data-i18n="home.hero.cardFoot" data-i18n-html>{{ i18n "home.hero.cardFoot" | safeHTML }}</p>
         </div>
       </div>
     </div>
@@ -61,24 +71,24 @@
   {{ end }}
 
   {{ $features := slice
-    (dict "icon" "🗺️" "title" "Mapa curricular interativo" "description" "Navegue por cursos, semestres e disciplinas com uma visão organizada dos currículos oficiais.")
-    (dict "icon" "🎧" "title" "Playlists integradas" "description" "Cada unidade curricular recebe playlists do YouTube e materiais públicos selecionados pela comunidade.")
-    (dict "icon" "✅" "title" "Marcação de progresso" "description" "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo.")
-    (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
+    (dict "icon" "🗺️" "titleKey" "home.features.curriculum.title" "descriptionKey" "home.features.curriculum.description")
+    (dict "icon" "🎧" "titleKey" "home.features.playlists.title" "descriptionKey" "home.features.playlists.description")
+    (dict "icon" "✅" "titleKey" "home.features.progress.title" "descriptionKey" "home.features.progress.description")
+    (dict "icon" "🌈" "titleKey" "home.features.community.title" "descriptionKey" "home.features.community.description")
   }}
   <section class="facodi-section facodi-section--features">
     <div class="container-lg section-wrap">
       <div class="facodi-section__header section-header text-center">
-        <span class="facodi-section__eyebrow">Experiência FACODI</span>
-        <h2 class="section-title facodi-section__title">Experiência FACODI na palma da mão</h2>
-        <p class="facodi-section__subtitle">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
+        <span class="facodi-section__eyebrow" data-i18n="home.features.eyebrow">{{ i18n "home.features.eyebrow" }}</span>
+        <h2 class="section-title facodi-section__title" data-i18n="home.features.title">{{ i18n "home.features.title" }}</h2>
+        <p class="facodi-section__subtitle" data-i18n="home.features.subtitle">{{ i18n "home.features.subtitle" }}</p>
       </div>
       <div class="facodi-grid facodi-grid--features">
         {{ range $features }}
         <div class="facodi-feature-card">
           <span class="facodi-feature-card__icon">{{ .icon }}</span>
-          <h3 class="facodi-feature-card__title">{{ .title }}</h3>
-          <p class="facodi-feature-card__description">{{ .description }}</p>
+          <h3 class="facodi-feature-card__title" data-i18n="{{ .titleKey }}">{{ i18n .titleKey }}</h3>
+          <p class="facodi-feature-card__description" data-i18n="{{ .descriptionKey }}">{{ i18n .descriptionKey }}</p>
         </div>
         {{ end }}
       </div>
@@ -90,9 +100,9 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow">Currículos abertos</span>
-          <h2 class="section-title facodi-section__title">Cursos em destaque na comunidade FACODI</h2>
-          <p class="facodi-section__subtitle">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
+          <span class="facodi-section__eyebrow" data-i18n="home.courses.eyebrow">{{ i18n "home.courses.eyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.courses.title">{{ i18n "home.courses.title" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.courses.subtitle">{{ i18n "home.courses.subtitle" }}</p>
         </div>
         <div class="facodi-section__cta">
           <a class="facodi-link facodi-link--cta" href="/courses/">{{ i18n "home.viewAllCourses" }}</a>
@@ -118,7 +128,12 @@
                 {{ with .Params.code }}<span>{{ i18n "common.code" }} {{ . }}</span>{{ end }}
               </div>
               {{ with .Params.ucs }}
-              <p class="facodi-course-card__foot">{{ len . }} unidades curriculares já mapeadas pela comunidade</p>
+                {{ $ucLen := len . }}
+                <p
+                  class="facodi-course-card__foot"
+                  data-i18n="home.courses.ucFoot"
+                  data-i18n-options='{{ dict "Count" $ucLen | jsonify | htmlEscape }}'
+                >{{ i18n "home.courses.ucFoot" (dict "Count" $ucLen) }}</p>
               {{ end }}
             </div>
           </article>
@@ -133,15 +148,15 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow facodi-section__eyebrow--light">Trilha comunitária</span>
-          <h2 class="section-title facodi-section__title">Como rola a jornada FACODI</h2>
-          <p class="facodi-section__subtitle">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
+          <span class="facodi-section__eyebrow facodi-section__eyebrow--light" data-i18n="home.journey.eyebrow">{{ i18n "home.journey.eyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.journey.title">{{ i18n "home.journey.title" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.journey.subtitle">{{ i18n "home.journey.subtitle" }}</p>
         </div>
       </div>
       <ol class="facodi-journey__list">
-        <li>Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
-        <li>Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
-        <li>Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
+        <li data-i18n="home.journey.steps.one">{{ i18n "home.journey.steps.one" }}</li>
+        <li data-i18n="home.journey.steps.two">{{ i18n "home.journey.steps.two" }}</li>
+        <li data-i18n="home.journey.steps.three">{{ i18n "home.journey.steps.three" }}</li>
       </ol>
     </div>
   </section>
@@ -151,9 +166,9 @@
 <section class="facodi-section facodi-section--manifesto">
   <div class="container-lg section-wrap">
     <div class="facodi-manifesto">
-      <span class="facodi-section__eyebrow">Manifesto Monynha Softwares</span>
-      <h2 class="section-title facodi-manifesto__title">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
-      <p class="facodi-manifesto__description">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
+      <span class="facodi-section__eyebrow" data-i18n="home.manifesto.eyebrow">{{ i18n "home.manifesto.eyebrow" }}</span>
+      <h2 class="section-title facodi-manifesto__title" data-i18n="home.manifesto.title">{{ i18n "home.manifesto.title" }}</h2>
+      <p class="facodi-manifesto__description" data-i18n="home.manifesto.description">{{ i18n "home.manifesto.description" }}</p>
       <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.readManifesto" }}</a>
     </div>
   </div>
@@ -164,8 +179,8 @@
 <section class="facodi-section facodi-section--cta">
   <div class="container-lg section-wrap">
     <div class="facodi-cta">
-      <h2 class="section-title facodi-cta__title">Bora colar com a FACODI?</h2>
-      <p class="facodi-cta__description">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
+      <h2 class="section-title facodi-cta__title" data-i18n="home.cta.title">{{ i18n "home.cta.title" }}</h2>
+      <p class="facodi-cta__description" data-i18n="home.cta.description">{{ i18n "home.cta.description" }}</p>
       <div class="facodi-cta__actions">
         <a class="facodi-hero__cta" href="/courses/">{{ i18n "home.viewCurricula" }}</a>
         <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.contactMonynha" }}</a>

--- a/layouts/topic/single.html
+++ b/layouts/topic/single.html
@@ -36,7 +36,7 @@
         {{ with $params.tags }}
           {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1">{{ . }}</span>{{ end }}
         {{ else }}
-          <span class="text-muted small">{{ i18n "topic.noTags" }}</span>
+          <span class="text-muted small" data-i18n="topic.noTags">{{ i18n "topic.noTags" }}</span>
         {{ end }}
       </div>
     </div>
@@ -45,7 +45,7 @@
     <div class="col-lg-8">
       <article class="content mb-5" id="topic-content" data-facodi-slot="topic-content">{{ .Content }}</article>
       <section id="topic-playlists" data-facodi-slot="topic-playlists">
-        <h2 class="h5">{{ i18n "topic.relatedPlaylists" }}</h2>
+        <h2 class="h5" data-i18n="topic.relatedPlaylists">{{ i18n "topic.relatedPlaylists" }}</h2>
         {{ if $params.youtube_playlists }}
         <ul class="list-unstyled">
           {{ range sort $params.youtube_playlists "priority" }}
@@ -57,7 +57,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "topic.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="topic.noPlaylists">{{ i18n "topic.noPlaylists" }}</p>
         {{ end }}
       </section>
     </div>

--- a/layouts/uc/list.html
+++ b/layouts/uc/list.html
@@ -26,7 +26,7 @@
         <div>
           <span class="badge bg-secondary-subtle text-secondary">{{ $params.code }}</span>
           {{ with $params.semester }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.semester" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ . }}</span>
           {{ end }}
           <h1 class="display-6 mt-3">{{ .Title }}</h1>
           {{ with $params.description }}<p class="lead text-muted">{{ . }}</p>{{ end }}
@@ -34,16 +34,16 @@
         <div class="card border-0 shadow-sm">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.ects" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "uc.prerequisites" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="uc.prerequisites">{{ i18n "uc.prerequisites" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end" data-facodi-uc-prerequisites>
                 {{ if $params.prerequisites }}
                   {{ delimit $params.prerequisites ", " }}
                 {{ else }}
-                  <span class="text-muted">{{ i18n "uc.noPrerequisites" }}</span>
+                  <span class="text-muted" data-i18n="uc.noPrerequisites">{{ i18n "uc.noPrerequisites" }}</span>
                 {{ end }}
               </dd>
             </dl>
@@ -58,12 +58,12 @@
       {{ $topics := .RegularPages }}
       <section class="mb-5" id="uc-topics" data-facodi-slot="uc-topics">
         <div class="d-flex align-items-center justify-content-between mb-3">
-          <h2 class="h4 mb-0">{{ i18n "uc.topics" }}</h2>
+          <h2 class="h4 mb-0" data-i18n="uc.topics">{{ i18n "uc.topics" }}</h2>
           {{ $topicCount := len $topics }}
-          <span class="text-muted small">{{ $topicCount }} {{ if eq $topicCount 1 }}{{ i18n "common.topic" }}{{ else }}{{ i18n "common.topics" }}{{ end }}</span>
+          <span class="text-muted small">{{ $topicCount }} <span data-i18n="{{ if eq $topicCount 1 }}common.topic{{ else }}common.topics{{ end }}">{{ if eq $topicCount 1 }}{{ i18n "common.topic" }}{{ else }}{{ i18n "common.topics" }}{{ end }}</span></span>
         </div>
         {{ if not (len $topics) }}
-        <div class="alert alert-info" role="alert">{{ i18n "uc.noTopics" }}</div>
+        <div class="alert alert-info" role="alert" data-i18n="uc.noTopics">{{ i18n "uc.noTopics" }}</div>
         {{ else }}
         <div class="list-group list-group-flush">
           {{ range sort $topics "Title" }}
@@ -75,7 +75,7 @@
               </div>
               {{ with .Params.youtube_playlists }}
               {{ $playlistCount := len . }}
-              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} {{ if eq $playlistCount 1 }}{{ i18n "common.playlist" }}{{ else }}{{ i18n "common.playlists" }}{{ end }}</span>
+              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} {{ if eq $playlistCount 1 }}<span data-i18n="common.playlist">{{ i18n "common.playlist" }}</span>{{ else }}<span data-i18n="common.playlists">{{ i18n "common.playlists" }}</span>{{ end }}</span>
               {{ end }}
             </div>
             {{ with .Params.tags }}
@@ -91,17 +91,17 @@
     </div>
     <div class="col-lg-3 order-lg-0">
       <aside class="mb-5" id="uc-learning-outcomes" data-facodi-slot="uc-outcomes">
-        <h2 class="h5">{{ i18n "uc.learningOutcomes" }}</h2>
+        <h2 class="h5" data-i18n="uc.learningOutcomes">{{ i18n "uc.learningOutcomes" }}</h2>
         {{ if $params.learning_outcomes }}
         <ol class="ps-3">
           {{ range $params.learning_outcomes }}<li class="mb-2">{{ . }}</li>{{ end }}
         </ol>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noLearningOutcomes" }}</p>
+        <p class="text-muted small" data-i18n="uc.noLearningOutcomes">{{ i18n "uc.noLearningOutcomes" }}</p>
         {{ end }}
       </aside>
       <aside id="uc-playlists" data-facodi-slot="uc-playlists">
-        <h2 class="h5">{{ i18n "uc.playlists" }}</h2>
+        <h2 class="h5" data-i18n="uc.playlists">{{ i18n "uc.playlists" }}</h2>
         {{ if $params.youtube_playlists }}
         <ul class="list-unstyled">
           {{ range sort $params.youtube_playlists "priority" }}
@@ -113,7 +113,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="uc.noPlaylists">{{ i18n "uc.noPlaylists" }}</p>
         {{ end }}
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- embed the consolidated translation map and locale config in the footer partial so custom.js can drive `data-i18n` updates across the site
- add the missing hero, feature, journey, CTA, and menu strings to the pt/en/es/fr translation files while aligning menu definitions to shared routes
- update the Supabase loader helpers to resolve translations from the new dataset without touching the underlying course content

## Testing
- ./node_modules/.bin/hugo

------
https://chatgpt.com/codex/tasks/task_e_68d052a9dd708322b41793006c4503dc