### PR TITLE
Localize home hero and normalize internal URLs

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -116,6 +116,150 @@
     "translation": "Discover the Monynha Softwares ecosystem"
   },
   {
+    "id": "home.heroBadge",
+    "translation": "Accessible, open, community-powered higher education"
+  },
+  {
+    "id": "home.heroPillOpenLabel",
+    "translation": "Open and free"
+  },
+  {
+    "id": "home.heroPillOpenDescription",
+    "translation": "Official curricula and public materials with no paywalls, just how the community deserves."
+  },
+  {
+    "id": "home.heroPillCommunityLabel",
+    "translation": "Monynha community"
+  },
+  {
+    "id": "home.heroPillCommunityDescription",
+    "translation": "Collaborative curation with pride, diversity, and transparency."
+  },
+  {
+    "id": "home.heroCardLabel",
+    "translation": "Community numbers"
+  },
+  {
+    "id": "home.heroCardCoursesLabel",
+    "translation": "official tracks organised"
+  },
+  {
+    "id": "home.heroCardUnitsLabel",
+    "translation": "curricular units with playlists and open materials"
+  },
+  {
+    "id": "home.heroCardProgress",
+    "translation": "Progress tracked by learners with version history everyone can trust."
+  },
+  {
+    "id": "home.heroCardFoot",
+    "translation": "Created by <a href=\"{{ .MonynhaURL }}\" target=\"_blank\" rel=\"noopener\">Monynha Softwares</a> to democratize technology, confront hypocrisy, and amplify those who learn outside the norm."
+  },
+  {
+    "id": "home.featuresEyebrow",
+    "translation": "FACODI experience"
+  },
+  {
+    "id": "home.featuresTitle",
+    "translation": "FACODI experience at your fingertips"
+  },
+  {
+    "id": "home.featuresSubtitle",
+    "translation": "Open technology to organise curricula, support learners, and celebrate every community contribution."
+  },
+  {
+    "id": "home.feature.map.title",
+    "translation": "Interactive curriculum map"
+  },
+  {
+    "id": "home.feature.map.description",
+    "translation": "Browse courses, semesters, and subjects with an organised view of official curricula."
+  },
+  {
+    "id": "home.feature.playlists.title",
+    "translation": "Integrated playlists"
+  },
+  {
+    "id": "home.feature.playlists.description",
+    "translation": "Every curricular unit gets YouTube playlists and public materials curated by the community."
+  },
+  {
+    "id": "home.feature.progress.title",
+    "translation": "Progress tracking"
+  },
+  {
+    "id": "home.feature.progress.description",
+    "translation": "Follow what you have studied and celebrate each module completed at your own pace."
+  },
+  {
+    "id": "home.feature.curatorship.title",
+    "translation": "Diverse curatorship"
+  },
+  {
+    "id": "home.feature.curatorship.description",
+    "translation": "A vibrant collective ensures accessibility, welcoming language, and real representation."
+  },
+  {
+    "id": "home.coursesEyebrow",
+    "translation": "Open curricula"
+  },
+  {
+    "id": "home.coursesTitle",
+    "translation": "Featured courses from the FACODI community"
+  },
+  {
+    "id": "home.coursesSubtitle",
+    "translation": "Official curricula from undergraduate degrees and related areas with curricular units, open playlists, and organised learning outcomes."
+  },
+  {
+    "id": "home.courseCardFootSuffix",
+    "translation": "already mapped by the community"
+  },
+  {
+    "id": "home.journeyEyebrow",
+    "translation": "Community journey"
+  },
+  {
+    "id": "home.journeyTitle",
+    "translation": "How the FACODI journey unfolds"
+  },
+  {
+    "id": "home.journeySubtitle",
+    "translation": "From choosing a course to celebrating progress, every step is designed to support learners, educators, and knowledge sharers."
+  },
+  {
+    "id": "home.journeyStep1",
+    "translation": "Choose an official curriculum and explore semesters, workloads, versions, and institutional context."
+  },
+  {
+    "id": "home.journeyStep2",
+    "translation": "Dive into curricular units with learning outcomes, related topics, and open playlists."
+  },
+  {
+    "id": "home.journeyStep3",
+    "translation": "Track your progress, share materials with the community, and keep a living revision history."
+  },
+  {
+    "id": "home.manifestoEyebrow",
+    "translation": "Monynha Softwares manifesto"
+  },
+  {
+    "id": "home.manifestoTitle",
+    "translation": "Democratize technology, confront hypocrisy, and give voice to creators outside the norm"
+  },
+  {
+    "id": "home.manifestoDescription",
+    "translation": "FACODI is born from this socio-political commitment: using accessible technology to open paths in higher education, respecting cultural diversity, and celebrating popular knowledge."
+  },
+  {
+    "id": "home.ctaTitle",
+    "translation": "Ready to join FACODI?"
+  },
+  {
+    "id": "home.ctaDescription",
+    "translation": "Bring playlists, public PDFs, articles, and ideas to strengthen the community digital faculty and keep the curriculum ever more diverse."
+  },
+  {
     "id": "home.readManifesto",
     "translation": "Read the full manifesto"
   },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -116,6 +116,150 @@
     "translation": "Conoce el ecosistema Monynha Softwares"
   },
   {
+    "id": "home.heroBadge",
+    "translation": "Educación superior accesible, abierta y comunitaria"
+  },
+  {
+    "id": "home.heroPillOpenLabel",
+    "translation": "Abierta y gratuita"
+  },
+  {
+    "id": "home.heroPillOpenDescription",
+    "translation": "Planes oficiales y materiales públicos sin muros de pago, tal como la comunidad merece."
+  },
+  {
+    "id": "home.heroPillCommunityLabel",
+    "translation": "Comunidad Monynha"
+  },
+  {
+    "id": "home.heroPillCommunityDescription",
+    "translation": "Curaduría colaborativa con orgullo, diversidad y transparencia."
+  },
+  {
+    "id": "home.heroCardLabel",
+    "translation": "En números comunitarios"
+  },
+  {
+    "id": "home.heroCardCoursesLabel",
+    "translation": "cursos oficiales organizados"
+  },
+  {
+    "id": "home.heroCardUnitsLabel",
+    "translation": "unidades curriculares con playlists y materiales abiertos"
+  },
+  {
+    "id": "home.heroCardProgress",
+    "translation": "Progreso marcado por quienes estudian y versiones rastreables para que todas confíen."
+  },
+  {
+    "id": "home.heroCardFoot",
+    "translation": "Creado por <a href=\"{{ .MonynhaURL }}\" target=\"_blank\" rel=\"noopener\">Monynha Softwares</a> para democratizar la tecnología, combatir la hipocresía y amplificar a quienes aprenden fuera de la norma."
+  },
+  {
+    "id": "home.featuresEyebrow",
+    "translation": "Experiencia FACODI"
+  },
+  {
+    "id": "home.featuresTitle",
+    "translation": "La experiencia FACODI en la palma de la mano"
+  },
+  {
+    "id": "home.featuresSubtitle",
+    "translation": "Tecnología abierta para organizar el currículo, apoyar a quienes estudian y valorar cada aporte de la comunidad."
+  },
+  {
+    "id": "home.feature.map.title",
+    "translation": "Mapa curricular interactivo"
+  },
+  {
+    "id": "home.feature.map.description",
+    "translation": "Navega por cursos, semestres y asignaturas con una visión organizada de los planes oficiales."
+  },
+  {
+    "id": "home.feature.playlists.title",
+    "translation": "Playlists integradas"
+  },
+  {
+    "id": "home.feature.playlists.description",
+    "translation": "Cada unidad curricular recibe playlists de YouTube y materiales públicos seleccionados por la comunidad."
+  },
+  {
+    "id": "home.feature.progress.title",
+    "translation": "Marcación de progreso"
+  },
+  {
+    "id": "home.feature.progress.description",
+    "translation": "Sigue lo que ya estudiaste y celebra cada módulo completado a tu ritmo."
+  },
+  {
+    "id": "home.feature.curatorship.title",
+    "translation": "Curaduría diversa"
+  },
+  {
+    "id": "home.feature.curatorship.description",
+    "translation": "Un colectivo vibrante garantiza accesibilidad, lenguaje acogedor y representatividad real."
+  },
+  {
+    "id": "home.coursesEyebrow",
+    "translation": "Currículos abiertos"
+  },
+  {
+    "id": "home.coursesTitle",
+    "translation": "Cursos destacados de la comunidad FACODI"
+  },
+  {
+    "id": "home.coursesSubtitle",
+    "translation": "Planes oficiales de licenciaturas y áreas afines con unidades curriculares, playlists abiertas y resultados de aprendizaje organizados."
+  },
+  {
+    "id": "home.courseCardFootSuffix",
+    "translation": "ya mapeadas por la comunidad"
+  },
+  {
+    "id": "home.journeyEyebrow",
+    "translation": "Travesía comunitaria"
+  },
+  {
+    "id": "home.journeyTitle",
+    "translation": "Cómo se vive la jornada FACODI"
+  },
+  {
+    "id": "home.journeySubtitle",
+    "translation": "Desde elegir el curso hasta celebrar los avances, cada paso fue pensado para apoyar a quienes aprenden, enseñan y comparten conocimiento."
+  },
+  {
+    "id": "home.journeyStep1",
+    "translation": "Elige un currículo oficial y visualiza semestres, cargas horarias, versiones y contexto institucional."
+  },
+  {
+    "id": "home.journeyStep2",
+    "translation": "Sumérgete en las unidades curriculares con resultados de aprendizaje, temas relacionados y playlists abiertas."
+  },
+  {
+    "id": "home.journeyStep3",
+    "translation": "Marca tu progreso, comparte materiales con la comunidad y mantiene vivo el historial de revisiones."
+  },
+  {
+    "id": "home.manifestoEyebrow",
+    "translation": "Manifiesto Monynha Softwares"
+  },
+  {
+    "id": "home.manifestoTitle",
+    "translation": "Democratizar la tecnología, combatir la hipocresía y dar voz a quienes crean fuera de la norma"
+  },
+  {
+    "id": "home.manifestoDescription",
+    "translation": "FACODI nace de este compromiso socio-político: usar tecnología accesible para abrir caminos en la educación superior, respetando la diversidad cultural y celebrando los saberes populares."
+  },
+  {
+    "id": "home.ctaTitle",
+    "translation": "¿Te sumas a FACODI?"
+  },
+  {
+    "id": "home.ctaDescription",
+    "translation": "Trae playlists, PDFs públicos, artículos e ideas para fortalecer la facultad digital comunitaria y hacer el currículo cada vez más diverso."
+  },
+  {
     "id": "home.readManifesto",
     "translation": "Conoce el manifiesto completo"
   },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -116,6 +116,150 @@
     "translation": "Découvrir l’écosystème Monynha Softwares"
   },
   {
+    "id": "home.heroBadge",
+    "translation": "Enseignement supérieur accessible, ouvert et communautaire"
+  },
+  {
+    "id": "home.heroPillOpenLabel",
+    "translation": "Ouverte et gratuite"
+  },
+  {
+    "id": "home.heroPillOpenDescription",
+    "translation": "Programmes officiels et ressources publiques sans paywall, exactement comme la communauté le mérite."
+  },
+  {
+    "id": "home.heroPillCommunityLabel",
+    "translation": "Communauté Monynha"
+  },
+  {
+    "id": "home.heroPillCommunityDescription",
+    "translation": "Curation collaborative avec fierté, diversité et transparence."
+  },
+  {
+    "id": "home.heroCardLabel",
+    "translation": "En chiffres communautaires"
+  },
+  {
+    "id": "home.heroCardCoursesLabel",
+    "translation": "parcours officiels organisés"
+  },
+  {
+    "id": "home.heroCardUnitsLabel",
+    "translation": "unités curriculaires avec playlists et ressources libres"
+  },
+  {
+    "id": "home.heroCardProgress",
+    "translation": "Progression marquée par celles et ceux qui étudient, avec des versions traçables pour inspirer confiance."
+  },
+  {
+    "id": "home.heroCardFoot",
+    "translation": "Créé par <a href=\"{{ .MonynhaURL }}\" target=\"_blank\" rel=\"noopener\">Monynha Softwares</a> pour démocratiser la technologie, combattre l’hypocrisie et amplifier celles et ceux qui apprennent hors des normes."
+  },
+  {
+    "id": "home.featuresEyebrow",
+    "translation": "Expérience FACODI"
+  },
+  {
+    "id": "home.featuresTitle",
+    "translation": "L’expérience FACODI au bout des doigts"
+  },
+  {
+    "id": "home.featuresSubtitle",
+    "translation": "Une technologie ouverte pour organiser le cursus, soutenir les personnes qui étudient et valoriser chaque contribution de la communauté."
+  },
+  {
+    "id": "home.feature.map.title",
+    "translation": "Carte curriculaire interactive"
+  },
+  {
+    "id": "home.feature.map.description",
+    "translation": "Parcourez cours, semestres et disciplines avec une vue organisée des programmes officiels."
+  },
+  {
+    "id": "home.feature.playlists.title",
+    "translation": "Playlists intégrées"
+  },
+  {
+    "id": "home.feature.playlists.description",
+    "translation": "Chaque unité curriculaire reçoit des playlists YouTube et des ressources publiques sélectionnées par la communauté."
+  },
+  {
+    "id": "home.feature.progress.title",
+    "translation": "Suivi des progrès"
+  },
+  {
+    "id": "home.feature.progress.description",
+    "translation": "Suivez ce que vous avez déjà étudié et célébrez chaque module terminé à votre rythme."
+  },
+  {
+    "id": "home.feature.curatorship.title",
+    "translation": "Curation diverse"
+  },
+  {
+    "id": "home.feature.curatorship.description",
+    "translation": "Un collectif vibrant garantit l’accessibilité, un langage accueillant et une véritable représentativité."
+  },
+  {
+    "id": "home.coursesEyebrow",
+    "translation": "Curriculums ouverts"
+  },
+  {
+    "id": "home.coursesTitle",
+    "translation": "Cours mis en avant par la communauté FACODI"
+  },
+  {
+    "id": "home.coursesSubtitle",
+    "translation": "Programmes officiels de licences et domaines connexes avec unités curriculaires, playlists ouvertes et résultats d’apprentissage organisés."
+  },
+  {
+    "id": "home.courseCardFootSuffix",
+    "translation": "déjà cartographiées par la communauté"
+  },
+  {
+    "id": "home.journeyEyebrow",
+    "translation": "Parcours communautaire"
+  },
+  {
+    "id": "home.journeyTitle",
+    "translation": "Comment se déroule le parcours FACODI"
+  },
+  {
+    "id": "home.journeySubtitle",
+    "translation": "Du choix du cours à la célébration des progrès, chaque étape est pensée pour soutenir celles et ceux qui apprennent, enseignent et partagent le savoir."
+  },
+  {
+    "id": "home.journeyStep1",
+    "translation": "Choisissez un programme officiel et visualisez semestres, charges horaires, versions et contexte institutionnel."
+  },
+  {
+    "id": "home.journeyStep2",
+    "translation": "Plongez dans les unités curriculaires avec résultats d’apprentissage, sujets associés et playlists ouvertes."
+  },
+  {
+    "id": "home.journeyStep3",
+    "translation": "Suivez vos progrès, partagez des ressources avec la communauté et gardez un historique vivant des révisions."
+  },
+  {
+    "id": "home.manifestoEyebrow",
+    "translation": "Manifeste Monynha Softwares"
+  },
+  {
+    "id": "home.manifestoTitle",
+    "translation": "Démocratiser la technologie, combattre l’hypocrisie et donner la parole à celles et ceux qui créent hors des normes"
+  },
+  {
+    "id": "home.manifestoDescription",
+    "translation": "FACODI naît de cet engagement socio-politique : utiliser une technologie accessible pour ouvrir des voies dans l’enseignement supérieur, respecter la diversité culturelle et célébrer les savoirs populaires."
+  },
+  {
+    "id": "home.ctaTitle",
+    "translation": "On rejoint FACODI ?"
+  },
+  {
+    "id": "home.ctaDescription",
+    "translation": "Apporte des playlists, des PDF publics, des articles et des idées pour renforcer la faculté numérique communautaire et rendre le cursus toujours plus diversifié."
+  },
+  {
     "id": "home.readManifesto",
     "translation": "Lire le manifeste complet"
   },

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -116,6 +116,150 @@
     "translation": "Conheça o ecossistema Monynha Softwares"
   },
   {
+    "id": "home.heroBadge",
+    "translation": "Ensino superior acessível, aberto e comunitário"
+  },
+  {
+    "id": "home.heroPillOpenLabel",
+    "translation": "Aberta e gratuita"
+  },
+  {
+    "id": "home.heroPillOpenDescription",
+    "translation": "Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece."
+  },
+  {
+    "id": "home.heroPillCommunityLabel",
+    "translation": "Comunidade Monynha"
+  },
+  {
+    "id": "home.heroPillCommunityDescription",
+    "translation": "Curadoria colaborativa com orgulho, diversidade e transparência."
+  },
+  {
+    "id": "home.heroCardLabel",
+    "translation": "Em números comunitários"
+  },
+  {
+    "id": "home.heroCardCoursesLabel",
+    "translation": "cursos oficiais organizados"
+  },
+  {
+    "id": "home.heroCardUnitsLabel",
+    "translation": "unidades curriculares com playlists e materiais livres"
+  },
+  {
+    "id": "home.heroCardProgress",
+    "translation": "Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar."
+  },
+  {
+    "id": "home.heroCardFoot",
+    "translation": "Criado pela <a href=\"{{ .MonynhaURL }}\" target=\"_blank\" rel=\"noopener\">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão."
+  },
+  {
+    "id": "home.featuresEyebrow",
+    "translation": "Experiência FACODI"
+  },
+  {
+    "id": "home.featuresTitle",
+    "translation": "Experiência FACODI na palma da mão"
+  },
+  {
+    "id": "home.featuresSubtitle",
+    "translation": "Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade."
+  },
+  {
+    "id": "home.feature.map.title",
+    "translation": "Mapa curricular interativo"
+  },
+  {
+    "id": "home.feature.map.description",
+    "translation": "Navegue por cursos, semestres e disciplinas com uma visão organizada dos currículos oficiais."
+  },
+  {
+    "id": "home.feature.playlists.title",
+    "translation": "Playlists integradas"
+  },
+  {
+    "id": "home.feature.playlists.description",
+    "translation": "Cada unidade curricular recebe playlists do YouTube e materiais públicos selecionados pela comunidade."
+  },
+  {
+    "id": "home.feature.progress.title",
+    "translation": "Marcação de progresso"
+  },
+  {
+    "id": "home.feature.progress.description",
+    "translation": "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo."
+  },
+  {
+    "id": "home.feature.curatorship.title",
+    "translation": "Curadoria diversa"
+  },
+  {
+    "id": "home.feature.curatorship.description",
+    "translation": "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real."
+  },
+  {
+    "id": "home.coursesEyebrow",
+    "translation": "Currículos abertos"
+  },
+  {
+    "id": "home.coursesTitle",
+    "translation": "Cursos em destaque na comunidade FACODI"
+  },
+  {
+    "id": "home.coursesSubtitle",
+    "translation": "Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados."
+  },
+  {
+    "id": "home.courseCardFootSuffix",
+    "translation": "já mapeadas pela comunidade"
+  },
+  {
+    "id": "home.journeyEyebrow",
+    "translation": "Trilha comunitária"
+  },
+  {
+    "id": "home.journeyTitle",
+    "translation": "Como rola a jornada FACODI"
+  },
+  {
+    "id": "home.journeySubtitle",
+    "translation": "Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento."
+  },
+  {
+    "id": "home.journeyStep1",
+    "translation": "Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional."
+  },
+  {
+    "id": "home.journeyStep2",
+    "translation": "Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas."
+  },
+  {
+    "id": "home.journeyStep3",
+    "translation": "Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões."
+  },
+  {
+    "id": "home.manifestoEyebrow",
+    "translation": "Manifesto Monynha Softwares"
+  },
+  {
+    "id": "home.manifestoTitle",
+    "translation": "Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão"
+  },
+  {
+    "id": "home.manifestoDescription",
+    "translation": "A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares."
+  },
+  {
+    "id": "home.ctaTitle",
+    "translation": "Bora colar com a FACODI?"
+  },
+  {
+    "id": "home.ctaDescription",
+    "translation": "Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso."
+  },
+  {
     "id": "home.readManifesto",
     "translation": "Conheça o manifesto completo"
   },

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,7 +19,7 @@
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
                 <h2 class="h4 facodi-card__title">
