### PR TITLE
Refactor runtime localization and Google Translate fallback

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,17 @@
 const THEME_STORAGE_KEY = 'facodi-theme-preference';
+const LOCALE_STORAGE_KEY = 'facodi-locale';
 const root = document.documentElement;
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+let facodiConfig = {
+  defaultLocale: 'pt',
+  defaultGoogle: 'pt',
+  locales: []
+};
+let facodiTranslations = {};
+let currentLocale = 'pt';
+let googleTranslateReady = false;
+let pendingGoogleTarget = null;
 
 function readStoredTheme() {
   try {
@@ -56,21 +67,314 @@ function initTheme() {
   }
 }
 
+function parseJSONContent(element) {
+  if (!element) {
+    return null;
+  }
+  const raw = element.textContent || element.innerText || '';
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    return null;
+  }
+}
+
+function normalizeLocaleCode(code) {
+  return (code || '').toString().trim().toLowerCase();
+}
+
+function loadConfig() {
+  const data = parseJSONContent(document.getElementById('facodi-config')) || {};
+  const locales = Array.isArray(data.locales) ? data.locales : [];
+  const mappedLocales = locales
+    .map((entry) => {
+      const code = normalizeLocaleCode(entry.code || entry.Code);
+      if (!code) {
+        return null;
+      }
+      const label = entry.label || entry.Label || code.toUpperCase();
+      const google = normalizeLocaleCode(entry.google || entry.Google || code);
+      return { code, label, google: google || code };
+    })
+    .filter(Boolean);
+
+  if (!mappedLocales.length) {
+    mappedLocales.push({ code: 'pt', label: 'Português', google: 'pt' });
+  }
+
+  const defaultLocale = normalizeLocaleCode(data.defaultLocale || facodiConfig.defaultLocale || mappedLocales[0].code);
+  const defaultEntry = mappedLocales.find((entry) => entry.code === defaultLocale) || mappedLocales[0];
+
+  facodiConfig = {
+    defaultLocale: defaultEntry.code,
+    defaultGoogle: defaultEntry.google || defaultEntry.code,
+    locales: mappedLocales
+  };
+  currentLocale = facodiConfig.defaultLocale;
+}
+
+function loadTranslations() {
+  const data = parseJSONContent(document.getElementById('facodi-translations')) || {};
+  const entries = Object.keys(data).reduce((acc, locale) => {
+    const normalized = normalizeLocaleCode(locale);
+    const dictionary = data[locale] || {};
+    const mapped = Object.keys(dictionary).reduce((map, key) => {
+      const value = dictionary[key];
+      if (typeof value === 'string') {
+        map[key] = value;
+      }
+      return map;
+    }, {});
+    if (normalized) {
+      acc[normalized] = mapped;
+    }
+    return acc;
+  }, {});
+  facodiTranslations = entries;
+}
+
+function getLocaleInfo(locale) {
+  const normalized = normalizeLocaleCode(locale);
+  return facodiConfig.locales.find((entry) => entry.code === normalized) || null;
+}
+
+function readStoredLocale() {
+  try {
+    const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+    return stored ? normalizeLocaleCode(stored) : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function storeLocale(value) {
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, value);
+  } catch (error) {
+    // Ignore persistence errors.
+  }
+}
+
+function parseVars(element) {
+  const raw = element.getAttribute('data-i18n-vars');
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Object.keys(parsed).reduce((acc, key) => {
+      const value = parsed[key];
+      if (value === null || value === undefined) {
+        return acc;
+      }
+      acc[key] = typeof value === 'string' ? value : String(value);
+      return acc;
+    }, {});
+  } catch (error) {
+    return null;
+  }
+}
+
+const PLACEHOLDER_PATTERN = /\{\{\s*\.([A-Za-z0-9_]+)\s*\}\}/g;
+
+function renderTemplate(template, vars) {
+  if (typeof template !== 'string' || !vars) {
+    return template;
+  }
+  return template.replace(PLACEHOLDER_PATTERN, (match, key) => {
+    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+      return vars[key];
+    }
+    return match;
+  });
+}
+
+function getTranslation(locale, key) {
+  if (!key) {
+    return undefined;
+  }
+  const normalized = normalizeLocaleCode(locale);
+  const fallbackLocale = facodiConfig.defaultLocale;
+  const primary = facodiTranslations[normalized] || {};
+  if (Object.prototype.hasOwnProperty.call(primary, key)) {
+    return primary[key];
+  }
+  const fallback = facodiTranslations[fallbackLocale] || {};
+  return fallback[key];
+}
+
+function applyTranslations(locale) {
+  if (!facodiTranslations || !Object.keys(facodiTranslations).length) {
+    return;
+  }
+  const elements = document.querySelectorAll('[data-i18n]');
+  elements.forEach((element) => {
+    const key = element.getAttribute('data-i18n');
+    if (!key) {
+      return;
+    }
+    const template = getTranslation(locale, key);
+    if (typeof template !== 'string') {
+      return;
+    }
+    const vars = parseVars(element);
+    const rendered = renderTemplate(template, vars);
+    if (element.hasAttribute('data-i18n-html')) {
+      element.innerHTML = rendered;
+    } else {
+      element.textContent = rendered;
+    }
+  });
+
+  const attrElements = document.querySelectorAll('[data-i18n-attr]');
+  attrElements.forEach((element) => {
+    const mappingRaw = element.getAttribute('data-i18n-attr');
+    if (!mappingRaw) {
+      return;
+    }
+    let mapping;
+    try {
+      mapping = JSON.parse(mappingRaw);
+    } catch (error) {
+      return;
+    }
+    const vars = parseVars(element);
+    Object.keys(mapping).forEach((attr) => {
+      const attrKey = mapping[attr];
+      const template = getTranslation(locale, attrKey);
+      if (typeof template !== 'string') {
+        return;
+      }
+      const rendered = renderTemplate(template, vars);
+      element.setAttribute(attr, rendered);
+    });
+  });
+}
+
+function updateLocaleIndicators(locale) {
+  const normalized = normalizeLocaleCode(locale) || facodiConfig.defaultLocale;
+  root.lang = normalized;
+  if (document.body) {
+    document.body.dataset.lang = normalized;
+  }
+}
+
+function setSelectValue(locale) {
+  const select = document.querySelector('[data-facodi-language-select]');
+  if (!select) {
+    return;
+  }
+  const normalized = normalizeLocaleCode(locale);
+  const available = facodiConfig.locales.map((entry) => entry.code);
+  const target = available.includes(normalized) ? normalized : facodiConfig.defaultLocale;
+  select.value = target;
+}
+
+function shouldAutoTranslate() {
+  const body = document.body;
+  if (!body) {
+    return false;
+  }
+  return body.dataset.autoTranslate === 'true';
+}
+
+function hideGoogleArtifacts() {
+  const bannerFrames = document.querySelectorAll('.goog-te-banner-frame, .goog-te-balloon-frame');
+  bannerFrames.forEach((frame) => {
+    frame.style.setProperty('display', 'none', 'important');
+  });
+  document.documentElement.style.top = '0px';
+  if (document.body) {
+    document.body.style.top = '0px';
+  }
+}
+
+function applyGoogleTranslation(targetCode) {
+  const combo = document.querySelector('.goog-te-combo');
+  if (!combo) {
+    return false;
+  }
+  const normalized = normalizeLocaleCode(targetCode);
+  const defaultGoogle = normalizeLocaleCode(facodiConfig.defaultGoogle);
+  const value = !normalized || normalized === defaultGoogle ? '' : normalized;
+  if (combo.value !== value) {
+    combo.value = value;
+  }
+  combo.dispatchEvent(new Event('change'));
+  hideGoogleArtifacts();
+  pendingGoogleTarget = null;
+  return true;
+}
+
+function scheduleGoogleTranslation(locale) {
+  const shouldTranslate = locale !== facodiConfig.defaultLocale && shouldAutoTranslate();
+  const info = getLocaleInfo(locale);
+  const target = shouldTranslate ? (info && info.google ? info.google : locale) : facodiConfig.defaultGoogle;
+  pendingGoogleTarget = target;
+  if (googleTranslateReady) {
+    applyGoogleTranslation(target);
+  }
+}
+
+function markProtectedContent() {
+  const body = document.body;
+  if (!body) {
+    return;
+  }
+  if (body.dataset.course || body.dataset.uc || body.dataset.topic) {
+    const main = document.getElementById('main-content');
+    if (main) {
+      main.classList.add('notranslate');
+      main.setAttribute('translate', 'no');
+    }
+  }
+}
+
+function setLocale(locale) {
+  const normalized = normalizeLocaleCode(locale);
+  const available = facodiConfig.locales.map((entry) => entry.code);
+  const target = available.includes(normalized) ? normalized : facodiConfig.defaultLocale;
+  currentLocale = target;
+  applyTranslations(target);
+  updateLocaleIndicators(target);
+  setSelectValue(target);
+  storeLocale(target);
+  scheduleGoogleTranslation(target);
+}
+
 function initLanguageSwitcher() {
   const select = document.querySelector('[data-facodi-language-select]');
   if (!select) {
     return;
   }
-
   select.addEventListener('change', (event) => {
-    const target = event.target.value;
-    if (target && typeof target === 'string') {
-      window.location.assign(target);
-    }
+    setLocale(event.target.value);
   });
+}
+
+function initializeLocalization() {
+  loadConfig();
+  loadTranslations();
 }
 
 window.addEventListener('DOMContentLoaded', () => {
   initTheme();
+  markProtectedContent();
+  initializeLocalization();
   initLanguageSwitcher();
+  const storedLocale = readStoredLocale();
+  setLocale(storedLocale || facodiConfig.defaultLocale);
+});
+
+document.addEventListener('facodi:googleTranslateReady', () => {
+  googleTranslateReady = true;
+  if (pendingGoogleTarget === null) {
+    scheduleGoogleTranslation(currentLocale);
+  } else {
+    applyGoogleTranslation(pendingGoogleTarget);
+  }
+  hideGoogleArtifacts();
 });

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -998,6 +998,18 @@ html[data-theme="dark"] .facodi-theme-icon--light {
   border-top: 1px solid var(--facodi-surface-border);
 }
 
