### PR TITLE
Finalize runtime translation integration

### DIFF
--- a/assets/css/facodi.css
+++ b/assets/css/facodi.css
@@ -748,3 +748,16 @@ html[data-theme="dark"] .facodi-cta {
   gap: 1rem;
   flex-wrap: wrap;
 }
+
+.facodi-google-translate,
+body > .skiptranslate,
+.goog-te-banner-frame,
+.goog-te-gadget,
+.goog-tooltip,
+.goog-te-balloon-frame {
+  display: none !important;
+}
+
+body {
+  top: 0 !important;
+}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,55 @@
 const THEME_STORAGE_KEY = 'facodi-theme-preference';
+const LANGUAGE_STORAGE_KEY = 'facodi-language';
 const root = document.documentElement;
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+function readJSONScript(id) {
+  const node = document.getElementById(id);
+  if (!node) {
+    return null;
+  }
+  try {
+    const content = node.textContent || '';
+    return JSON.parse(content) || null;
+  } catch (error) {
+    console.warn('[FACODI] Failed to parse JSON script:', id, error);
+    return null;
+  }
+}
+
+const localeConfigRaw = readJSONScript('facodi-locale-config');
+const localeConfig = Array.isArray(localeConfigRaw) ? localeConfigRaw : [];
+const translationCatalog = readJSONScript('facodi-i18n-catalog') || {};
+const languageConfig = readJSONScript('facodi-language-config') || {};
+const DEFAULT_LOCALE = languageConfig.defaultLocale || document.documentElement.lang || 'pt';
+let currentLocale = DEFAULT_LOCALE;
+
+let resolveGoogleReady;
+const googleReady = new Promise((resolve) => {
+  resolveGoogleReady = resolve;
+});
+
+const localeIndex = localeConfig.reduce((accumulator, entry) => {
+  if (entry && entry.code) {
+    accumulator[entry.code] = entry;
+  }
+  return accumulator;
+}, {});
+
+function getLocaleEntry(code) {
+  if (code && Object.prototype.hasOwnProperty.call(localeIndex, code)) {
+    return localeIndex[code];
+  }
+  return null;
+}
+
+function getGoogleLanguageCode(code) {
+  const entry = getLocaleEntry(code);
+  if (entry && entry.googleCode) {
+    return entry.googleCode;
+  }
+  return code;
+}
 
 function readStoredTheme() {
   try {
@@ -15,6 +64,23 @@ function storeTheme(value) {
     localStorage.setItem(THEME_STORAGE_KEY, value);
   } catch (error) {
     // Ignore storage errors (e.g., private mode).
+  }
+}
+
+function readStoredLocale() {
+  try {
+    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    return stored || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function storeLocale(value) {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, value);
+  } catch (error) {
+    // Ignore storage errors.
   }
 }
 
@@ -56,6 +122,191 @@ function initTheme() {
   }
 }
 