-                  <a class="facodi-card__link" href="{{ .RelPermalink }}">{{ .Title }}</a>
+                  <a class="facodi-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a>
                 </h2>
                 {{ with .Params.description }}
                   <p class="text-muted">{{ . }}</p>
@@ -31,7 +31,7 @@
                 {{ with .PublishDate }}
                   <span class="facodi-card__meta">{{ i18n "list.published" }} {{ .Format "02 MMMM 2006" }}</span>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ .RelPermalink }}">{{ i18n "list.readMore" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "list.readMore" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -17,7 +17,7 @@
           <article class="col-md-6 col-lg-4">
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
-                <h2 class="h4 facodi-card__title"><a class="facodi-card__link" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+                <h2 class="h4 facodi-card__title"><a class="facodi-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h2>
                 {{ with .Summary }}<p class="text-muted">{{ . | plainify }}</p>{{ end }}
               </div>
               <footer class="facodi-card__footer">
@@ -27,7 +27,7 @@
                     {{ range $tags }}<span class="badge bg-light text-muted">{{ . }}</span>{{ end }}
                   </div>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ .RelPermalink }}">{{ i18n "taxonomy.viewEntry" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "taxonomy.viewEntry" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -15,11 +15,11 @@
           <article class="col-md-6 col-lg-4">
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
-                <h2 class="h5 facodi-card__title"><a class="facodi-card__link" href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></h2>
+                <h2 class="h5 facodi-card__title"><a class="facodi-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ .Page.Title }}</a></h2>
                 <p class="facodi-card__meta">{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
               </div>
               <footer class="facodi-card__footer">
-                <a class="facodi-card__cta" href="{{ .Page.RelPermalink }}">{{ i18n "terms.viewTerm" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ i18n "terms.viewTerm" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_partials/facodi/langless-url.html
+++ b/layouts/_partials/facodi/langless-url.html
@@ -1,0 +1,25 @@
+{{- $url := .url | default "" -}}
+{{- if not $url -}}
+  {{- "" -}}
+{{- else -}}
+  {{- $clean := $url -}}
+  {{- $isExternal := or (strings.HasPrefix $clean "http://") (strings.HasPrefix $clean "https://") (strings.HasPrefix $clean "//") -}}
+  {{- if not $isExternal -}}
+    {{- $defaultLang := site.Params.facodi.defaultLocale | default site.Language.Lang -}}
+    {{- range site.Languages -}}
+      {{- if ne .Lang $defaultLang -}}
+        {{- $prefix := printf "/%s" .Lang -}}
+        {{- if hasPrefix $clean $prefix -}}
+          {{- $trimmed := strings.TrimPrefix $clean $prefix -}}
+          {{- if eq $trimmed "" -}}
+            {{- $clean = "/" -}}
+          {{- else -}}
+            {{- $trimmed = strings.TrimPrefix $trimmed "/" -}}
+            {{- $clean = printf "/%s" $trimmed -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $clean -}}
+{{- end -}}

--- a/layouts/_partials/footer/footer.html
+++ b/layouts/_partials/footer/footer.html
@@ -10,7 +10,14 @@
         <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.navigation" }}</h3>
         <ul class="list-unstyled mb-0">
           {{ range site.Menus.main }}
-            <li><a class="facodi-footer__link" href="{{ .URL | absLangURL }}">{{ .Name }}</a></li>
+            {{- $itemURL := .URL | default "" -}}
+            {{- $isExternal := or (strings.HasPrefix $itemURL "http://") (strings.HasPrefix $itemURL "https://") (strings.HasPrefix $itemURL "//") -}}
+            {{- $href := $itemURL -}}
+            {{- if not $isExternal -}}
+              {{- $href = partial "facodi/langless-url.html" (dict "url" $itemURL) -}}
+              {{- $href = relURL $href -}}
+            {{- end -}}
+            <li><a class="facodi-footer__link" href="{{ $href }}">{{ .Name }}</a></li>
           {{ end }}
         </ul>
       </div>

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -78,13 +78,27 @@
                 <ul class="dropdown-menu shadow rounded border-0">
                   {{ range .Children -}}
                   {{- $active = eq .Name $current.Title -}}
-                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
+                    {{- $childURL := .URL | default "" -}}
+                    {{- $childExternal := or (strings.HasPrefix $childURL "http://") (strings.HasPrefix $childURL "https://") (strings.HasPrefix $childURL "//") -}}
+                    {{- $childHref := $childURL -}}
+                    {{- if not $childExternal -}}
+                      {{- $childHref = partial "facodi/langless-url.html" (dict "url" $childURL) -}}
+                      {{- $childHref = relURL $childHref -}}
+                    {{- end -}}
+                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
                   {{ end -}}
                 </ul>
               </li>
             {{ else -}}
               <li class="nav-item">
-                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
+                {{- $itemURL := .URL | default "" -}}
+                {{- $isExternal := or (strings.HasPrefix $itemURL "http://") (strings.HasPrefix $itemURL "https://") (strings.HasPrefix $itemURL "//") -}}
+                {{- $href := $itemURL -}}
+                {{- if not $isExternal -}}
+                  {{- $href = partial "facodi/langless-url.html" (dict "url" $itemURL) -}}
+                  {{- $href = relURL $href -}}
+                {{- end -}}
+                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
               </li>
             {{ end -}}
           {{ end -}}

--- a/layouts/course/list.html
+++ b/layouts/course/list.html
@@ -114,7 +114,7 @@
                       <span class="course-uc-card__code">{{ $ucParams.code }}</span>
                       {{ with $ucParams.semester }}<span class="course-uc-card__semester">{{ i18n "common.semester" }} {{ . }}</span>{{ end }}
                     </div>
-                    <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+                    <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
                     {{ with $ucParams.description }}<p class="course-uc-card__summary">{{ . }}</p>{{ end }}
                     <dl class="course-uc-card__details">
                       <dt>{{ i18n "common.ects" }}</dt>

--- a/layouts/courses/list.html
+++ b/layouts/courses/list.html
@@ -44,7 +44,7 @@
             <dd class="col-7">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
           </dl>
           <div class="mt-auto">
-            <a class="btn btn-outline-primary w-100" href="{{ .RelPermalink }}">{{ i18n "catalog.viewCurriculum" }}</a>
+            <a class="btn btn-outline-primary w-100" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "catalog.viewCurriculum" }}</a>
           </div>
         </div>
       </div>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -18,8 +18,8 @@
       <div class="facodi-hero__grid">
         <div class="facodi-hero__content">
           <div class="facodi-hero__intro">
-            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">Ensino superior acessível, aberto e comunitário</span>
-            <h1 class="facodi-hero__title">FACODI — Faculdade Comunitária Digital</h1>
+            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">{{ i18n "home.heroBadge" }}</span>
+            <h1 class="facodi-hero__title">{{ site.Title }}</h1>
             <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
           </div>
           <div class="facodi-hero__actions">
@@ -28,23 +28,23 @@
           </div>
           <div class="facodi-hero__meta">
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--success">Aberta e gratuita</span>
-              <p>Currículos oficiais e materiais públicos sem paywall, do jeitinho que a comunidade merece.</p>
+              <span class="facodi-pill facodi-pill--success">{{ i18n "home.heroPillOpenLabel" }}</span>
+              <p>{{ i18n "home.heroPillOpenDescription" }}</p>
             </div>
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--outline">Comunidade Monynha</span>
-              <p>Curadoria colaborativa com orgulho, diversidade e transparência.</p>
+              <span class="facodi-pill facodi-pill--outline">{{ i18n "home.heroPillCommunityLabel" }}</span>
+              <p>{{ i18n "home.heroPillCommunityDescription" }}</p>
             </div>
           </div>
         </div>
         <div class="facodi-hero__card">
-          <span class="facodi-hero__card-label">Em números comunitários</span>
+          <span class="facodi-hero__card-label">{{ i18n "home.heroCardLabel" }}</span>
           <ul class="facodi-hero__stat-list">
-            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> cursos oficiais organizados</li>
-            <li><strong>{{ $scratch.Get "ucCount" }}</strong> unidades curriculares com playlists e materiais livres</li>
-            <li>Progresso marcado por quem estuda e versões rastreáveis para todo mundo confiar.</li>
+            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> {{ i18n "home.heroCardCoursesLabel" }}</li>
+            <li><strong>{{ $scratch.Get "ucCount" }}</strong> {{ i18n "home.heroCardUnitsLabel" }}</li>
+            <li>{{ i18n "home.heroCardProgress" }}</li>
           </ul>
-          <p class="facodi-hero__card-foot">Criado pela <a href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a> para democratizar tecnologia, combater hipocrisia e amplificar quem aprende fora do padrão.</p>
+          <p class="facodi-hero__card-foot">{{ i18n "home.heroCardFoot" (dict "MonynhaURL" "https://monynha.com") | safeHTML }}</p>
         </div>
       </div>
     </div>
@@ -61,17 +61,17 @@
   {{ end }}
 
   {{ $features := slice
-    (dict "icon" "🗺️" "title" "Mapa curricular interativo" "description" "Navegue por cursos, semestres e disciplinas com uma visão organizada dos currículos oficiais.")
-    (dict "icon" "🎧" "title" "Playlists integradas" "description" "Cada unidade curricular recebe playlists do YouTube e materiais públicos selecionados pela comunidade.")
-    (dict "icon" "✅" "title" "Marcação de progresso" "description" "Acompanhe o que já foi estudado e celebre cada módulo concluído no seu tempo.")
-    (dict "icon" "🌈" "title" "Curadoria diversa" "description" "Um coletivo vibrante garante acessibilidade, linguagem acolhedora e representatividade real.")
+    (dict "icon" "🗺️" "title" (i18n "home.feature.map.title") "description" (i18n "home.feature.map.description"))
+    (dict "icon" "🎧" "title" (i18n "home.feature.playlists.title") "description" (i18n "home.feature.playlists.description"))
+    (dict "icon" "✅" "title" (i18n "home.feature.progress.title") "description" (i18n "home.feature.progress.description"))
+    (dict "icon" "🌈" "title" (i18n "home.feature.curatorship.title") "description" (i18n "home.feature.curatorship.description"))
   }}
   <section class="facodi-section facodi-section--features">
     <div class="container-lg section-wrap">
       <div class="facodi-section__header section-header text-center">
-        <span class="facodi-section__eyebrow">Experiência FACODI</span>
-        <h2 class="section-title facodi-section__title">Experiência FACODI na palma da mão</h2>
-        <p class="facodi-section__subtitle">Tecnologia aberta para organizar o currículo, apoiar quem estuda e valorizar cada contribuição da comunidade.</p>
+        <span class="facodi-section__eyebrow">{{ i18n "home.featuresEyebrow" }}</span>
+        <h2 class="section-title facodi-section__title">{{ i18n "home.featuresTitle" }}</h2>
+        <p class="facodi-section__subtitle">{{ i18n "home.featuresSubtitle" }}</p>
       </div>
       <div class="facodi-grid facodi-grid--features">
         {{ range $features }}
@@ -90,9 +90,9 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow">Currículos abertos</span>
-          <h2 class="section-title facodi-section__title">Cursos em destaque na comunidade FACODI</h2>
-          <p class="facodi-section__subtitle">Currículos oficiais de licenciaturas e áreas afins com unidades curriculares, playlists abertas e resultados de aprendizagem organizados.</p>
+          <span class="facodi-section__eyebrow">{{ i18n "home.coursesEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title">{{ i18n "home.coursesTitle" }}</h2>
+          <p class="facodi-section__subtitle">{{ i18n "home.coursesSubtitle" }}</p>
         </div>
         <div class="facodi-section__cta">
           <a class="facodi-link facodi-link--cta" href="/courses/">{{ i18n "home.viewAllCourses" }}</a>
@@ -106,7 +106,7 @@
               {{ with .Params.plan_version }}
               <span class="facodi-pill facodi-pill--outline">{{ i18n "common.plan" }} {{ . }}</span>
               {{ end }}
-              <h3 class="facodi-course-card__title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+              <h3 class="facodi-course-card__title"><a href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
               {{ with .Params.summary }}
               <p class="facodi-course-card__summary">{{ . }}</p>
               {{ end }}
@@ -118,7 +118,8 @@
                 {{ with .Params.code }}<span>{{ i18n "common.code" }} {{ . }}</span>{{ end }}
               </div>
               {{ with .Params.ucs }}
-              <p class="facodi-course-card__foot">{{ len . }} unidades curriculares já mapeadas pela comunidade</p>
+              {{ $ucCount := len . }}
+              <p class="facodi-course-card__foot">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }} {{ i18n "home.courseCardFootSuffix" }}</p>
               {{ end }}
             </div>
           </article>
@@ -133,15 +134,15 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow facodi-section__eyebrow--light">Trilha comunitária</span>
-          <h2 class="section-title facodi-section__title">Como rola a jornada FACODI</h2>
-          <p class="facodi-section__subtitle">Da escolha do curso até a celebração do progresso, cada passo foi pensado para apoiar quem aprende, quem ensina e quem curte compartilhar conhecimento.</p>
+          <span class="facodi-section__eyebrow facodi-section__eyebrow--light">{{ i18n "home.journeyEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title">{{ i18n "home.journeyTitle" }}</h2>
+          <p class="facodi-section__subtitle">{{ i18n "home.journeySubtitle" }}</p>
         </div>
       </div>
       <ol class="facodi-journey__list">
-        <li>Escolha um currículo oficial e visualize semestres, cargas horárias, versões e contexto institucional.</li>
-        <li>Mergulhe nas unidades curriculares com resultados de aprendizagem, tópicos relacionados e playlists abertas.</li>
-        <li>Marque o progresso, compartilhe materiais com a comunidade e mantenha vivo o histórico de revisões.</li>
+        <li>{{ i18n "home.journeyStep1" }}</li>
+        <li>{{ i18n "home.journeyStep2" }}</li>
+        <li>{{ i18n "home.journeyStep3" }}</li>
       </ol>
     </div>
   </section>
@@ -151,9 +152,9 @@
 <section class="facodi-section facodi-section--manifesto">
   <div class="container-lg section-wrap">
     <div class="facodi-manifesto">
-      <span class="facodi-section__eyebrow">Manifesto Monynha Softwares</span>
-      <h2 class="section-title facodi-manifesto__title">Democratizar tecnologia, combater hipocrisia e dar voz a quem cria fora do padrão</h2>
-      <p class="facodi-manifesto__description">A FACODI nasce desse compromisso político-social: usar tecnologia acessível para abrir caminhos na educação superior, respeitando diversidade cultural e celebrando conhecimentos populares.</p>
+      <span class="facodi-section__eyebrow">{{ i18n "home.manifestoEyebrow" }}</span>
+      <h2 class="section-title facodi-manifesto__title">{{ i18n "home.manifestoTitle" }}</h2>
+      <p class="facodi-manifesto__description">{{ i18n "home.manifestoDescription" }}</p>
       <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.readManifesto" }}</a>
     </div>
   </div>
@@ -164,8 +165,8 @@
 <section class="facodi-section facodi-section--cta">
   <div class="container-lg section-wrap">
     <div class="facodi-cta">
-      <h2 class="section-title facodi-cta__title">Bora colar com a FACODI?</h2>
-      <p class="facodi-cta__description">Traga playlists, PDFs públicos, artigos e ideias para fortalecer a faculdade comunitária digital e deixar o currículo cada vez mais diverso.</p>
+      <h2 class="section-title facodi-cta__title">{{ i18n "home.ctaTitle" }}</h2>
+      <p class="facodi-cta__description">{{ i18n "home.ctaDescription" }}</p>
       <div class="facodi-cta__actions">
         <a class="facodi-hero__cta" href="/courses/">{{ i18n "home.viewCurricula" }}</a>
         <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.contactMonynha" }}</a>

--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -2,7 +2,8 @@
 {{- range site.RegularPages -}}
   {{- if ne .Params.searchable false -}}
     {{- $summary := .Summary | default (.Plain | truncate 200) -}}
-    {{- $items = $items | append (dict "title" .Title "summary" ($summary | plainify) "permalink" .RelPermalink "lang" .Lang "type" .Type) -}}
+    {{- $permalink := partial "facodi/langless-url.html" (dict "url" .RelPermalink) -}}
+    {{- $items = $items | append (dict "title" .Title "summary" ($summary | plainify) "permalink" $permalink "lang" .Lang "type" .Type) -}}
   {{- end -}}
 {{- end -}}
 {{- $items | jsonify -}}

--- a/layouts/uc/list.html
+++ b/layouts/uc/list.html
@@ -67,7 +67,7 @@
         {{ else }}
         <div class="list-group list-group-flush">
           {{ range sort $topics "Title" }}
-          <a class="list-group-item list-group-item-action" href="{{ .RelPermalink }}">
+          <a class="list-group-item list-group-item-action" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">
             <div class="d-flex justify-content-between align-items-start">
               <div>
                 <h3 class="h6 mb-1">{{ .Title }}</h3>


### PR DESCRIPTION
## Summary
- internationalized the home layout strings and kept the course metrics rendered with translation keys only
- added Portuguese, English, Spanish and French translations for the new home content
- introduced a langless URL helper and updated navigation, listings and cards to drop language prefixes from internal links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d052a9dd708322b41793006c4503dc