+.facodi-google-translate,
+.goog-te-banner-frame,
+.goog-te-gadget,
+.goog-te-banner-frame.skiptranslate,
+.goog-te-balloon-frame {
+  display: none !important;
+}
+
+body {
+  top: 0 !important;
+}
+
 // Responsive tweaks
 @media (max-width: 991.98px) {
   .facodi-navbar__inner {

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -13,6 +13,7 @@ summarylength = 20 # 70 (default)
 # Multilingual
 defaultContentLanguage = "pt"
 defaultContentLanguageInSubdir = false
+disableLanguages = ["en", "es", "fr"]
 
 copyRight = "Copyright (c) 2020-2024 Thulite"
 

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -5,27 +5,3 @@
   [pt.params]
     languageISO = "PT"
     languageTag = "pt-PT"
-
-[en]
-  languageName = "English"
-  contentDir = "content"
-  weight = 5
-  [en.params]
-    languageISO = "EN"
-    languageTag = "en-US"
-
-[fr]
-  languageName = "Français"
-  contentDir = "content"
-  weight = 10
-  [fr.params]
-    languageISO = "FR"
-    languageTag = "fr-FR"
-
-[es]
-  languageName = "Español"
-  contentDir = "content"
-  weight = 15
-  [es.params]
-    languageISO = "ES"
-    languageTag = "es-ES"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -7,6 +7,22 @@ images = ["cover.png"]
   supabaseUrl = ""
   supabaseAnonKey = ""
   defaultLocale = "pt"
+  [[facodi.locales]]
+    code = "pt"
+    label = "Português"
+    google = "pt"
+  [[facodi.locales]]
+    code = "en"
+    label = "English"
+    google = "en"
+  [[facodi.locales]]
+    code = "es"
+    label = "Español"
+    google = "es"
+  [[facodi.locales]]
+    code = "fr"
+    label = "Français"
+    google = "fr"
 
 # mainSections
 mainSections = ["docs"]
@@ -56,7 +72,7 @@ mainSections = ["docs"]
   scrollSpy = true # true (default) or false
 
   # Multilingual
-  multilingualMode = true # false (default) or true
+  multilingualMode = false # false (default) or true
   showMissingLanguages = true # whether or not to show untranslated languages in the language menu; true (default) or false
 
   # Versioning

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -6,6 +6,7 @@ date: 2023-09-07T17:19:07+02:00
 lastmod: 2023-09-07T17:19:07+02:00
 draft: false
 type: "legal"
+autoTranslate: true
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -97,14 +97,24 @@
       {{- end -}}
     {{- end -}}
   {{- end -}}
+  {{- $autoTranslate := false -}}
+  {{- with .Params.autoTranslate -}}
+    {{- $autoTranslate = . -}}
+  {{- end -}}
+  {{- if $autoTranslate -}}
+    {{- $bodyAttrs = $bodyAttrs | append "data-auto-translate=\"true\"" -}}
+  {{- else -}}
+    {{- $bodyAttrs = $bodyAttrs | append "data-auto-translate=\"false\"" -}}
+  {{- end -}}
   <body {{- if gt (len $bodyAttrs) 0 }} {{ delimit $bodyAttrs " " }}{{ end }}>
-    <a class="visually-hidden-focusable" href="#main-content">{{ i18n "common.skipToContent" }}</a>
+    <a class="visually-hidden-focusable" href="#main-content" data-i18n="common.skipToContent">{{ i18n "common.skipToContent" }}</a>
     {{ partial "header/header.html" . }}
     <main id="main-content" class="flex-fill" role="main">
       {{ block "main" . }}{{ end }}
     </main>
     {{ block "sidebar-prefooter" . }}{{ end }}
     {{ block "sidebar-footer" . }}{{ end }}
+    <div id="google_translate_element" class="facodi-google-translate" aria-hidden="true"></div>
     {{ partial "footer/footer.html" . }}
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <section class="facodi-section facodi-section--list py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "list.sectionIntro" }}</span>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="list.sectionIntro">{{ i18n "list.sectionIntro" }}</span>
       <h1 class="section-title mb-3">{{ .Title }}</h1>
       {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
       {{ with .Content }}<div class="content text-start">{{ . }}</div>{{ end }}
@@ -11,7 +11,7 @@
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm" role="status">{{ i18n "list.empty" }}</div>
+      <div class="alert alert-info shadow-sm" role="status" data-i18n="list.empty">{{ i18n "list.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -29,16 +29,16 @@
               </div>
               <footer class="facodi-card__footer">
                 {{ with .PublishDate }}
-                  <span class="facodi-card__meta">{{ i18n "list.published" }} {{ .Format "02 MMMM 2006" }}</span>
+                  <span class="facodi-card__meta"><span data-i18n="list.published">{{ i18n "list.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "list.readMore" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="list.readMore">{{ i18n "list.readMore" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}" data-i18n-attr='{{ dict "aria-label" "list.pagination" | jsonify | safeHTML }}'>
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,15 +8,15 @@
           {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
           {{ if or .PublishDate .Lastmod }}
             <p class="facodi-meta text-muted mb-0">
-              {{ with .PublishDate }}<span>{{ i18n "single.published" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
-              {{ with .Lastmod }}<span class="ms-3">{{ i18n "single.updated" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .PublishDate }}<span><span data-i18n="single.published">{{ i18n "single.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .Lastmod }}<span class="ms-3"><span data-i18n="single.updated">{{ i18n "single.updated" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
             </p>
           {{ end }}
         </header>
         <div class="content facodi-content">{{ .Content }}</div>
         {{ with .Params.tags }}
           <footer class="facodi-tags mt-5">
-            <h2 class="h5 mb-3">{{ i18n "single.tags" }}</h2>
+            <h2 class="h5 mb-3" data-i18n="single.tags">{{ i18n "single.tags" }}</h2>
             <div class="facodi-tag-list">
               {{ range . }}<a class="badge rounded-pill bg-light text-muted" href="{{ "tags" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end }}
             </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,15 +2,15 @@
 <section class="facodi-section facodi-section--taxonomy py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "taxonomy.termEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "taxonomy.termTitle" (dict "Term" .Data.Term "Name" .Title) }}</h1>
-      {{ with .Data.Term | humanize }}<p class="lead text-muted">{{ i18n "taxonomy.termIntro" (dict "Term" .) }}</p>{{ end }}
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="taxonomy.termEyebrow">{{ i18n "taxonomy.termEyebrow" }}</span>
+      <h1 class="section-title mb-3" data-i18n="taxonomy.termTitle" data-i18n-vars='{{ dict "Term" .Data.Term "Name" .Title | jsonify | safeHTML }}'>{{ i18n "taxonomy.termTitle" (dict "Term" .Data.Term "Name" .Title) }}</h1>
+      {{ with .Data.Term | humanize }}<p class="lead text-muted" data-i18n="taxonomy.termIntro" data-i18n-vars='{{ dict "Term" . | jsonify | safeHTML }}'>{{ i18n "taxonomy.termIntro" (dict "Term" .) }}</p>{{ end }}
     </header>
     {{ $collection := .Pages }}
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "taxonomy.noEntries" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="taxonomy.noEntries">{{ i18n "taxonomy.noEntries" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -27,14 +27,14 @@
                     {{ range $tags }}<span class="badge bg-light text-muted">{{ . }}</span>{{ end }}
                   </div>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "taxonomy.viewEntry" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="taxonomy.viewEntry">{{ i18n "taxonomy.viewEntry" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}" data-i18n-attr='{{ dict "aria-label" "taxonomy.pagination" | jsonify | safeHTML }}'>
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,13 +2,13 @@
 <section class="facodi-section facodi-section--terms py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "terms.overviewEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "terms.overviewTitle" (dict "Taxonomy" (.Title | humanize)) }}</h1>
-      <p class="lead text-muted">{{ i18n "terms.overviewIntro" }}</p>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="terms.overviewEyebrow">{{ i18n "terms.overviewEyebrow" }}</span>
+      <h1 class="section-title mb-3" data-i18n="terms.overviewTitle" data-i18n-vars='{{ dict "Taxonomy" (.Title | humanize) | jsonify | safeHTML }}'>{{ i18n "terms.overviewTitle" (dict "Taxonomy" (.Title | humanize)) }}</h1>
+      <p class="lead text-muted" data-i18n="terms.overviewIntro">{{ i18n "terms.overviewIntro" }}</p>
     </header>
     {{ $terms := .Data.Terms.Alphabetical }}
     {{ if not (len $terms) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "terms.empty" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="terms.empty">{{ i18n "terms.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $terms }}
@@ -16,10 +16,10 @@
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
                 <h2 class="h5 facodi-card__title"><a class="facodi-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ .Page.Title }}</a></h2>
-                <p class="facodi-card__meta">{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
+                <p class="facodi-card__meta" data-i18n="terms.entryCount" data-i18n-vars='{{ dict "Count" .Count | jsonify | safeHTML }}'>{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
               </div>
               <footer class="facodi-card__footer">
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ i18n "terms.viewTerm" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}" data-i18n="terms.viewTerm">{{ i18n "terms.viewTerm" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_partials/footer/footer.html
+++ b/layouts/_partials/footer/footer.html
@@ -4,10 +4,10 @@
       <div class="col-lg-6">
         <h2 class="h5 text-uppercase text-muted">{{ site.Title }}</h2>
         <p class="mb-3 text-muted">{{ site.Params.description }}</p>
-        <p class="small text-muted mb-0">{{ i18n "footer.license" }}</p>
+        <p class="small text-muted mb-0" data-i18n="footer.license">{{ i18n "footer.license" }}</p>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.navigation" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.navigation">{{ i18n "footer.navigation" }}</h3>
         <ul class="list-unstyled mb-0">
           {{ range site.Menus.main }}
             {{- $itemURL := .URL | default "" -}}
@@ -22,7 +22,7 @@
         </ul>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.community" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.community">{{ i18n "footer.community" }}</h3>
         <ul class="list-unstyled mb-0">
           <li><a class="facodi-footer__link" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener">GitHub</a></li>
           <li><a class="facodi-footer__link" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a></li>
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="facodi-footer__bottom mt-4 pt-4 border-top">
-      <p class="small text-muted mb-0">{{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}</p>
+      <p class="small text-muted mb-0" data-i18n="footer.copyright" data-i18n-vars='{{ dict "Year" now.Year "Organization" "Monynha Softwares" | jsonify | safeHTML }}'>{{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}</p>
     </div>
   </div>
 </footer>

--- a/layouts/_partials/footer/script-footer-custom.html
+++ b/layouts/_partials/footer/script-footer-custom.html
@@ -1,40 +1,59 @@
 {{- $supabaseUrl := or (getenv "SUPABASE_URL") site.Params.facodi.supabaseUrl -}}
 {{- $supabaseAnon := or (getenv "SUPABASE_ANON_KEY") site.Params.facodi.supabaseAnonKey -}}
-{{- $translationKeys := slice
-  "course.noUcs"
-  "common.unit"
-  "common.units"
-  "common.semester"
-  "common.year"
-  "common.playlist"
-  "common.playlists"
-  "common.topic"
-  "common.topics"
-  "common.ects"
-  "common.language"
-  "uc.topics"
-  "uc.noTopics"
-  "uc.playlists"
-  "uc.noPlaylists"
-  "uc.learningOutcomes"
-  "uc.noLearningOutcomes"
-  "uc.noPrerequisites"
-  "topic.noTags"
-  "topic.relatedPlaylists"
-  "topic.noPlaylists"
--}}
-{{- $translationMap := dict -}}
-{{- range $translationKeys -}}
-  {{- $translationMap = merge $translationMap (dict . (i18n .)) -}}
+{{- $locales := site.Params.facodi.locales | default (slice (dict "code" "pt" "label" "Português" "google" "pt")) -}}
+{{- $defaultLocale := site.Params.facodi.defaultLocale | default "pt" -}}
+{{- $translationBundle := dict -}}
+{{- range $locale := $locales -}}
+  {{- $code := $locale.code | default $locale.Code | lower -}}
+  {{- $filePath := printf "i18n/%s.json" $code -}}
+  {{- $entries := transform.Unmarshal (readFile $filePath) -}}
+  {{- $localeMap := dict -}}
+  {{- range $entry := $entries -}}
+    {{- $id := $entry.id | default $entry.Id -}}
+    {{- $translation := $entry.translation | default $entry.Translation -}}
+    {{- if and $id (not (in $localeMap $id)) -}}
+      {{- $localeMap = merge $localeMap (dict $id $translation) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $translationBundle = merge $translationBundle (dict $code $localeMap) -}}
 {{- end -}}
-<script id="facodi-translations" type="application/json">{{ $translationMap | jsonify | safeHTML }}</script>
-<script id="facodi-config" type="application/json">{{ dict "supabaseUrl" $supabaseUrl "supabaseAnonKey" $supabaseAnon | jsonify | safeHTML }}</script>
+<script id="facodi-translations" type="application/json">{{ $translationBundle | jsonify | safeHTML }}</script>
+<script id="facodi-config" type="application/json">{{ dict "supabaseUrl" $supabaseUrl "supabaseAnonKey" $supabaseAnon "defaultLocale" $defaultLocale "locales" $locales | jsonify | safeHTML }}</script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js" integrity="sha384-AkNSQdptcXlJ0/NBZc4qGk86cDVXcCevwoWgEKIpHOEfbvlXGLlIkimQtONt8KNf" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
 {{ $customScript := resources.Get "js/custom.js" | js.Build (dict "format" "iife" "target" "es2017") }}
 <script src="{{ $customScript.RelPermalink }}" defer></script>
 <script src="{{ "js/supabaseClient.js" | relURL }}" defer></script>
 <script src="{{ "js/loaders.js" | relURL }}" defer></script>
+<script>
+  window.facodiGoogleTranslateInit = function () {
+    if (!window.google || !window.google.translate) {
+      return;
+    }
+    var bundle = document.getElementById('facodi-config');
+    var locales = [];
+    if (bundle) {
+      try {
+        var config = JSON.parse(bundle.textContent || bundle.innerText || '{}');
+        locales = (config.locales || []).map(function (locale) {
+          return locale.google || locale.code;
+        });
+      } catch (error) {
+        locales = [];
+      }
+    }
+    var targetLanguages = locales.filter(function (code) {
+      return code && code !== 'pt';
+    }).join(',');
+    window.facodiGoogleTranslateElement = new google.translate.TranslateElement({
+      pageLanguage: 'pt',
+      autoDisplay: false,
+      includedLanguages: targetLanguages
+    }, 'google_translate_element');
+    document.dispatchEvent(new CustomEvent('facodi:googleTranslateReady'));
+  };
+</script>
+<script src="//translate.google.com/translate_a/element.js?cb=facodiGoogleTranslateInit" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     if (!window.facodiLoaders) {

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -21,8 +21,8 @@
     <a class="navbar-brand facodi-navbar__brand" href="{{ relLangURL "" }}">{{ .Site.Title }}</a>
 
     <!-- Main navigation button -->
-    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}">
-      <span class="visually-hidden">{{ i18n "nav.openMenu" }}</span>
+    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}" data-i18n-attr='{{ dict "aria-label" "nav.openMainMenu" | jsonify | safeHTML }}'>
+      <span class="visually-hidden" data-i18n="nav.openMenu">{{ i18n "nav.openMenu" }}</span>
       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
         <line x1="4" y1="8" x2="20" y2="8"></line>
@@ -37,7 +37,7 @@
       {{ end -}}
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="offcanvasNavMainLabel">{{ site.Title }}</h5>
-        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}">
+        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}" data-i18n-attr='{{ dict "aria-label" "nav.closeMenu" | jsonify | safeHTML }}'>
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M18 6l-12 12"></path>
@@ -104,45 +104,30 @@
           {{ end -}}
         </ul>
         <div class="facodi-navbar__actions d-flex flex-column flex-sm-row align-items-stretch align-items-lg-center gap-3 ms-lg-auto">
-          {{ $currentRel := .RelPermalink }}
-          {{ $path := $currentRel }}
-          {{ range site.Languages }}
-            {{ if hasPrefix $path (printf "/%s/" .Lang) }}
-              {{ $path = strings.TrimPrefix (printf "/%s" .Lang) $path }}
-            {{ end }}
-          {{ end }}
-          {{ $defaultLang := site.Params.facodi.defaultLocale | default site.Language.Lang }}
+          {{- $locales := site.Params.facodi.locales | default (slice (dict "code" "pt" "label" "Português")) -}}
+          {{- $defaultLocale := site.Params.facodi.defaultLocale | default "pt" -}}
           <div class="facodi-navbar__language">
-            <label class="visually-hidden" for="facodi-language-select">{{ i18n "nav.languageLabel" }}</label>
-            <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select aria-label="{{ i18n "nav.languageLabel" }}">
-              {{ range site.Languages }}
-                {{ $translations := where $.AllTranslations "Lang" .Lang }}
-                {{ $target := "" }}
-                {{ if $translations }}
-                  {{ $target = (index $translations 0).RelPermalink }}
-                {{ else }}
-                  {{ $prefix := "" }}
-                  {{ if ne .Lang $defaultLang }}
-                    {{ $prefix = printf "/%s" .Lang }}
-                  {{ end }}
-                  {{ $target = printf "%s%s" $prefix $path }}
-                {{ end }}
-                <option value="{{ $target }}"{{ if eq $.Lang .Lang }} selected{{ end }}>{{ .LanguageName }}</option>
-              {{ end }}
+            <label class="visually-hidden" for="facodi-language-select" data-i18n="nav.languageLabel">{{ i18n "nav.languageLabel" }}</label>
+            <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select aria-label="{{ i18n "nav.languageLabel" }}" data-i18n-attr='{{ dict "aria-label" "nav.languageLabel" | jsonify | safeHTML }}'>
+              {{- range $locales -}}
+                {{- $code := .code | default .Code -}}
+                {{- $label := .label | default .Label -}}
+                <option value="{{ $code }}"{{ if eq (lower $code) (lower $defaultLocale) }} selected{{ end }}>{{ $label }}</option>
+              {{- end -}}
             </select>
           </div>
-          <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}">
+          <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}" data-i18n-attr='{{ dict "aria-label" "nav.themeToggle" | jsonify | safeHTML }}'>
             <span class="facodi-theme-icon facodi-theme-icon--light" aria-hidden="true">☀️</span>
             <span class="facodi-theme-icon facodi-theme-icon--dark" aria-hidden="true">🌙</span>
-            <span class="visually-hidden">{{ i18n "nav.themeToggle" }}</span>
+            <span class="visually-hidden" data-i18n="nav.themeToggle">{{ i18n "nav.themeToggle" }}</span>
           </button>
-          <a class="facodi-navbar__icon" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" aria-label="{{ i18n "nav.github" }}">
+          <a class="facodi-navbar__icon" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" aria-label="{{ i18n "nav.github" }}" data-i18n-attr='{{ dict "aria-label" "nav.github" | jsonify | safeHTML }}'>
             <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" role="img">
               <path d="M12 .5a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.1c-3.3.7-4-1.6-4-1.6-.5-1.3-1.2-1.6-1.2-1.6-1-.7.1-.7.1-.7 1.1.1 1.7 1.1 1.7 1.1 1 .1.8-.8 1.7-1.1 1.5-.3 2.6.5 3 .8.1-.8.4-1.3.7-1.6-2.7-.3-5.6-1.4-5.6-6.1 0-1.3.5-2.4 1.1-3.3-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.7.9 1.1 2 1.1 3.3 0 4.7-2.9 5.8-5.6 6.1.4.3.8 1 .8 2.1v3.1c0 .3.2.7.8.6A12 12 0 0 0 12 .5Z" />
             </svg>
           </a>
           {{ if site.Params.doks.navBarButton -}}
-            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}" data-i18n="nav.viewTracks">{{ i18n "nav.viewTracks" }}</a>
           {{ end -}}
         </div>
       </div>

--- a/layouts/course/list.html
+++ b/layouts/course/list.html
@@ -13,7 +13,7 @@
         <div>
           <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
           {{ with $params.plan_version }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.plan" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
           {{ end }}
           <h1 class="display-5 mt-3">{{ .Title }}</h1>
           {{ with $params.summary }}<p class="lead text-muted mb-0" data-facodi-course-summary>{{ . }}</p>{{ end }}
@@ -21,17 +21,17 @@
         <div class="card shadow-sm border-0">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.degree" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.degree | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.ectsTotal" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.ectsTotal">{{ i18n "common.ectsTotal" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects_total | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.duration" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.duration_semesters | default "--" }} <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.institution" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.institution">{{ i18n "common.institution" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.institution | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.school" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.school">{{ i18n "common.school" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.school | default "--" }}</dd>
             </dl>
           </div>
@@ -58,12 +58,12 @@
       {{ $ucPages := $scratch.Get "ucs" }}
       {{ $ucCount := len $ucPages }}
       <div class="course-ucs__header">
-        <h2 class="section-title course-ucs__title">{{ i18n "course.curricularUnits" }}</h2>
-        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span>
+        <h2 class="section-title course-ucs__title" data-i18n="course.curricularUnits">{{ i18n "course.curricularUnits" }}</h2>
+        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} {{ if eq $ucCount 1 }}<span data-i18n="common.unit">{{ i18n "common.unit" }}</span>{{ else }}<span data-i18n="common.units">{{ i18n "common.units" }}</span>{{ end }}</span>
       </div>
       <div class="course-uc-groups" id="course-ucs" data-facodi-slot="course-ucs">
         {{ if not $ucCount }}
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning" role="alert" data-i18n="course.noUcs">
           {{ i18n "course.noUcs" }}
         </div>
         {{ else }}
@@ -99,27 +99,27 @@
           {{ $semesterMap := index $grouped $yearKey }}
           <section class="course-uc-year">
             <header class="course-uc-year__header">
-              <h3 class="course-uc-year__title">{{ i18n "common.year" }} {{ $year }}</h3>
+              <h3 class="course-uc-year__title"><span data-i18n="common.year">{{ i18n "common.year" }}</span> {{ $year }}</h3>
             </header>
             {{ range $sem := seq 1 2 }}
               {{ $semKey := printf "%d" $sem }}
               {{ with index $semesterMap $semKey }}
               <div class="course-uc-semester">
-                <h4 class="course-uc-semester__title">{{ i18n "common.semester" }} {{ add (mul (sub $year 1) 2) $sem }}</h4>
+                <h4 class="course-uc-semester__title"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ add (mul (sub $year 1) 2) $sem }}</h4>
                 <div class="course-uc-grid">
                   {{ range . }}
                   {{ $ucParams := .Params }}
                   <article class="course-uc-card">
                     <div class="course-uc-card__meta">
                       <span class="course-uc-card__code">{{ $ucParams.code }}</span>
-                      {{ with $ucParams.semester }}<span class="course-uc-card__semester">{{ i18n "common.semester" }} {{ . }}</span>{{ end }}
+                      {{ with $ucParams.semester }}<span class="course-uc-card__semester"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ . }}</span>{{ end }}
                     </div>
                     <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
                     {{ with $ucParams.description }}<p class="course-uc-card__summary">{{ . }}</p>{{ end }}
                     <dl class="course-uc-card__details">
-                      <dt>{{ i18n "common.ects" }}</dt>
+                      <dt data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
                       <dd>{{ $ucParams.ects | default "--" }}</dd>
-                      <dt>{{ i18n "common.language" }}</dt>
+                      <dt data-i18n="common.language">{{ i18n "common.language" }}</dt>
                       <dd>{{ $ucParams.language | default "--" }}</dd>
                     </dl>
                   </article>

--- a/layouts/courses/list.html
+++ b/layouts/courses/list.html
@@ -13,7 +13,7 @@
     {{ $courses := sort .Sections "Title" }}
     {{ if not (len $courses) }}
     <div class="col-12">
-      <div class="alert alert-warning" role="alert">
+      <div class="alert alert-warning" role="alert" data-i18n="catalog.noCourses">
         {{ i18n "catalog.noCourses" }}
       </div>
     </div>
@@ -26,7 +26,7 @@
           <div class="d-flex align-items-center justify-content-between mb-3">
             <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
             {{ with $params.plan_version }}
-            <span class="text-muted small">{{ i18n "common.plan" }} {{ . }}</span>
+            <span class="text-muted small"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
             {{ end }}
           </div>
           <h2 class="h4">{{ .Title }}</h2>
@@ -36,15 +36,15 @@
           {{ with .Summary }}<p class="text-muted">{{ . }}</p>{{ end }}
           {{ end }}
           <dl class="row small text-muted mb-4">
-            <dt class="col-5">{{ i18n "common.degree" }}</dt>
+            <dt class="col-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
             <dd class="col-7">{{ $params.degree | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.ects" }}</dt>
+            <dt class="col-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
             <dd class="col-7">{{ $params.ects_total | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.duration" }}</dt>
-            <dd class="col-7">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
+            <dt class="col-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+            <dd class="col-7">{{ $params.duration_semesters | default "--" }} <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
           </dl>
           <div class="mt-auto">
-            <a class="btn btn-outline-primary w-100" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "catalog.viewCurriculum" }}</a>
+            <a class="btn btn-outline-primary w-100" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="catalog.viewCurriculum">{{ i18n "catalog.viewCurriculum" }}</a>
           </div>
         </div>
       </div>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -18,33 +18,33 @@
       <div class="facodi-hero__grid">
         <div class="facodi-hero__content">
           <div class="facodi-hero__intro">
-            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">{{ i18n "home.heroBadge" }}</span>
+            <span class="facodi-pill facodi-pill--brand facodi-hero__badge" data-i18n="home.heroBadge">{{ i18n "home.heroBadge" }}</span>
             <h1 class="facodi-hero__title">{{ site.Title }}</h1>
             <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
           </div>
           <div class="facodi-hero__actions">
-            <a class="facodi-hero__cta" href="/courses/" role="button">{{ i18n "nav.viewTracks" }}</a>
-            <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.ecosystemCta" }}</a>
+            <a class="facodi-hero__cta" href="/courses/" role="button" data-i18n="nav.viewTracks">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.ecosystemCta">{{ i18n "home.ecosystemCta" }}</a>
           </div>
           <div class="facodi-hero__meta">
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--success">{{ i18n "home.heroPillOpenLabel" }}</span>
-              <p>{{ i18n "home.heroPillOpenDescription" }}</p>
+              <span class="facodi-pill facodi-pill--success" data-i18n="home.heroPillOpenLabel">{{ i18n "home.heroPillOpenLabel" }}</span>
+              <p data-i18n="home.heroPillOpenDescription">{{ i18n "home.heroPillOpenDescription" }}</p>
             </div>
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--outline">{{ i18n "home.heroPillCommunityLabel" }}</span>
-              <p>{{ i18n "home.heroPillCommunityDescription" }}</p>
+              <span class="facodi-pill facodi-pill--outline" data-i18n="home.heroPillCommunityLabel">{{ i18n "home.heroPillCommunityLabel" }}</span>
+              <p data-i18n="home.heroPillCommunityDescription">{{ i18n "home.heroPillCommunityDescription" }}</p>
             </div>
           </div>
         </div>
         <div class="facodi-hero__card">
-          <span class="facodi-hero__card-label">{{ i18n "home.heroCardLabel" }}</span>
+          <span class="facodi-hero__card-label" data-i18n="home.heroCardLabel">{{ i18n "home.heroCardLabel" }}</span>
           <ul class="facodi-hero__stat-list">
-            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> {{ i18n "home.heroCardCoursesLabel" }}</li>
-            <li><strong>{{ $scratch.Get "ucCount" }}</strong> {{ i18n "home.heroCardUnitsLabel" }}</li>
-            <li>{{ i18n "home.heroCardProgress" }}</li>
+            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> <span data-i18n="home.heroCardCoursesLabel">{{ i18n "home.heroCardCoursesLabel" }}</span></li>
+            <li><strong>{{ $scratch.Get "ucCount" }}</strong> <span data-i18n="home.heroCardUnitsLabel">{{ i18n "home.heroCardUnitsLabel" }}</span></li>
+            <li data-i18n="home.heroCardProgress">{{ i18n "home.heroCardProgress" }}</li>
           </ul>
-          <p class="facodi-hero__card-foot">{{ i18n "home.heroCardFoot" (dict "MonynhaURL" "https://monynha.com") | safeHTML }}</p>
+          <p class="facodi-hero__card-foot" data-i18n="home.heroCardFoot" data-i18n-vars='{{ dict "MonynhaURL" "https://monynha.com" | jsonify | safeHTML }}' data-i18n-html="true">{{ i18n "home.heroCardFoot" (dict "MonynhaURL" "https://monynha.com") | safeHTML }}</p>
         </div>
       </div>
     </div>
@@ -61,24 +61,24 @@
   {{ end }}
 
   {{ $features := slice
-    (dict "icon" "🗺️" "title" (i18n "home.feature.map.title") "description" (i18n "home.feature.map.description"))
-    (dict "icon" "🎧" "title" (i18n "home.feature.playlists.title") "description" (i18n "home.feature.playlists.description"))
-    (dict "icon" "✅" "title" (i18n "home.feature.progress.title") "description" (i18n "home.feature.progress.description"))
-    (dict "icon" "🌈" "title" (i18n "home.feature.curatorship.title") "description" (i18n "home.feature.curatorship.description"))
+    (dict "icon" "🗺️" "titleKey" "home.feature.map.title" "descriptionKey" "home.feature.map.description")
+    (dict "icon" "🎧" "titleKey" "home.feature.playlists.title" "descriptionKey" "home.feature.playlists.description")
+    (dict "icon" "✅" "titleKey" "home.feature.progress.title" "descriptionKey" "home.feature.progress.description")
+    (dict "icon" "🌈" "titleKey" "home.feature.curatorship.title" "descriptionKey" "home.feature.curatorship.description")
   }}
   <section class="facodi-section facodi-section--features">
     <div class="container-lg section-wrap">
       <div class="facodi-section__header section-header text-center">
-        <span class="facodi-section__eyebrow">{{ i18n "home.featuresEyebrow" }}</span>
-        <h2 class="section-title facodi-section__title">{{ i18n "home.featuresTitle" }}</h2>
-        <p class="facodi-section__subtitle">{{ i18n "home.featuresSubtitle" }}</p>
+        <span class="facodi-section__eyebrow" data-i18n="home.featuresEyebrow">{{ i18n "home.featuresEyebrow" }}</span>
+        <h2 class="section-title facodi-section__title" data-i18n="home.featuresTitle">{{ i18n "home.featuresTitle" }}</h2>
+        <p class="facodi-section__subtitle" data-i18n="home.featuresSubtitle">{{ i18n "home.featuresSubtitle" }}</p>
       </div>
       <div class="facodi-grid facodi-grid--features">
         {{ range $features }}
         <div class="facodi-feature-card">
           <span class="facodi-feature-card__icon">{{ .icon }}</span>
-          <h3 class="facodi-feature-card__title">{{ .title }}</h3>
-          <p class="facodi-feature-card__description">{{ .description }}</p>
+          <h3 class="facodi-feature-card__title" data-i18n="{{ .titleKey }}">{{ i18n .titleKey }}</h3>
+          <p class="facodi-feature-card__description" data-i18n="{{ .descriptionKey }}">{{ i18n .descriptionKey }}</p>
         </div>
         {{ end }}
       </div>
@@ -90,12 +90,12 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow">{{ i18n "home.coursesEyebrow" }}</span>
-          <h2 class="section-title facodi-section__title">{{ i18n "home.coursesTitle" }}</h2>
-          <p class="facodi-section__subtitle">{{ i18n "home.coursesSubtitle" }}</p>
+          <span class="facodi-section__eyebrow" data-i18n="home.coursesEyebrow">{{ i18n "home.coursesEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.coursesTitle">{{ i18n "home.coursesTitle" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.coursesSubtitle">{{ i18n "home.coursesSubtitle" }}</p>
         </div>
         <div class="facodi-section__cta">
-          <a class="facodi-link facodi-link--cta" href="/courses/">{{ i18n "home.viewAllCourses" }}</a>
+          <a class="facodi-link facodi-link--cta" href="/courses/" data-i18n="home.viewAllCourses">{{ i18n "home.viewAllCourses" }}</a>
         </div>
       </div>
       <div class="facodi-grid facodi-grid--courses">
@@ -104,7 +104,7 @@
           <article class="facodi-course-card">
             <div class="facodi-course-card__body">
               {{ with .Params.plan_version }}
-              <span class="facodi-pill facodi-pill--outline">{{ i18n "common.plan" }} {{ . }}</span>
+              <span class="facodi-pill facodi-pill--outline"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
               {{ end }}
               <h3 class="facodi-course-card__title"><a href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
               {{ with .Params.summary }}
@@ -113,13 +113,13 @@
             </div>
             <div class="facodi-course-card__meta">
               <div class="facodi-course-card__stats">
-                {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> {{ i18n "common.ects" }}</span>{{ end }}
-                {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> {{ i18n "common.durationSuffix" }}</span>{{ end }}
-                {{ with .Params.code }}<span>{{ i18n "common.code" }} {{ . }}</span>{{ end }}
+                {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> <span data-i18n="common.ects">{{ i18n "common.ects" }}</span></span>{{ end }}
+                {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></span>{{ end }}
+                {{ with .Params.code }}<span><span data-i18n="common.code">{{ i18n "common.code" }}</span> {{ . }}</span>{{ end }}
               </div>
               {{ with .Params.ucs }}
               {{ $ucCount := len . }}
-              <p class="facodi-course-card__foot">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }} {{ i18n "home.courseCardFootSuffix" }}</p>
+              <p class="facodi-course-card__foot">{{ $ucCount }} {{ if eq $ucCount 1 }}<span data-i18n="common.unit">{{ i18n "common.unit" }}</span>{{ else }}<span data-i18n="common.units">{{ i18n "common.units" }}</span>{{ end }} <span data-i18n="home.courseCardFootSuffix">{{ i18n "home.courseCardFootSuffix" }}</span></p>
               {{ end }}
             </div>
           </article>
@@ -134,15 +134,15 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow facodi-section__eyebrow--light">{{ i18n "home.journeyEyebrow" }}</span>
-          <h2 class="section-title facodi-section__title">{{ i18n "home.journeyTitle" }}</h2>
-          <p class="facodi-section__subtitle">{{ i18n "home.journeySubtitle" }}</p>
+          <span class="facodi-section__eyebrow facodi-section__eyebrow--light" data-i18n="home.journeyEyebrow">{{ i18n "home.journeyEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.journeyTitle">{{ i18n "home.journeyTitle" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.journeySubtitle">{{ i18n "home.journeySubtitle" }}</p>
         </div>
       </div>
       <ol class="facodi-journey__list">
-        <li>{{ i18n "home.journeyStep1" }}</li>
-        <li>{{ i18n "home.journeyStep2" }}</li>
-        <li>{{ i18n "home.journeyStep3" }}</li>
+        <li data-i18n="home.journeyStep1">{{ i18n "home.journeyStep1" }}</li>
+        <li data-i18n="home.journeyStep2">{{ i18n "home.journeyStep2" }}</li>
+        <li data-i18n="home.journeyStep3">{{ i18n "home.journeyStep3" }}</li>
       </ol>
     </div>
   </section>
@@ -152,10 +152,10 @@
 <section class="facodi-section facodi-section--manifesto">
   <div class="container-lg section-wrap">
     <div class="facodi-manifesto">
-      <span class="facodi-section__eyebrow">{{ i18n "home.manifestoEyebrow" }}</span>
-      <h2 class="section-title facodi-manifesto__title">{{ i18n "home.manifestoTitle" }}</h2>
-      <p class="facodi-manifesto__description">{{ i18n "home.manifestoDescription" }}</p>
-      <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.readManifesto" }}</a>
+      <span class="facodi-section__eyebrow" data-i18n="home.manifestoEyebrow">{{ i18n "home.manifestoEyebrow" }}</span>
+      <h2 class="section-title facodi-manifesto__title" data-i18n="home.manifestoTitle">{{ i18n "home.manifestoTitle" }}</h2>
+      <p class="facodi-manifesto__description" data-i18n="home.manifestoDescription">{{ i18n "home.manifestoDescription" }}</p>
+      <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.readManifesto">{{ i18n "home.readManifesto" }}</a>
     </div>
   </div>
 </section>
@@ -165,11 +165,11 @@
 <section class="facodi-section facodi-section--cta">
   <div class="container-lg section-wrap">
     <div class="facodi-cta">
-      <h2 class="section-title facodi-cta__title">{{ i18n "home.ctaTitle" }}</h2>
-      <p class="facodi-cta__description">{{ i18n "home.ctaDescription" }}</p>
+      <h2 class="section-title facodi-cta__title" data-i18n="home.ctaTitle">{{ i18n "home.ctaTitle" }}</h2>
+      <p class="facodi-cta__description" data-i18n="home.ctaDescription">{{ i18n "home.ctaDescription" }}</p>
       <div class="facodi-cta__actions">
-        <a class="facodi-hero__cta" href="/courses/">{{ i18n "home.viewCurricula" }}</a>
-        <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.contactMonynha" }}</a>
+        <a class="facodi-hero__cta" href="/courses/" data-i18n="home.viewCurricula">{{ i18n "home.viewCurricula" }}</a>
+        <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.contactMonynha">{{ i18n "home.contactMonynha" }}</a>
       </div>
     </div>
   </div>

--- a/layouts/topic/single.html
+++ b/layouts/topic/single.html
@@ -36,7 +36,7 @@
         {{ with $params.tags }}
           {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1">{{ . }}</span>{{ end }}
         {{ else }}
-          <span class="text-muted small">{{ i18n "topic.noTags" }}</span>
+          <span class="text-muted small" data-i18n="topic.noTags">{{ i18n "topic.noTags" }}</span>
         {{ end }}
       </div>
     </div>
@@ -45,7 +45,7 @@
     <div class="col-lg-8">
       <article class="content mb-5" id="topic-content" data-facodi-slot="topic-content">{{ .Content }}</article>
       <section id="topic-playlists" data-facodi-slot="topic-playlists">
-        <h2 class="h5">{{ i18n "topic.relatedPlaylists" }}</h2>
+        <h2 class="h5" data-i18n="topic.relatedPlaylists">{{ i18n "topic.relatedPlaylists" }}</h2>
         {{ if $params.youtube_playlists }}
         <ul class="list-unstyled">
           {{ range sort $params.youtube_playlists "priority" }}
@@ -57,7 +57,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "topic.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="topic.noPlaylists">{{ i18n "topic.noPlaylists" }}</p>
         {{ end }}
       </section>
     </div>

--- a/layouts/uc/list.html
+++ b/layouts/uc/list.html
@@ -26,7 +26,7 @@
         <div>
           <span class="badge bg-secondary-subtle text-secondary">{{ $params.code }}</span>
           {{ with $params.semester }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.semester" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> {{ . }}</span>
           {{ end }}
           <h1 class="display-6 mt-3">{{ .Title }}</h1>
           {{ with $params.description }}<p class="lead text-muted">{{ . }}</p>{{ end }}
@@ -34,16 +34,16 @@
         <div class="card border-0 shadow-sm">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.ects" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "uc.prerequisites" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="uc.prerequisites">{{ i18n "uc.prerequisites" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end" data-facodi-uc-prerequisites>
                 {{ if $params.prerequisites }}
                   {{ delimit $params.prerequisites ", " }}
                 {{ else }}
-                  <span class="text-muted">{{ i18n "uc.noPrerequisites" }}</span>
+                  <span class="text-muted" data-i18n="uc.noPrerequisites">{{ i18n "uc.noPrerequisites" }}</span>
                 {{ end }}
               </dd>
             </dl>
@@ -58,12 +58,12 @@
       {{ $topics := .RegularPages }}
       <section class="mb-5" id="uc-topics" data-facodi-slot="uc-topics">
         <div class="d-flex align-items-center justify-content-between mb-3">
-          <h2 class="h4 mb-0">{{ i18n "uc.topics" }}</h2>
+          <h2 class="h4 mb-0" data-i18n="uc.topics">{{ i18n "uc.topics" }}</h2>
           {{ $topicCount := len $topics }}
-          <span class="text-muted small">{{ $topicCount }} {{ if eq $topicCount 1 }}{{ i18n "common.topic" }}{{ else }}{{ i18n "common.topics" }}{{ end }}</span>
+          <span class="text-muted small">{{ $topicCount }} {{ if eq $topicCount 1 }}<span data-i18n="common.topic">{{ i18n "common.topic" }}</span>{{ else }}<span data-i18n="common.topics">{{ i18n "common.topics" }}</span>{{ end }}</span>
         </div>
         {{ if not (len $topics) }}
-        <div class="alert alert-info" role="alert">{{ i18n "uc.noTopics" }}</div>
+        <div class="alert alert-info" role="alert" data-i18n="uc.noTopics">{{ i18n "uc.noTopics" }}</div>
         {{ else }}
         <div class="list-group list-group-flush">
           {{ range sort $topics "Title" }}
@@ -75,7 +75,7 @@
               </div>
               {{ with .Params.youtube_playlists }}
               {{ $playlistCount := len . }}
-              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} {{ if eq $playlistCount 1 }}{{ i18n "common.playlist" }}{{ else }}{{ i18n "common.playlists" }}{{ end }}</span>
+              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} {{ if eq $playlistCount 1 }}<span data-i18n="common.playlist">{{ i18n "common.playlist" }}</span>{{ else }}<span data-i18n="common.playlists">{{ i18n "common.playlists" }}</span>{{ end }}</span>
               {{ end }}
             </div>
             {{ with .Params.tags }}
@@ -91,17 +91,17 @@
     </div>
     <div class="col-lg-3 order-lg-0">
       <aside class="mb-5" id="uc-learning-outcomes" data-facodi-slot="uc-outcomes">
-        <h2 class="h5">{{ i18n "uc.learningOutcomes" }}</h2>
+        <h2 class="h5" data-i18n="uc.learningOutcomes">{{ i18n "uc.learningOutcomes" }}</h2>
         {{ if $params.learning_outcomes }}
         <ol class="ps-3">
           {{ range $params.learning_outcomes }}<li class="mb-2">{{ . }}</li>{{ end }}
         </ol>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noLearningOutcomes" }}</p>
+        <p class="text-muted small" data-i18n="uc.noLearningOutcomes">{{ i18n "uc.noLearningOutcomes" }}</p>
         {{ end }}
       </aside>
       <aside id="uc-playlists" data-facodi-slot="uc-playlists">
-        <h2 class="h5">{{ i18n "uc.playlists" }}</h2>
+        <h2 class="h5" data-i18n="uc.playlists">{{ i18n "uc.playlists" }}</h2>
         {{ if $params.youtube_playlists }}
         <ul class="list-unstyled">
           {{ range sort $params.youtube_playlists "priority" }}
@@ -113,7 +113,7 @@
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="uc.noPlaylists">{{ i18n "uc.noPlaylists" }}</p>
         {{ end }}
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- implement client-side locale management to avoid duplicate localized routes and integrate a hidden Google Translate fallback
- centralize locale metadata while disabling non-PT builds to keep routing single-language
- annotate templates with runtime translation markers, hide Google widgets, and flag the privacy page for automatic translation when needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07c70dd7083228aac1422e5b4b37f