+function toPascalCase(value) {
+  if (!value) {
+    return '';
+  }
+  return String(value)
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join('');
+}
+
+function getDatasetValue(element, placeholder) {
+  if (!element || !element.dataset || !placeholder) {
+    return undefined;
+  }
+  const base = placeholder.replace(/[^A-Za-z0-9]+/g, '');
+  const pascal = toPascalCase(base);
+  const lowerCamel = pascal ? pascal.charAt(0).toLowerCase() + pascal.slice(1) : '';
+  const candidates = [
+    `i18n${placeholder}`,
+    `i18n${base}`,
+    `i18n${pascal}`,
+    `i18n${lowerCamel}`,
+    `i18n${base.toUpperCase()}`,
+    `i18n${base.toLowerCase()}`,
+    `i18nParam${pascal}`,
+    `i18nParam${lowerCamel}`,
+  ];
+  for (const candidate of candidates) {
+    if (Object.prototype.hasOwnProperty.call(element.dataset, candidate)) {
+      return element.dataset[candidate];
+    }
+  }
+  return undefined;
+}
+
+function replaceTemplatePlaceholders(template, element) {
+  if (typeof template !== 'string') {
+    return template;
+  }
+  return template.replace(/{{\s*\.([A-Za-z0-9_]+)\s*}}/g, (match, name) => {
+    const value = getDatasetValue(element, name);
+    return value !== undefined ? value : '';
+  });
+}
+
+function getTranslation(locale, key) {
+  if (!key) {
+    return undefined;
+  }
+  const catalog = translationCatalog[locale];
+  if (catalog && Object.prototype.hasOwnProperty.call(catalog, key)) {
+    return catalog[key];
+  }
+  return undefined;
+}
+
+function normalizeLocale(code) {
+  if (code && Object.prototype.hasOwnProperty.call(translationCatalog, code)) {
+    return code;
+  }
+  return DEFAULT_LOCALE;
+}
+
+function updateTextNodeTranslation(element, locale) {
+  const key = element.dataset.i18n;
+  if (!key) {
+    return;
+  }
+  if (!Object.prototype.hasOwnProperty.call(element.dataset, 'i18nOriginal')) {
+    element.dataset.i18nOriginal = element.innerHTML;
+  }
+  let template = getTranslation(locale, key);
+  if (template === undefined || template === null || template === '') {
+    if (locale === DEFAULT_LOCALE) {
+      template = element.dataset.i18nOriginal || '';
+    } else {
+      template = getTranslation(DEFAULT_LOCALE, key) || element.dataset.i18nOriginal || '';
+    }
+  }
+  const rendered = replaceTemplatePlaceholders(template, element);
+  element.innerHTML = rendered;
+  if (!element.classList.contains('notranslate')) {
+    element.classList.add('notranslate');
+  }
+}
+
+function updateAttributeTranslations(element, locale) {
+  if (!element || !element.dataset) {
+    return;
+  }
+  Object.keys(element.dataset).forEach((datasetKey) => {
+    if (!datasetKey.startsWith('i18nAttr')) {
+      return;
+    }
+    const translationKey = element.dataset[datasetKey];
+    if (!translationKey) {
+      return;
+    }
+    const attrNamePart = datasetKey.slice('i18nAttr'.length);
+    if (!attrNamePart) {
+      return;
+    }
+    const attributeName = attrNamePart.replace(/([A-Z])/g, '-$1').toLowerCase();
+    const originalKey = `i18nAttrOriginal${attrNamePart}`;
+    if (!Object.prototype.hasOwnProperty.call(element.dataset, originalKey)) {
+      const originalValue = element.getAttribute(attributeName);
+      if (originalValue !== null) {
+        element.dataset[originalKey] = originalValue;
+      } else {
+        element.dataset[originalKey] = '';
+      }
+    }
+    let template = getTranslation(locale, translationKey);
+    if (template === undefined || template === null || template === '') {
+      if (locale === DEFAULT_LOCALE) {
+        element.setAttribute(attributeName, element.dataset[originalKey] || '');
+        return;
+      }
+      template = getTranslation(DEFAULT_LOCALE, translationKey) || element.dataset[originalKey] || '';
+    }
+    const rendered = replaceTemplatePlaceholders(template, element);
+    element.setAttribute(attributeName, rendered);
+  });
+}
+
+function applyManualTranslations(locale) {
+  const elements = document.querySelectorAll('[data-i18n]');
+  elements.forEach((element) => {
+    updateTextNodeTranslation(element, locale);
+    updateAttributeTranslations(element, locale);
+  });
+  document.querySelectorAll('[data-i18n-attr-aria-label], [data-i18n-attr-placeholder], [data-i18n-attr-title]').forEach((element) => {
+    updateAttributeTranslations(element, locale);
+  });
+}
+
+function updateLanguageSelect(locale) {
+  const select = document.querySelector('[data-facodi-language-select]');
+  if (!select) {
+    return;
+  }
+  if (select.value !== locale) {
+    select.value = locale;
+  }
+}
+
+function triggerGoogleTranslate(locale) {
+  const targetLocale = normalizeLocale(locale);
+  const googleCode = getGoogleLanguageCode(targetLocale);
+  const defaultGoogleCode = getGoogleLanguageCode(DEFAULT_LOCALE);
+
+  googleReady.then(() => {
+    const combo = document.querySelector('.goog-te-combo');
+    if (!combo) {
+      return;
+    }
+    const desired = targetLocale === DEFAULT_LOCALE ? defaultGoogleCode : googleCode;
+    if (!desired || combo.value === desired) {
+      combo.dispatchEvent(new Event('change'));
+      return;
+    }
+    combo.value = desired;
+    combo.dispatchEvent(new Event('change'));
+  });
+}
+
+function setLocale(locale, options = {}) {
+  const normalized = normalizeLocale(locale);
+  currentLocale = normalized;
+  if (options.persist !== false) {
+    storeLocale(normalized);
+  }
+  document.documentElement.setAttribute('lang', normalized);
+  applyManualTranslations(normalized);
+  updateLanguageSelect(normalized);
+  triggerGoogleTranslate(normalized);
+}
+
+window.facodiApplyTranslations = function facodiApplyTranslations() {
+  applyManualTranslations(currentLocale);
+};
+
 function initLanguageSwitcher() {
   const select = document.querySelector('[data-facodi-language-select]');
   if (!select) {
@@ -65,12 +316,44 @@ function initLanguageSwitcher() {
   select.addEventListener('change', (event) => {
     const target = event.target.value;
     if (target && typeof target === 'string') {
-      window.location.assign(target);
+      setLocale(target, { persist: true });
     }
   });
 }
 
+function initLocale() {
+  const stored = readStoredLocale();
+  if (stored) {
+    setLocale(stored, { persist: false });
+  } else {
+    setLocale(DEFAULT_LOCALE, { persist: false });
+  }
+}
+
+window.facodiInitGoogleTranslate = function facodiInitGoogleTranslate() {
+  const googleLanguages = Array.isArray(languageConfig.googleLanguages) ? languageConfig.googleLanguages : [];
+  const defaultGoogleCode = getGoogleLanguageCode(DEFAULT_LOCALE);
+  const includedLanguages = googleLanguages
+    .filter((code) => code && code !== defaultGoogleCode)
+    .join(',');
+  if (window.google && window.google.translate) {
+    new window.google.translate.TranslateElement(
+      {
+        pageLanguage: defaultGoogleCode,
+        includedLanguages,
+        autoDisplay: false,
+        layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+      },
+      'google_translate_element',
+    );
+  }
+  if (typeof resolveGoogleReady === 'function') {
+    resolveGoogleReady();
+  }
+};
+
 window.addEventListener('DOMContentLoaded', () => {
   initTheme();
+  initLocale();
   initLanguageSwitcher();
 });

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -6,13 +6,14 @@ disableHugoGeneratorInject = true
 enableEmoji = true
 enableGitInfo = false
 enableRobotsTXT = true
-languageCode = "pt-PT"
+languageCode = "pt-BR"
 rssLimit = 10
 summarylength = 20 # 70 (default)
 
 # Multilingual
 defaultContentLanguage = "pt"
 defaultContentLanguageInSubdir = false
+disableLanguages = ["en", "es", "fr"]
 
 copyRight = "Copyright (c) 2020-2024 Thulite"
 

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -3,8 +3,8 @@
   contentDir = "content"
   weight = 1
   [pt.params]
-    languageISO = "PT"
-    languageTag = "pt-PT"
+    languageISO = "BR"
+    languageTag = "pt-BR"
 
 [en]
   languageName = "English"

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Home"
+  identifier = "nav.menu.home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Courses"
+  identifier = "nav.menu.courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Roadmap"
+  identifier = "nav.menu.roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Privacy Policy"
+  identifier = "footer.menu.privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.es.toml
+++ b/config/_default/menus/menus.es.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Inicio"
+  identifier = "nav.menu.home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cursos"
+  identifier = "nav.menu.courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Hoja de ruta"
+  identifier = "nav.menu.roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Política de privacidad"
+  identifier = "footer.menu.privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.fr.toml
+++ b/config/_default/menus/menus.fr.toml
@@ -1,19 +1,23 @@
 [[main]]
   name = "Accueil"
+  identifier = "nav.menu.home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cours"
+  identifier = "nav.menu.courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Feuille de route"
+  identifier = "nav.menu.roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
 [[footer]]
   name = "Politique de confidentialité"
+  identifier = "footer.menu.privacy"
   url = "/privacy/"
   weight = 10

--- a/config/_default/menus/menus.pt.toml
+++ b/config/_default/menus/menus.pt.toml
@@ -18,16 +18,19 @@
 
 [[main]]
   name = "Início"
+  identifier = "nav.menu.home"
   pageRef = "/"
   weight = 1
 
 [[main]]
   name = "Cursos"
+  identifier = "nav.menu.courses"
   pageRef = "/courses/"
   weight = 5
 
 [[main]]
   name = "Roadmap"
+  identifier = "nav.menu.roadmap"
   url = "https://facodi.pt/roadmap"
   weight = 10
 
@@ -67,6 +70,7 @@
 
 [[footer]]
   name = "Política de Privacidade"
+  identifier = "footer.menu.privacy"
   url = "/privacy/"
   weight = 10
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -7,6 +7,12 @@ images = ["cover.png"]
   supabaseUrl = ""
   supabaseAnonKey = ""
   defaultLocale = "pt"
+  locales = [
+    { code = "pt", label = "Português", googleCode = "pt" },
+    { code = "en", label = "English", googleCode = "en" },
+    { code = "es", label = "Español", googleCode = "es" },
+    { code = "fr", label = "Français", googleCode = "fr" },
+  ]
 
 # mainSections
 mainSections = ["docs"]
@@ -56,8 +62,8 @@ mainSections = ["docs"]
   scrollSpy = true # true (default) or false
 
   # Multilingual
-  multilingualMode = true # false (default) or true
-  showMissingLanguages = true # whether or not to show untranslated languages in the language menu; true (default) or false
+  multilingualMode = false # false (default) or true
+  showMissingLanguages = false # whether or not to show untranslated languages in the language menu; true (default) or false
 
   # Versioning
   docsVersioning = false # false (default) or true

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -96,6 +96,14 @@
     "translation": "Community"
   },
   {
+    "id": "footer.communityGithub",
+    "translation": "GitHub"
+  },
+  {
+    "id": "footer.communityMonynha",
+    "translation": "Monynha Softwares"
+  },
+  {
     "id": "footer.copyright",
     "translation": "© {{ .Year }} {{ .Organization }}. Crafted with love by the FACODI community."
   },
@@ -106,6 +114,10 @@
   {
     "id": "footer.navigation",
     "translation": "Navigation"
+  },
+  {
+    "id": "footer.menu.privacy",
+    "translation": "Privacy Policy"
   },
   {
     "id": "home.contactMonynha",
@@ -318,6 +330,18 @@
   {
     "id": "nav.viewTracks",
     "translation": "Explore tracks"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Home"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Courses"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Roadmap"
   },
   {
     "id": "single.published",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -96,6 +96,14 @@
     "translation": "Comunidad"
   },
   {
+    "id": "footer.communityGithub",
+    "translation": "GitHub"
+  },
+  {
+    "id": "footer.communityMonynha",
+    "translation": "Monynha Softwares"
+  },
+  {
     "id": "footer.copyright",
     "translation": "© {{ .Year }} {{ .Organization }}. Construido con cariño por la comunidad FACODI."
   },
@@ -106,6 +114,10 @@
   {
     "id": "footer.navigation",
     "translation": "Navegación"
+  },
+  {
+    "id": "footer.menu.privacy",
+    "translation": "Política de privacidad"
   },
   {
     "id": "home.contactMonynha",
@@ -318,6 +330,18 @@
   {
     "id": "nav.viewTracks",
     "translation": "Explorar rutas"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Inicio"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cursos"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Hoja de ruta"
   },
   {
     "id": "single.published",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -96,6 +96,14 @@
     "translation": "Communauté"
   },
   {
+    "id": "footer.communityGithub",
+    "translation": "GitHub"
+  },
+  {
+    "id": "footer.communityMonynha",
+    "translation": "Monynha Softwares"
+  },
+  {
     "id": "footer.copyright",
     "translation": "© {{ .Year }} {{ .Organization }}. Créé avec amour par la communauté FACODI."
   },
@@ -106,6 +114,10 @@
   {
     "id": "footer.navigation",
     "translation": "Navigation"
+  },
+  {
+    "id": "footer.menu.privacy",
+    "translation": "Politique de confidentialité"
   },
   {
     "id": "home.contactMonynha",
@@ -318,6 +330,18 @@
   {
     "id": "nav.viewTracks",
     "translation": "Explorer les parcours"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Accueil"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cours"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Feuille de route"
   },
   {
     "id": "single.published",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -96,6 +96,14 @@
     "translation": "Comunidade"
   },
   {
+    "id": "footer.communityGithub",
+    "translation": "GitHub"
+  },
+  {
+    "id": "footer.communityMonynha",
+    "translation": "Monynha Softwares"
+  },
+  {
     "id": "footer.copyright",
     "translation": "© {{ .Year }} {{ .Organization }}. Construído com carinho pela comunidade FACODI."
   },
@@ -106,6 +114,10 @@
   {
     "id": "footer.navigation",
     "translation": "Navegação"
+  },
+  {
+    "id": "footer.menu.privacy",
+    "translation": "Política de Privacidade"
   },
   {
     "id": "home.contactMonynha",
@@ -318,6 +330,18 @@
   {
     "id": "nav.viewTracks",
     "translation": "Explorar trilhas"
+  },
+  {
+    "id": "nav.menu.home",
+    "translation": "Início"
+  },
+  {
+    "id": "nav.menu.courses",
+    "translation": "Cursos"
+  },
+  {
+    "id": "nav.menu.roadmap",
+    "translation": "Roadmap"
   },
   {
     "id": "single.published",

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -98,7 +98,7 @@
     {{- end -}}
   {{- end -}}
   <body {{- if gt (len $bodyAttrs) 0 }} {{ delimit $bodyAttrs " " }}{{ end }}>
-    <a class="visually-hidden-focusable" href="#main-content">{{ i18n "common.skipToContent" }}</a>
+    <a class="visually-hidden-focusable" href="#main-content" data-i18n="common.skipToContent">{{ i18n "common.skipToContent" }}</a>
     {{ partial "header/header.html" . }}
     <main id="main-content" class="flex-fill" role="main">
       {{ block "main" . }}{{ end }}
@@ -114,5 +114,6 @@
     ></script>
     {{ partial "footer/script-footer-custom.html" . }}
     {{ block "scripts" . }}{{ end }}
+    <div id="google_translate_element" class="facodi-google-translate" aria-hidden="true"></div>
   </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <section class="facodi-section facodi-section--list py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "list.sectionIntro" }}</span>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="list.sectionIntro">{{ i18n "list.sectionIntro" }}</span>
       <h1 class="section-title mb-3">{{ .Title }}</h1>
       {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
       {{ with .Content }}<div class="content text-start">{{ . }}</div>{{ end }}
@@ -11,7 +11,7 @@
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm" role="status">{{ i18n "list.empty" }}</div>
+      <div class="alert alert-info shadow-sm" role="status" data-i18n="list.empty">{{ i18n "list.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -29,16 +29,16 @@
               </div>
               <footer class="facodi-card__footer">
                 {{ with .PublishDate }}
-                  <span class="facodi-card__meta">{{ i18n "list.published" }} {{ .Format "02 MMMM 2006" }}</span>
+                  <span class="facodi-card__meta"><span data-i18n="list.published">{{ i18n "list.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "list.readMore" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="list.readMore">{{ i18n "list.readMore" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "list.pagination" }}" data-i18n-attr-aria-label="list.pagination">
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,15 +8,15 @@
           {{ with .Params.lead }}<p class="lead text-muted">{{ . }}</p>{{ end }}
           {{ if or .PublishDate .Lastmod }}
             <p class="facodi-meta text-muted mb-0">
-              {{ with .PublishDate }}<span>{{ i18n "single.published" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
-              {{ with .Lastmod }}<span class="ms-3">{{ i18n "single.updated" }} {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .PublishDate }}<span><span data-i18n="single.published">{{ i18n "single.published" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
+              {{ with .Lastmod }}<span class="ms-3"><span data-i18n="single.updated">{{ i18n "single.updated" }}</span> {{ .Format "02 MMMM 2006" }}</span>{{ end }}
             </p>
           {{ end }}
         </header>
         <div class="content facodi-content">{{ .Content }}</div>
         {{ with .Params.tags }}
           <footer class="facodi-tags mt-5">
-            <h2 class="h5 mb-3">{{ i18n "single.tags" }}</h2>
+            <h2 class="h5 mb-3" data-i18n="single.tags">{{ i18n "single.tags" }}</h2>
             <div class="facodi-tag-list">
               {{ range . }}<a class="badge rounded-pill bg-light text-muted" href="{{ "tags" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end }}
             </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,15 +2,15 @@
 <section class="facodi-section facodi-section--taxonomy py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "taxonomy.termEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "taxonomy.termTitle" (dict "Term" .Data.Term "Name" .Title) }}</h1>
-      {{ with .Data.Term | humanize }}<p class="lead text-muted">{{ i18n "taxonomy.termIntro" (dict "Term" .) }}</p>{{ end }}
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="taxonomy.termEyebrow">{{ i18n "taxonomy.termEyebrow" }}</span>
+      <h1 class="section-title mb-3" data-i18n="taxonomy.termTitle" data-i18n-term="{{ .Data.Term | htmlEscape }}" data-i18n-name="{{ .Title | htmlEscape }}">{{ i18n "taxonomy.termTitle" (dict "Term" .Data.Term "Name" .Title) }}</h1>
+      {{ with .Data.Term | humanize }}<p class="lead text-muted" data-i18n="taxonomy.termIntro" data-i18n-term="{{ . | htmlEscape }}">{{ i18n "taxonomy.termIntro" (dict "Term" .) }}</p>{{ end }}
     </header>
     {{ $collection := .Pages }}
     {{ $paginator := .Paginate $collection }}
     {{ $pages := $paginator.Pages }}
     {{ if not (len $pages) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "taxonomy.noEntries" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="taxonomy.noEntries">{{ i18n "taxonomy.noEntries" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $pages }}
@@ -27,14 +27,14 @@
                     {{ range $tags }}<span class="badge bg-light text-muted">{{ . }}</span>{{ end }}
                   </div>
                 {{ end }}
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "taxonomy.viewEntry" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="taxonomy.viewEntry">{{ i18n "taxonomy.viewEntry" }}</a>
               </footer>
             </div>
           </article>
         {{ end }}
       </div>
       {{ if gt .Paginator.TotalPages 1 }}
-        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}">
+        <nav class="facodi-pagination" aria-label="{{ i18n "taxonomy.pagination" }}" data-i18n-attr-aria-label="taxonomy.pagination">
           {{ template "_internal/pagination.html" . }}
         </nav>
       {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,13 +2,13 @@
 <section class="facodi-section facodi-section--terms py-5">
   <div class="container-lg">
     <header class="facodi-section__header text-center mb-5">
-      <span class="facodi-section__eyebrow text-uppercase text-muted">{{ i18n "terms.overviewEyebrow" }}</span>
-      <h1 class="section-title mb-3">{{ i18n "terms.overviewTitle" (dict "Taxonomy" (.Title | humanize)) }}</h1>
-      <p class="lead text-muted">{{ i18n "terms.overviewIntro" }}</p>
+      <span class="facodi-section__eyebrow text-uppercase text-muted" data-i18n="terms.overviewEyebrow">{{ i18n "terms.overviewEyebrow" }}</span>
+      <h1 class="section-title mb-3" data-i18n="terms.overviewTitle" data-i18n-taxonomy="{{ (.Title | humanize) | htmlEscape }}">{{ i18n "terms.overviewTitle" (dict "Taxonomy" (.Title | humanize)) }}</h1>
+      <p class="lead text-muted" data-i18n="terms.overviewIntro">{{ i18n "terms.overviewIntro" }}</p>
     </header>
     {{ $terms := .Data.Terms.Alphabetical }}
     {{ if not (len $terms) }}
-      <div class="alert alert-info shadow-sm">{{ i18n "terms.empty" }}</div>
+      <div class="alert alert-info shadow-sm" data-i18n="terms.empty">{{ i18n "terms.empty" }}</div>
     {{ else }}
       <div class="row g-4">
         {{ range $terms }}
@@ -16,10 +16,10 @@
             <div class="facodi-card h-100">
               <div class="facodi-card__body">
                 <h2 class="h5 facodi-card__title"><a class="facodi-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ .Page.Title }}</a></h2>
-                <p class="facodi-card__meta">{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
+                <p class="facodi-card__meta" data-i18n="terms.entryCount" data-i18n-count="{{ .Count }}">{{ i18n "terms.entryCount" (dict "Count" .Count) }}</p>
               </div>
               <footer class="facodi-card__footer">
-                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}">{{ i18n "terms.viewTerm" }}</a>
+                <a class="facodi-card__cta" href="{{ partial "facodi/langless-url.html" (dict "url" .Page.RelPermalink) }}" data-i18n="terms.viewTerm">{{ i18n "terms.viewTerm" }}</a>
               </footer>
             </div>
           </article>

--- a/layouts/_partials/footer/footer.html
+++ b/layouts/_partials/footer/footer.html
@@ -4,10 +4,10 @@
       <div class="col-lg-6">
         <h2 class="h5 text-uppercase text-muted">{{ site.Title }}</h2>
         <p class="mb-3 text-muted">{{ site.Params.description }}</p>
-        <p class="small text-muted mb-0">{{ i18n "footer.license" }}</p>
+        <p class="small text-muted mb-0" data-i18n="footer.license">{{ i18n "footer.license" }}</p>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.navigation" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.navigation">{{ i18n "footer.navigation" }}</h3>
         <ul class="list-unstyled mb-0">
           {{ range site.Menus.main }}
             {{- $itemURL := .URL | default "" -}}
@@ -17,20 +17,30 @@
               {{- $href = partial "facodi/langless-url.html" (dict "url" $itemURL) -}}
               {{- $href = relURL $href -}}
             {{- end -}}
-            <li><a class="facodi-footer__link" href="{{ $href }}">{{ .Name }}</a></li>
+            {{- $labelKey := .Identifier | default "" -}}
+            {{- $labelText := cond (ne $labelKey "") (i18n $labelKey) .Name -}}
+            <li>
+              <a class="facodi-footer__link" href="{{ $href }}">
+                {{- if $labelKey -}}
+                  <span data-i18n="{{ $labelKey }}">{{ $labelText }}</span>
+                {{- else -}}
+                  {{ $labelText }}
+                {{- end -}}
+              </a>
+            </li>
           {{ end }}
         </ul>
       </div>
       <div class="col-lg-3">
-        <h3 class="h6 text-uppercase text-muted">{{ i18n "footer.community" }}</h3>
+        <h3 class="h6 text-uppercase text-muted" data-i18n="footer.community">{{ i18n "footer.community" }}</h3>
         <ul class="list-unstyled mb-0">
-          <li><a class="facodi-footer__link" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener">GitHub</a></li>
-          <li><a class="facodi-footer__link" href="https://monynha.com" target="_blank" rel="noopener">Monynha Softwares</a></li>
+          <li><a class="facodi-footer__link" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" data-i18n="footer.communityGithub">{{ i18n "footer.communityGithub" }}</a></li>
+          <li><a class="facodi-footer__link" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="footer.communityMonynha">{{ i18n "footer.communityMonynha" }}</a></li>
         </ul>
       </div>
     </div>
     <div class="facodi-footer__bottom mt-4 pt-4 border-top">
-      <p class="small text-muted mb-0">{{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}</p>
+      <p class="small text-muted mb-0" data-i18n="footer.copyright" data-i18n-year="{{ now.Year }}" data-i18n-organization="Monynha Softwares">{{ i18n "footer.copyright" (dict "Year" now.Year "Organization" "Monynha Softwares") }}</p>
     </div>
   </div>
 </footer>

--- a/layouts/_partials/footer/script-footer-custom.html
+++ b/layouts/_partials/footer/script-footer-custom.html
@@ -1,5 +1,32 @@
 {{- $supabaseUrl := or (getenv "SUPABASE_URL") site.Params.facodi.supabaseUrl -}}
 {{- $supabaseAnon := or (getenv "SUPABASE_ANON_KEY") site.Params.facodi.supabaseAnonKey -}}
+{{- $locales := site.Params.facodi.locales | default (slice) -}}
+{{- $defaultLocale := site.Params.facodi.defaultLocale | default site.Language.Lang -}}
+{{- $fullCatalog := dict -}}
+{{- $googleCodes := slice -}}
+{{- range $locales -}}
+  {{- $code := .code | default "" -}}
+  {{- if not $code -}}
+    {{- continue -}}
+  {{- end -}}
+  {{- $path := printf "i18n/%s.json" $code -}}
+  {{- $raw := readFile $path | transform.Unmarshal -}}
+  {{- $entries := dict -}}
+  {{- range $raw -}}
+    {{- $id := .id | default "" -}}
+    {{- if not $id -}}
+      {{- continue -}}
+    {{- end -}}
+    {{- $entries = merge $entries (dict $id (.translation | default "")) -}}
+  {{- end -}}
+  {{- $fullCatalog = merge $fullCatalog (dict $code $entries) -}}
+  {{- with .googleCode -}}
+    {{- $googleCodes = $googleCodes | append . -}}
+  {{- else -}}
+    {{- $googleCodes = $googleCodes | append $code -}}
+  {{- end -}}
+{{- end -}}
+{{- $googleCodes = uniq $googleCodes -}}
 {{- $translationKeys := slice
   "course.noUcs"
   "common.unit"
@@ -28,6 +55,9 @@
   {{- $translationMap = merge $translationMap (dict . (i18n .)) -}}
 {{- end -}}
 <script id="facodi-translations" type="application/json">{{ $translationMap | jsonify | safeHTML }}</script>
+<script id="facodi-i18n-catalog" type="application/json">{{ $fullCatalog | jsonify | safeHTML }}</script>
+<script id="facodi-locale-config" type="application/json">{{ $locales | jsonify | safeHTML }}</script>
+<script id="facodi-language-config" type="application/json">{{ dict "defaultLocale" $defaultLocale "googleLanguages" $googleCodes | jsonify | safeHTML }}</script>
 <script id="facodi-config" type="application/json">{{ dict "supabaseUrl" $supabaseUrl "supabaseAnonKey" $supabaseAnon | jsonify | safeHTML }}</script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js" integrity="sha384-AkNSQdptcXlJ0/NBZc4qGk86cDVXcCevwoWgEKIpHOEfbvlXGLlIkimQtONt8KNf" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
@@ -35,6 +65,7 @@
 <script src="{{ $customScript.RelPermalink }}" defer></script>
 <script src="{{ "js/supabaseClient.js" | relURL }}" defer></script>
 <script src="{{ "js/loaders.js" | relURL }}" defer></script>
+<script src="https://translate.googleapis.com/translate_a/element.js?cb=facodiInitGoogleTranslate" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     if (!window.facodiLoaders) {

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -21,8 +21,8 @@
     <a class="navbar-brand facodi-navbar__brand" href="{{ relLangURL "" }}">{{ .Site.Title }}</a>
 
     <!-- Main navigation button -->
-    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}">
-      <span class="visually-hidden">{{ i18n "nav.openMenu" }}</span>
+    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}" data-i18n-attr-aria-label="nav.openMainMenu">
+      <span class="visually-hidden" data-i18n="nav.openMenu">{{ i18n "nav.openMenu" }}</span>
       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
         <line x1="4" y1="8" x2="20" y2="8"></line>
@@ -37,7 +37,7 @@
       {{ end -}}
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="offcanvasNavMainLabel">{{ site.Title }}</h5>
-        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}">
+        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}" data-i18n-attr-aria-label="nav.closeMenu">
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M18 6l-12 12"></path>
@@ -66,10 +66,16 @@
             {{- $active = or $active (eq .Name $current.Title) -}}
             {{- $active = or $active (eq .Name ($section | humanize)) -}}
             {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "authors")) -}}
+            {{- $labelKey := .Identifier | default "" -}}
+            {{- $labelText := cond (ne $labelKey "") (i18n $labelKey) .Name -}}
             {{ if .HasChildren -}}
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                  {{ .Name -}}
+                  {{- if $labelKey -}}
+                    <span data-i18n="{{ $labelKey }}">{{ $labelText }}</span>
+                  {{- else -}}
+                    {{ $labelText -}}
+                  {{- end -}}
                   <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                     <path d="M6 9l6 6l6 -6"></path>
@@ -78,6 +84,8 @@
                 <ul class="dropdown-menu shadow rounded border-0">
                   {{ range .Children -}}
                   {{- $active = eq .Name $current.Title -}}
+                    {{- $childKey := .Identifier | default "" -}}
+                    {{- $childLabel := cond (ne $childKey "") (i18n $childKey) .Name -}}
                     {{- $childURL := .URL | default "" -}}
                     {{- $childExternal := or (strings.HasPrefix $childURL "http://") (strings.HasPrefix $childURL "https://") (strings.HasPrefix $childURL "//") -}}
                     {{- $childHref := $childURL -}}
@@ -85,7 +93,15 @@
                       {{- $childHref = partial "facodi/langless-url.html" (dict "url" $childURL) -}}
                       {{- $childHref = relURL $childHref -}}
                     {{- end -}}
-                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
+                    <li>
+                      <a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="true"{{ end }}>
+                        {{- if $childKey -}}
+                          <span data-i18n="{{ $childKey }}">{{ $childLabel }}</span>
+                        {{- else -}}
+                          {{ $childLabel }}
+                        {{- end -}}
+                      </a>
+                    </li>
                   {{ end -}}
                 </ul>
               </li>
@@ -98,51 +114,42 @@
                   {{- $href = partial "facodi/langless-url.html" (dict "url" $itemURL) -}}
                   {{- $href = relURL $href -}}
                 {{- end -}}
-                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
+                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="true"{{ end }}>
+                  {{- if $labelKey -}}
+                    <span data-i18n="{{ $labelKey }}">{{ $labelText }}</span>
+                  {{- else -}}
+                    {{ $labelText }}
+                  {{- end -}}
+                </a>
               </li>
             {{ end -}}
           {{ end -}}
         </ul>
         <div class="facodi-navbar__actions d-flex flex-column flex-sm-row align-items-stretch align-items-lg-center gap-3 ms-lg-auto">
-          {{ $currentRel := .RelPermalink }}
-          {{ $path := $currentRel }}
-          {{ range site.Languages }}
-            {{ if hasPrefix $path (printf "/%s/" .Lang) }}
-              {{ $path = strings.TrimPrefix (printf "/%s" .Lang) $path }}
-            {{ end }}
-          {{ end }}
-          {{ $defaultLang := site.Params.facodi.defaultLocale | default site.Language.Lang }}
           <div class="facodi-navbar__language">
-            <label class="visually-hidden" for="facodi-language-select">{{ i18n "nav.languageLabel" }}</label>
-            <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select aria-label="{{ i18n "nav.languageLabel" }}">
-              {{ range site.Languages }}
-                {{ $translations := where $.AllTranslations "Lang" .Lang }}
-                {{ $target := "" }}
-                {{ if $translations }}
-                  {{ $target = (index $translations 0).RelPermalink }}
-                {{ else }}
-                  {{ $prefix := "" }}
-                  {{ if ne .Lang $defaultLang }}
-                    {{ $prefix = printf "/%s" .Lang }}
-                  {{ end }}
-                  {{ $target = printf "%s%s" $prefix $path }}
-                {{ end }}
-                <option value="{{ $target }}"{{ if eq $.Lang .Lang }} selected{{ end }}>{{ .LanguageName }}</option>
-              {{ end }}
+            <label class="visually-hidden" for="facodi-language-select" data-i18n="nav.languageLabel">{{ i18n "nav.languageLabel" }}</label>
+            {{- $locales := site.Params.facodi.locales | default (slice) -}}
+            {{- $defaultLocale := site.Params.facodi.defaultLocale | default site.Language.Lang -}}
+            <select id="facodi-language-select" class="facodi-navbar__select" data-facodi-language-select data-default-locale="{{ $defaultLocale }}" aria-label="{{ i18n "nav.languageLabel" }}" data-i18n-attr-aria-label="nav.languageLabel">
+              {{- range $index, $locale := $locales -}}
+                {{- $code := $locale.code | default "" -}}
+                {{- $label := $locale.label | default $code -}}
+                <option value="{{ $code }}"{{ if eq $.Lang $code }} selected{{ end }}>{{ $label }}</option>
+              {{- end -}}
             </select>
           </div>
-          <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}">
+          <button type="button" class="facodi-navbar__theme-toggle" data-facodi-theme-toggle aria-pressed="false" aria-label="{{ i18n "nav.themeToggle" }}" data-i18n-attr-aria-label="nav.themeToggle">
             <span class="facodi-theme-icon facodi-theme-icon--light" aria-hidden="true">☀️</span>
             <span class="facodi-theme-icon facodi-theme-icon--dark" aria-hidden="true">🌙</span>
-            <span class="visually-hidden">{{ i18n "nav.themeToggle" }}</span>
+            <span class="visually-hidden" data-i18n="nav.themeToggle">{{ i18n "nav.themeToggle" }}</span>
           </button>
-          <a class="facodi-navbar__icon" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" aria-label="{{ i18n "nav.github" }}">
+          <a class="facodi-navbar__icon" href="https://github.com/Monynha-Softwares/facodi.pt" target="_blank" rel="noopener" aria-label="{{ i18n "nav.github" }}" data-i18n-attr-aria-label="nav.github">
             <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" role="img">
               <path d="M12 .5a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.1c-3.3.7-4-1.6-4-1.6-.5-1.3-1.2-1.6-1.2-1.6-1-.7.1-.7.1-.7 1.1.1 1.7 1.1 1.7 1.1 1 .1.8-.8 1.7-1.1 1.5-.3 2.6.5 3 .8.1-.8.4-1.3.7-1.6-2.7-.3-5.6-1.4-5.6-6.1 0-1.3.5-2.4 1.1-3.3-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.7.9 1.1 2 1.1 3.3 0 4.7-2.9 5.8-5.6 6.1.4.3.8 1 .8 2.1v3.1c0 .3.2.7.8.6A12 12 0 0 0 12 .5Z" />
             </svg>
           </a>
           {{ if site.Params.doks.navBarButton -}}
-            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-navbar__cta" href="{{ site.Params.doks.navBarButtonUrl | absURL }}" data-i18n="nav.viewTracks">{{ i18n "nav.viewTracks" }}</a>
           {{ end -}}
         </div>
       </div>

--- a/layouts/course/list.html
+++ b/layouts/course/list.html
@@ -11,28 +11,28 @@
     <div class="col-lg-10">
       <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-4">
         <div>
-          <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
+          <span class="badge bg-primary-subtle text-primary fw-semibold notranslate">{{ $params.code }}</span>
           {{ with $params.plan_version }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.plan" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> <span class="notranslate">{{ . }}</span></span>
           {{ end }}
-          <h1 class="display-5 mt-3">{{ .Title }}</h1>
-          {{ with $params.summary }}<p class="lead text-muted mb-0" data-facodi-course-summary>{{ . }}</p>{{ end }}
+          <h1 class="display-5 mt-3 notranslate">{{ .Title }}</h1>
+          {{ with $params.summary }}<p class="lead text-muted mb-0 notranslate" data-facodi-course-summary>{{ . }}</p>{{ end }}
         </div>
         <div class="card shadow-sm border-0">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.degree" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.degree | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.ectsTotal" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects_total | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.duration" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.institution" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.institution | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.school" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.school | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.degree | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.ectsTotal">{{ i18n "common.ectsTotal" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.ects_total | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end"><span class="notranslate">{{ $params.duration_semesters | default "--" }}</span> <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.language | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.institution">{{ i18n "common.institution" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.institution | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.school">{{ i18n "common.school" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.school | default "--" }}</dd>
             </dl>
           </div>
         </div>
@@ -41,7 +41,7 @@
   </div>
   <div class="row justify-content-center">
     <div class="col-lg-10">
-      <div class="content mb-5">{{ .Content }}</div>
+      <div class="content mb-5 notranslate">{{ .Content }}</div>
       <hr class="my-5" />
       {{ $scratch := newScratch }}
       {{ $scratch.Set "ucs" (slice) }}
@@ -58,13 +58,13 @@
       {{ $ucPages := $scratch.Get "ucs" }}
       {{ $ucCount := len $ucPages }}
       <div class="course-ucs__header">
-        <h2 class="section-title course-ucs__title">{{ i18n "course.curricularUnits" }}</h2>
-        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span>
+        <h2 class="section-title course-ucs__title" data-i18n="course.curricularUnits">{{ i18n "course.curricularUnits" }}</h2>
+        <span class="course-ucs__count" id="course-uc-count">{{ $ucCount }} <span data-i18n="{{ if eq $ucCount 1 }}common.unit{{ else }}common.units{{ end }}">{{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span></span>
       </div>
       <div class="course-uc-groups" id="course-ucs" data-facodi-slot="course-ucs">
         {{ if not $ucCount }}
         <div class="alert alert-warning" role="alert">
-          {{ i18n "course.noUcs" }}
+          <span data-i18n="course.noUcs">{{ i18n "course.noUcs" }}</span>
         </div>
         {{ else }}
         {{ $ucPages = sort $ucPages "Params.semester" "asc" }}
@@ -99,28 +99,28 @@
           {{ $semesterMap := index $grouped $yearKey }}
           <section class="course-uc-year">
             <header class="course-uc-year__header">
-              <h3 class="course-uc-year__title">{{ i18n "common.year" }} {{ $year }}</h3>
+              <h3 class="course-uc-year__title"><span data-i18n="common.year">{{ i18n "common.year" }}</span> <span class="notranslate">{{ $year }}</span></h3>
             </header>
             {{ range $sem := seq 1 2 }}
               {{ $semKey := printf "%d" $sem }}
               {{ with index $semesterMap $semKey }}
               <div class="course-uc-semester">
-                <h4 class="course-uc-semester__title">{{ i18n "common.semester" }} {{ add (mul (sub $year 1) 2) $sem }}</h4>
+                <h4 class="course-uc-semester__title"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> <span class="notranslate">{{ add (mul (sub $year 1) 2) $sem }}</span></h4>
                 <div class="course-uc-grid">
                   {{ range . }}
                   {{ $ucParams := .Params }}
                   <article class="course-uc-card">
                     <div class="course-uc-card__meta">
-                      <span class="course-uc-card__code">{{ $ucParams.code }}</span>
-                      {{ with $ucParams.semester }}<span class="course-uc-card__semester">{{ i18n "common.semester" }} {{ . }}</span>{{ end }}
+                      <span class="course-uc-card__code notranslate">{{ $ucParams.code }}</span>
+                      {{ with $ucParams.semester }}<span class="course-uc-card__semester"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> <span class="notranslate">{{ . }}</span></span>{{ end }}
                     </div>
-                    <h3 class="course-uc-card__title"><a class="course-uc-card__link" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
-                    {{ with $ucParams.description }}<p class="course-uc-card__summary">{{ . }}</p>{{ end }}
+                    <h3 class="course-uc-card__title notranslate"><a class="course-uc-card__link notranslate" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
+                    {{ with $ucParams.description }}<p class="course-uc-card__summary notranslate">{{ . }}</p>{{ end }}
                     <dl class="course-uc-card__details">
-                      <dt>{{ i18n "common.ects" }}</dt>
-                      <dd>{{ $ucParams.ects | default "--" }}</dd>
-                      <dt>{{ i18n "common.language" }}</dt>
-                      <dd>{{ $ucParams.language | default "--" }}</dd>
+                      <dt data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
+                      <dd class="notranslate">{{ $ucParams.ects | default "--" }}</dd>
+                      <dt data-i18n="common.language">{{ i18n "common.language" }}</dt>
+                      <dd class="notranslate">{{ $ucParams.language | default "--" }}</dd>
                     </dl>
                   </article>
                   {{ end }}

--- a/layouts/courses/list.html
+++ b/layouts/courses/list.html
@@ -14,7 +14,7 @@
     {{ if not (len $courses) }}
     <div class="col-12">
       <div class="alert alert-warning" role="alert">
-        {{ i18n "catalog.noCourses" }}
+        <span data-i18n="catalog.noCourses">{{ i18n "catalog.noCourses" }}</span>
       </div>
     </div>
     {{ end }}
@@ -24,27 +24,27 @@
       <div class="card h-100 shadow-sm border-0">
         <div class="card-body d-flex flex-column">
           <div class="d-flex align-items-center justify-content-between mb-3">
-            <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $params.code }}</span>
+            <span class="badge bg-primary-subtle text-primary fw-semibold notranslate">{{ $params.code }}</span>
             {{ with $params.plan_version }}
-            <span class="text-muted small">{{ i18n "common.plan" }} {{ . }}</span>
+            <span class="text-muted small"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> <span class="notranslate">{{ . }}</span></span>
             {{ end }}
           </div>
-          <h2 class="h4">{{ .Title }}</h2>
+          <h2 class="h4 notranslate">{{ .Title }}</h2>
           {{ with $params.summary }}
-          <p class="text-muted">{{ . }}</p>
+          <p class="text-muted notranslate">{{ . }}</p>
           {{ else }}
-          {{ with .Summary }}<p class="text-muted">{{ . }}</p>{{ end }}
+          {{ with .Summary }}<p class="text-muted notranslate">{{ . }}</p>{{ end }}
           {{ end }}
           <dl class="row small text-muted mb-4">
-            <dt class="col-5">{{ i18n "common.degree" }}</dt>
-            <dd class="col-7">{{ $params.degree | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.ects" }}</dt>
-            <dd class="col-7">{{ $params.ects_total | default "--" }}</dd>
-            <dt class="col-5">{{ i18n "common.duration" }}</dt>
-            <dd class="col-7">{{ $params.duration_semesters | default "--" }} {{ i18n "common.durationSuffix" }}</dd>
+            <dt class="col-5" data-i18n="common.degree">{{ i18n "common.degree" }}</dt>
+            <dd class="col-7 notranslate">{{ $params.degree | default "--" }}</dd>
+            <dt class="col-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
+            <dd class="col-7 notranslate">{{ $params.ects_total | default "--" }}</dd>
+            <dt class="col-5" data-i18n="common.duration">{{ i18n "common.duration" }}</dt>
+            <dd class="col-7"><span class="notranslate">{{ $params.duration_semesters | default "--" }}</span> <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></dd>
           </dl>
           <div class="mt-auto">
-            <a class="btn btn-outline-primary w-100" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ i18n "catalog.viewCurriculum" }}</a>
+            <a class="btn btn-outline-primary w-100" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}" data-i18n="catalog.viewCurriculum">{{ i18n "catalog.viewCurriculum" }}</a>
           </div>
         </div>
       </div>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -18,33 +18,33 @@
       <div class="facodi-hero__grid">
         <div class="facodi-hero__content">
           <div class="facodi-hero__intro">
-            <span class="facodi-pill facodi-pill--brand facodi-hero__badge">{{ i18n "home.heroBadge" }}</span>
+            <span class="facodi-pill facodi-pill--brand facodi-hero__badge" data-i18n="home.heroBadge">{{ i18n "home.heroBadge" }}</span>
             <h1 class="facodi-hero__title">{{ site.Title }}</h1>
             <p class="facodi-hero__description">{{ .Params.lead | safeHTML }}</p>
           </div>
           <div class="facodi-hero__actions">
-            <a class="facodi-hero__cta" href="/courses/" role="button">{{ i18n "nav.viewTracks" }}</a>
-            <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.ecosystemCta" }}</a>
+            <a class="facodi-hero__cta" href="/courses/" role="button" data-i18n="nav.viewTracks">{{ i18n "nav.viewTracks" }}</a>
+            <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.ecosystemCta">{{ i18n "home.ecosystemCta" }}</a>
           </div>
           <div class="facodi-hero__meta">
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--success">{{ i18n "home.heroPillOpenLabel" }}</span>
-              <p>{{ i18n "home.heroPillOpenDescription" }}</p>
+              <span class="facodi-pill facodi-pill--success" data-i18n="home.heroPillOpenLabel">{{ i18n "home.heroPillOpenLabel" }}</span>
+              <p data-i18n="home.heroPillOpenDescription">{{ i18n "home.heroPillOpenDescription" }}</p>
             </div>
             <div class="facodi-hero__meta-item">
-              <span class="facodi-pill facodi-pill--outline">{{ i18n "home.heroPillCommunityLabel" }}</span>
-              <p>{{ i18n "home.heroPillCommunityDescription" }}</p>
+              <span class="facodi-pill facodi-pill--outline" data-i18n="home.heroPillCommunityLabel">{{ i18n "home.heroPillCommunityLabel" }}</span>
+              <p data-i18n="home.heroPillCommunityDescription">{{ i18n "home.heroPillCommunityDescription" }}</p>
             </div>
           </div>
         </div>
         <div class="facodi-hero__card">
-          <span class="facodi-hero__card-label">{{ i18n "home.heroCardLabel" }}</span>
+          <span class="facodi-hero__card-label" data-i18n="home.heroCardLabel">{{ i18n "home.heroCardLabel" }}</span>
           <ul class="facodi-hero__stat-list">
-            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> {{ i18n "home.heroCardCoursesLabel" }}</li>
-            <li><strong>{{ $scratch.Get "ucCount" }}</strong> {{ i18n "home.heroCardUnitsLabel" }}</li>
-            <li>{{ i18n "home.heroCardProgress" }}</li>
+            <li><strong>{{ $scratch.Get "coursesCount" }}</strong> <span data-i18n="home.heroCardCoursesLabel">{{ i18n "home.heroCardCoursesLabel" }}</span></li>
+            <li><strong>{{ $scratch.Get "ucCount" }}</strong> <span data-i18n="home.heroCardUnitsLabel">{{ i18n "home.heroCardUnitsLabel" }}</span></li>
+            <li data-i18n="home.heroCardProgress">{{ i18n "home.heroCardProgress" }}</li>
           </ul>
-          <p class="facodi-hero__card-foot">{{ i18n "home.heroCardFoot" (dict "MonynhaURL" "https://monynha.com") | safeHTML }}</p>
+          <p class="facodi-hero__card-foot" data-i18n="home.heroCardFoot" data-i18n-monynha-url="https://monynha.com">{{ i18n "home.heroCardFoot" (dict "MonynhaURL" "https://monynha.com") | safeHTML }}</p>
         </div>
       </div>
     </div>
@@ -61,24 +61,24 @@
   {{ end }}
 
   {{ $features := slice
-    (dict "icon" "🗺️" "title" (i18n "home.feature.map.title") "description" (i18n "home.feature.map.description"))
-    (dict "icon" "🎧" "title" (i18n "home.feature.playlists.title") "description" (i18n "home.feature.playlists.description"))
-    (dict "icon" "✅" "title" (i18n "home.feature.progress.title") "description" (i18n "home.feature.progress.description"))
-    (dict "icon" "🌈" "title" (i18n "home.feature.curatorship.title") "description" (i18n "home.feature.curatorship.description"))
+    (dict "icon" "🗺️" "titleKey" "home.feature.map.title" "descriptionKey" "home.feature.map.description")
+    (dict "icon" "🎧" "titleKey" "home.feature.playlists.title" "descriptionKey" "home.feature.playlists.description")
+    (dict "icon" "✅" "titleKey" "home.feature.progress.title" "descriptionKey" "home.feature.progress.description")
+    (dict "icon" "🌈" "titleKey" "home.feature.curatorship.title" "descriptionKey" "home.feature.curatorship.description")
   }}
   <section class="facodi-section facodi-section--features">
     <div class="container-lg section-wrap">
       <div class="facodi-section__header section-header text-center">
-        <span class="facodi-section__eyebrow">{{ i18n "home.featuresEyebrow" }}</span>
-        <h2 class="section-title facodi-section__title">{{ i18n "home.featuresTitle" }}</h2>
-        <p class="facodi-section__subtitle">{{ i18n "home.featuresSubtitle" }}</p>
+        <span class="facodi-section__eyebrow" data-i18n="home.featuresEyebrow">{{ i18n "home.featuresEyebrow" }}</span>
+        <h2 class="section-title facodi-section__title" data-i18n="home.featuresTitle">{{ i18n "home.featuresTitle" }}</h2>
+        <p class="facodi-section__subtitle" data-i18n="home.featuresSubtitle">{{ i18n "home.featuresSubtitle" }}</p>
       </div>
       <div class="facodi-grid facodi-grid--features">
         {{ range $features }}
         <div class="facodi-feature-card">
           <span class="facodi-feature-card__icon">{{ .icon }}</span>
-          <h3 class="facodi-feature-card__title">{{ .title }}</h3>
-          <p class="facodi-feature-card__description">{{ .description }}</p>
+          <h3 class="facodi-feature-card__title" data-i18n="{{ .titleKey }}">{{ i18n .titleKey }}</h3>
+          <p class="facodi-feature-card__description" data-i18n="{{ .descriptionKey }}">{{ i18n .descriptionKey }}</p>
         </div>
         {{ end }}
       </div>
@@ -90,12 +90,12 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow">{{ i18n "home.coursesEyebrow" }}</span>
-          <h2 class="section-title facodi-section__title">{{ i18n "home.coursesTitle" }}</h2>
-          <p class="facodi-section__subtitle">{{ i18n "home.coursesSubtitle" }}</p>
+          <span class="facodi-section__eyebrow" data-i18n="home.coursesEyebrow">{{ i18n "home.coursesEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.coursesTitle">{{ i18n "home.coursesTitle" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.coursesSubtitle">{{ i18n "home.coursesSubtitle" }}</p>
         </div>
         <div class="facodi-section__cta">
-          <a class="facodi-link facodi-link--cta" href="/courses/">{{ i18n "home.viewAllCourses" }}</a>
+          <a class="facodi-link facodi-link--cta" href="/courses/" data-i18n="home.viewAllCourses">{{ i18n "home.viewAllCourses" }}</a>
         </div>
       </div>
       <div class="facodi-grid facodi-grid--courses">
@@ -104,7 +104,7 @@
           <article class="facodi-course-card">
             <div class="facodi-course-card__body">
               {{ with .Params.plan_version }}
-              <span class="facodi-pill facodi-pill--outline">{{ i18n "common.plan" }} {{ . }}</span>
+              <span class="facodi-pill facodi-pill--outline"><span data-i18n="common.plan">{{ i18n "common.plan" }}</span> {{ . }}</span>
               {{ end }}
               <h3 class="facodi-course-card__title"><a href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">{{ .Title }}</a></h3>
               {{ with .Params.summary }}
@@ -113,13 +113,13 @@
             </div>
             <div class="facodi-course-card__meta">
               <div class="facodi-course-card__stats">
-                {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> {{ i18n "common.ects" }}</span>{{ end }}
-                {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> {{ i18n "common.durationSuffix" }}</span>{{ end }}
-                {{ with .Params.code }}<span>{{ i18n "common.code" }} {{ . }}</span>{{ end }}
+                {{ with .Params.ects_total }}<span><strong>{{ . }}</strong> <span data-i18n="common.ects">{{ i18n "common.ects" }}</span></span>{{ end }}
+                {{ with .Params.duration_semesters }}<span><strong>{{ . }}</strong> <span data-i18n="common.durationSuffix">{{ i18n "common.durationSuffix" }}</span></span>{{ end }}
+                {{ with .Params.code }}<span><span data-i18n="common.code">{{ i18n "common.code" }}</span> {{ . }}</span>{{ end }}
               </div>
               {{ with .Params.ucs }}
               {{ $ucCount := len . }}
-              <p class="facodi-course-card__foot">{{ $ucCount }} {{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }} {{ i18n "home.courseCardFootSuffix" }}</p>
+              <p class="facodi-course-card__foot">{{ $ucCount }} <span data-i18n="{{ if eq $ucCount 1 }}common.unit{{ else }}common.units{{ end }}">{{ if eq $ucCount 1 }}{{ i18n "common.unit" }}{{ else }}{{ i18n "common.units" }}{{ end }}</span> <span data-i18n="home.courseCardFootSuffix">{{ i18n "home.courseCardFootSuffix" }}</span></p>
               {{ end }}
             </div>
           </article>
@@ -134,15 +134,15 @@
     <div class="container-lg section-wrap">
       <div class="facodi-section__header facodi-section__header--split section-header">
         <div class="section-header section-header--flush">
-          <span class="facodi-section__eyebrow facodi-section__eyebrow--light">{{ i18n "home.journeyEyebrow" }}</span>
-          <h2 class="section-title facodi-section__title">{{ i18n "home.journeyTitle" }}</h2>
-          <p class="facodi-section__subtitle">{{ i18n "home.journeySubtitle" }}</p>
+          <span class="facodi-section__eyebrow facodi-section__eyebrow--light" data-i18n="home.journeyEyebrow">{{ i18n "home.journeyEyebrow" }}</span>
+          <h2 class="section-title facodi-section__title" data-i18n="home.journeyTitle">{{ i18n "home.journeyTitle" }}</h2>
+          <p class="facodi-section__subtitle" data-i18n="home.journeySubtitle">{{ i18n "home.journeySubtitle" }}</p>
         </div>
       </div>
       <ol class="facodi-journey__list">
-        <li>{{ i18n "home.journeyStep1" }}</li>
-        <li>{{ i18n "home.journeyStep2" }}</li>
-        <li>{{ i18n "home.journeyStep3" }}</li>
+        <li data-i18n="home.journeyStep1">{{ i18n "home.journeyStep1" }}</li>
+        <li data-i18n="home.journeyStep2">{{ i18n "home.journeyStep2" }}</li>
+        <li data-i18n="home.journeyStep3">{{ i18n "home.journeyStep3" }}</li>
       </ol>
     </div>
   </section>
@@ -152,10 +152,10 @@
 <section class="facodi-section facodi-section--manifesto">
   <div class="container-lg section-wrap">
     <div class="facodi-manifesto">
-      <span class="facodi-section__eyebrow">{{ i18n "home.manifestoEyebrow" }}</span>
-      <h2 class="section-title facodi-manifesto__title">{{ i18n "home.manifestoTitle" }}</h2>
-      <p class="facodi-manifesto__description">{{ i18n "home.manifestoDescription" }}</p>
-      <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.readManifesto" }}</a>
+      <span class="facodi-section__eyebrow" data-i18n="home.manifestoEyebrow">{{ i18n "home.manifestoEyebrow" }}</span>
+      <h2 class="section-title facodi-manifesto__title" data-i18n="home.manifestoTitle">{{ i18n "home.manifestoTitle" }}</h2>
+      <p class="facodi-manifesto__description" data-i18n="home.manifestoDescription">{{ i18n "home.manifestoDescription" }}</p>
+      <a class="facodi-link facodi-link--cta" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.readManifesto">{{ i18n "home.readManifesto" }}</a>
     </div>
   </div>
 </section>
@@ -165,11 +165,11 @@
 <section class="facodi-section facodi-section--cta">
   <div class="container-lg section-wrap">
     <div class="facodi-cta">
-      <h2 class="section-title facodi-cta__title">{{ i18n "home.ctaTitle" }}</h2>
-      <p class="facodi-cta__description">{{ i18n "home.ctaDescription" }}</p>
+      <h2 class="section-title facodi-cta__title" data-i18n="home.ctaTitle">{{ i18n "home.ctaTitle" }}</h2>
+      <p class="facodi-cta__description" data-i18n="home.ctaDescription">{{ i18n "home.ctaDescription" }}</p>
       <div class="facodi-cta__actions">
-        <a class="facodi-hero__cta" href="/courses/">{{ i18n "home.viewCurricula" }}</a>
-        <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener">{{ i18n "home.contactMonynha" }}</a>
+        <a class="facodi-hero__cta" href="/courses/" data-i18n="home.viewCurricula">{{ i18n "home.viewCurricula" }}</a>
+        <a class="facodi-hero__secondary" href="https://monynha.com" target="_blank" rel="noopener" data-i18n="home.contactMonynha">{{ i18n "home.contactMonynha" }}</a>
       </div>
     </div>
   </div>

--- a/layouts/topic/single.html
+++ b/layouts/topic/single.html
@@ -29,35 +29,35 @@
 <section class="section container py-5">
   <div class="row justify-content-center mb-5">
     <div class="col-lg-8 text-center">
-      <span class="badge bg-warning-subtle text-warning">{{ $params.slug | default "topic" }}</span>
-      <h1 class="display-6 mt-3">{{ .Title }}</h1>
-      {{ with $params.summary }}<p class="lead text-muted">{{ . }}</p>{{ end }}
+      <span class="badge bg-warning-subtle text-warning notranslate">{{ $params.slug | default "topic" }}</span>
+      <h1 class="display-6 mt-3 notranslate">{{ .Title }}</h1>
+      {{ with $params.summary }}<p class="lead text-muted notranslate">{{ . }}</p>{{ end }}
       <div class="mt-3" data-facodi-slot="topic-tags">
         {{ with $params.tags }}
-          {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1">{{ . }}</span>{{ end }}
+          {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1 notranslate">{{ . }}</span>{{ end }}
         {{ else }}
-          <span class="text-muted small">{{ i18n "topic.noTags" }}</span>
+          <span class="text-muted small" data-i18n="topic.noTags">{{ i18n "topic.noTags" }}</span>
         {{ end }}
       </div>
     </div>
   </div>
   <div class="row justify-content-center">
     <div class="col-lg-8">
-      <article class="content mb-5" id="topic-content" data-facodi-slot="topic-content">{{ .Content }}</article>
+      <article class="content mb-5 notranslate" id="topic-content" data-facodi-slot="topic-content">{{ .Content }}</article>
       <section id="topic-playlists" data-facodi-slot="topic-playlists">
-        <h2 class="h5">{{ i18n "topic.relatedPlaylists" }}</h2>
+        <h2 class="h5" data-i18n="topic.relatedPlaylists">{{ i18n "topic.relatedPlaylists" }}</h2>
         {{ if $params.youtube_playlists }}
-        <ul class="list-unstyled">
+        <ul class="list-unstyled notranslate">
           {{ range sort $params.youtube_playlists "priority" }}
           <li class="mb-2">
-            <a class="d-inline-flex align-items-center" href="https://www.youtube.com/playlist?list={{ .id }}" target="_blank" rel="noopener">
+            <a class="d-inline-flex align-items-center notranslate" href="https://www.youtube.com/playlist?list={{ .id }}" target="_blank" rel="noopener">
               <span class="badge bg-danger me-2">YT</span>{{ .id }}
             </a>
           </li>
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "topic.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="topic.noPlaylists">{{ i18n "topic.noPlaylists" }}</p>
         {{ end }}
       </section>
     </div>

--- a/layouts/uc/list.html
+++ b/layouts/uc/list.html
@@ -24,26 +24,26 @@
     <div class="col-lg-10">
       <div class="d-flex flex-column flex-lg-row justify-content-between gap-4">
         <div>
-          <span class="badge bg-secondary-subtle text-secondary">{{ $params.code }}</span>
+          <span class="badge bg-secondary-subtle text-secondary notranslate">{{ $params.code }}</span>
           {{ with $params.semester }}
-          <span class="badge bg-info-subtle text-info ms-2">{{ i18n "common.semester" }} {{ . }}</span>
+          <span class="badge bg-info-subtle text-info ms-2"><span data-i18n="common.semester">{{ i18n "common.semester" }}</span> <span class="notranslate">{{ . }}</span></span>
           {{ end }}
-          <h1 class="display-6 mt-3">{{ .Title }}</h1>
-          {{ with $params.description }}<p class="lead text-muted">{{ . }}</p>{{ end }}
+          <h1 class="display-6 mt-3 notranslate">{{ .Title }}</h1>
+          {{ with $params.description }}<p class="lead text-muted notranslate">{{ . }}</p>{{ end }}
         </div>
         <div class="card border-0 shadow-sm">
           <div class="card-body">
             <dl class="row mb-0 small">
-              <dt class="col-6 col-lg-5">{{ i18n "common.ects" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.ects | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "common.language" }}</dt>
-              <dd class="col-6 col-lg-7 text-lg-end">{{ $params.language | default "--" }}</dd>
-              <dt class="col-6 col-lg-5">{{ i18n "uc.prerequisites" }}</dt>
+              <dt class="col-6 col-lg-5" data-i18n="common.ects">{{ i18n "common.ects" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.ects | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="common.language">{{ i18n "common.language" }}</dt>
+              <dd class="col-6 col-lg-7 text-lg-end notranslate">{{ $params.language | default "--" }}</dd>
+              <dt class="col-6 col-lg-5" data-i18n="uc.prerequisites">{{ i18n "uc.prerequisites" }}</dt>
               <dd class="col-6 col-lg-7 text-lg-end" data-facodi-uc-prerequisites>
                 {{ if $params.prerequisites }}
-                  {{ delimit $params.prerequisites ", " }}
+                  <span class="notranslate">{{ delimit $params.prerequisites ", " }}</span>
                 {{ else }}
-                  <span class="text-muted">{{ i18n "uc.noPrerequisites" }}</span>
+                  <span class="text-muted" data-i18n="uc.noPrerequisites">{{ i18n "uc.noPrerequisites" }}</span>
                 {{ end }}
               </dd>
             </dl>
@@ -54,33 +54,33 @@
   </div>
   <div class="row justify-content-center">
     <div class="col-lg-7 order-lg-1">
-      <article class="content mb-5" id="uc-content" data-facodi-slot="uc-content">{{ .Content }}</article>
+      <article class="content mb-5 notranslate" id="uc-content" data-facodi-slot="uc-content">{{ .Content }}</article>
       {{ $topics := .RegularPages }}
       <section class="mb-5" id="uc-topics" data-facodi-slot="uc-topics">
         <div class="d-flex align-items-center justify-content-between mb-3">
-          <h2 class="h4 mb-0">{{ i18n "uc.topics" }}</h2>
+          <h2 class="h4 mb-0" data-i18n="uc.topics">{{ i18n "uc.topics" }}</h2>
           {{ $topicCount := len $topics }}
-          <span class="text-muted small">{{ $topicCount }} {{ if eq $topicCount 1 }}{{ i18n "common.topic" }}{{ else }}{{ i18n "common.topics" }}{{ end }}</span>
+          <span class="text-muted small">{{ $topicCount }} <span data-i18n="{{ if eq $topicCount 1 }}common.topic{{ else }}common.topics{{ end }}">{{ if eq $topicCount 1 }}{{ i18n "common.topic" }}{{ else }}{{ i18n "common.topics" }}{{ end }}</span></span>
         </div>
         {{ if not (len $topics) }}
-        <div class="alert alert-info" role="alert">{{ i18n "uc.noTopics" }}</div>
+        <div class="alert alert-info" role="alert" data-i18n="uc.noTopics">{{ i18n "uc.noTopics" }}</div>
         {{ else }}
         <div class="list-group list-group-flush">
           {{ range sort $topics "Title" }}
           <a class="list-group-item list-group-item-action" href="{{ partial "facodi/langless-url.html" (dict "url" .RelPermalink) }}">
             <div class="d-flex justify-content-between align-items-start">
               <div>
-                <h3 class="h6 mb-1">{{ .Title }}</h3>
-                {{ with .Params.summary }}<p class="mb-1 small text-muted">{{ . }}</p>{{ end }}
+                <h3 class="h6 mb-1 notranslate">{{ .Title }}</h3>
+                {{ with .Params.summary }}<p class="mb-1 small text-muted notranslate">{{ . }}</p>{{ end }}
               </div>
               {{ with .Params.youtube_playlists }}
               {{ $playlistCount := len . }}
-              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} {{ if eq $playlistCount 1 }}{{ i18n "common.playlist" }}{{ else }}{{ i18n "common.playlists" }}{{ end }}</span>
+              <span class="badge bg-primary-subtle text-primary">{{ $playlistCount }} <span data-i18n="{{ if eq $playlistCount 1 }}common.playlist{{ else }}common.playlists{{ end }}">{{ if eq $playlistCount 1 }}{{ i18n "common.playlist" }}{{ else }}{{ i18n "common.playlists" }}{{ end }}</span></span>
               {{ end }}
             </div>
             {{ with .Params.tags }}
             <div class="mt-2">
-              {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1">{{ . }}</span>{{ end }}
+              {{ range . }}<span class="badge rounded-pill bg-light text-muted me-1 notranslate">{{ . }}</span>{{ end }}
             </div>
             {{ end }}
           </a>
@@ -91,29 +91,29 @@
     </div>
     <div class="col-lg-3 order-lg-0">
       <aside class="mb-5" id="uc-learning-outcomes" data-facodi-slot="uc-outcomes">
-        <h2 class="h5">{{ i18n "uc.learningOutcomes" }}</h2>
+        <h2 class="h5" data-i18n="uc.learningOutcomes">{{ i18n "uc.learningOutcomes" }}</h2>
         {{ if $params.learning_outcomes }}
-        <ol class="ps-3">
+        <ol class="ps-3 notranslate">
           {{ range $params.learning_outcomes }}<li class="mb-2">{{ . }}</li>{{ end }}
         </ol>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noLearningOutcomes" }}</p>
+        <p class="text-muted small" data-i18n="uc.noLearningOutcomes">{{ i18n "uc.noLearningOutcomes" }}</p>
         {{ end }}
       </aside>
       <aside id="uc-playlists" data-facodi-slot="uc-playlists">
-        <h2 class="h5">{{ i18n "uc.playlists" }}</h2>
+        <h2 class="h5" data-i18n="uc.playlists">{{ i18n "uc.playlists" }}</h2>
         {{ if $params.youtube_playlists }}
-        <ul class="list-unstyled">
+        <ul class="list-unstyled notranslate">
           {{ range sort $params.youtube_playlists "priority" }}
           <li class="mb-2">
-            <a class="d-inline-flex align-items-center" href="https://www.youtube.com/playlist?list={{ .id }}" target="_blank" rel="noopener">
+            <a class="d-inline-flex align-items-center notranslate" href="https://www.youtube.com/playlist?list={{ .id }}" target="_blank" rel="noopener">
               <span class="badge bg-danger me-2">YT</span>{{ .id }}
             </a>
           </li>
           {{ end }}
         </ul>
         {{ else }}
-        <p class="text-muted small">{{ i18n "uc.noPlaylists" }}</p>
+        <p class="text-muted small" data-i18n="uc.noPlaylists">{{ i18n "uc.noPlaylists" }}</p>
         {{ end }}
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- configure Hugo to serve a single Portuguese routing tree while exposing locale metadata for the runtime translator
- annotate templates with `data-i18n` hooks and hide Google Translate UI artifacts while embedding translation payloads
- update the Supabase loaders and custom runtime script to apply manual translations, reapply them on dynamic content, and fall back to pt-BR when necessary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07c70dd7083228aac1422e5b4b37f