### PR TITLE
Improve responsive layouts for course/UC/topic content

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -35,6 +35,35 @@ dl.row {
   }
 }
 
+// Improve content responsiveness
+.content,
+.facodi-rich-content {
+  overflow-wrap: anywhere;
+
+  img,
+  svg,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  iframe {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  pre {
+    overflow-x: auto;
+  }
+}
+
 // Better card spacing and hover effects
 .card {
   transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;

--- a/layouts/course/single.html
+++ b/layouts/course/single.html
@@ -14,7 +14,7 @@
       </div>
       <section class="mb-5">
         <h2 class="h4">{{ i18n "course_synced_heading" }}</h2>
-        <div id="course-content-md" class="border rounded-3 p-4 bg-light-subtle" data-course-content>
+        <div id="course-content-md" class="border rounded-3 p-4 bg-light-subtle facodi-rich-content" data-course-content>
           <p class="text-muted mb-0">{{ i18n "course_synced_loading" }}</p>
         </div>
       </section>
@@ -30,16 +30,16 @@
         <div class="card-body">
           <h2 class="h5">{{ i18n "course_details_heading" }}</h2>
           <dl class="row mb-0 small" data-course-details>
-            <dt class="col-5">{{ i18n "course_details_institution" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "course_details_school" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "course_details_ects" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "course_details_duration" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "course_details_language" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "course_details_institution" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "course_details_school" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "course_details_ects" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "course_details_duration" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "course_details_language" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
           </dl>
         </div>
       </aside>

--- a/layouts/topic/single.html
+++ b/layouts/topic/single.html
@@ -11,7 +11,7 @@
       </div>
       <section class="mb-5">
         <h2 class="h4">{{ i18n "topic_synced_heading" }}</h2>
-        <div class="border rounded-3 p-4 bg-light-subtle" data-topic-content>
+        <div class="border rounded-3 p-4 bg-light-subtle facodi-rich-content" data-topic-content>
           <p class="text-muted mb-0">{{ i18n "topic_synced_loading" }}</p>
         </div>
       </section>

--- a/layouts/uc/single.html
+++ b/layouts/uc/single.html
@@ -11,7 +11,7 @@
       </div>
       <section class="mb-5">
         <h2 class="h4">{{ i18n "uc_synced_heading" }}</h2>
-        <div class="border rounded-3 p-4 bg-light-subtle" data-uc-content>
+        <div class="border rounded-3 p-4 bg-light-subtle facodi-rich-content" data-uc-content>
           <p class="text-muted mb-0">{{ i18n "uc_synced_loading" }}</p>
         </div>
       </section>
@@ -39,16 +39,16 @@
         <div class="card-body">
           <h2 class="h5">{{ i18n "uc_details_heading" }}</h2>
           <dl class="row mb-0 small" data-uc-details>
-            <dt class="col-5">{{ i18n "uc_details_course" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "uc_details_ects" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "uc_details_semester" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "uc_details_language" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
-            <dt class="col-5">{{ i18n "uc_details_prerequisites" }}</dt>
-            <dd class="col-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "uc_details_course" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "uc_details_ects" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "uc_details_semester" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "uc_details_language" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
+            <dt class="col-12 col-sm-5">{{ i18n "uc_details_prerequisites" }}</dt>
+            <dd class="col-12 col-sm-7 text-muted">—</dd>
           </dl>
         </div>
       </aside>

--- a/static/js/loaders.js
+++ b/static/js/loaders.js
@@ -119,16 +119,16 @@
       }
 
       detailsEl.innerHTML = `
-        <dt class="col-5">${t('course.details.institution', 'Instituição')}</dt>
-        <dd class="col-7">${toText(course.institution)}</dd>
-        <dt class="col-5">${t('course.details.school', 'Escola')}</dt>
-        <dd class="col-7">${toText(course.school)}</dd>
-        <dt class="col-5">${t('course.details.ects', 'ECTS')}</dt>
-        <dd class="col-7">${toText(course.ects_total)}</dd>
-        <dt class="col-5">${t('course.details.duration', 'Duração')}</dt>
-        <dd class="col-7">${durationLabel(course.duration_semesters)}</dd>
-        <dt class="col-5">${t('course.details.language', 'Idioma')}</dt>
-        <dd class="col-7">${toText(course.language)}</dd>
+        <dt class="col-12 col-sm-5">${t('course.details.institution', 'Instituição')}</dt>
+        <dd class="col-12 col-sm-7">${toText(course.institution)}</dd>
+        <dt class="col-12 col-sm-5">${t('course.details.school', 'Escola')}</dt>
+        <dd class="col-12 col-sm-7">${toText(course.school)}</dd>
+        <dt class="col-12 col-sm-5">${t('course.details.ects', 'ECTS')}</dt>
+        <dd class="col-12 col-sm-7">${toText(course.ects_total)}</dd>
+        <dt class="col-12 col-sm-5">${t('course.details.duration', 'Duração')}</dt>
+        <dd class="col-12 col-sm-7">${durationLabel(course.duration_semesters)}</dd>
+        <dt class="col-12 col-sm-5">${t('course.details.language', 'Idioma')}</dt>
+        <dd class="col-12 col-sm-7">${toText(course.language)}</dd>
       `;
 
       const { data: courseContent, error: contentError } = await client
@@ -223,16 +223,16 @@
       }
 
       detailsEl.innerHTML = `
-        <dt class="col-5">${t('uc.details.course', 'Curso')}</dt>
-        <dd class="col-7">${toText(uc.course_code)}</dd>
-        <dt class="col-5">${t('uc.details.ects', 'ECTS')}</dt>
-        <dd class="col-7">${toText(uc.ects)}</dd>
-        <dt class="col-5">${t('uc.details.semester', 'Semestre')}</dt>
-        <dd class="col-7">${toText(uc.semester)}</dd>
-        <dt class="col-5">${t('uc.details.language', 'Idioma')}</dt>
-        <dd class="col-7">${toText(uc.language)}</dd>
-        <dt class="col-5">${t('uc.details.prerequisites', 'Pré-requisitos')}</dt>
-        <dd class="col-7">${toText(uc.prerequisites)}</dd>
+        <dt class="col-12 col-sm-5">${t('uc.details.course', 'Curso')}</dt>
+        <dd class="col-12 col-sm-7">${toText(uc.course_code)}</dd>
+        <dt class="col-12 col-sm-5">${t('uc.details.ects', 'ECTS')}</dt>
+        <dd class="col-12 col-sm-7">${toText(uc.ects)}</dd>
+        <dt class="col-12 col-sm-5">${t('uc.details.semester', 'Semestre')}</dt>
+        <dd class="col-12 col-sm-7">${toText(uc.semester)}</dd>
+        <dt class="col-12 col-sm-5">${t('uc.details.language', 'Idioma')}</dt>
+        <dd class="col-12 col-sm-7">${toText(uc.language)}</dd>
+        <dt class="col-12 col-sm-5">${t('uc.details.prerequisites', 'Pré-requisitos')}</dt>
+        <dd class="col-12 col-sm-7">${toText(uc.prerequisites)}</dd>
       `;
 
       const { data: ucContent, error: ucContentError } = await client


### PR DESCRIPTION
### Motivation

- Fix mobile and small-screen rendering issues where synced Markdown content, images, tables or iframes could overflow or be clipped.
- Make course and UC detail areas more readable on narrow screens by stacking definition list terms and values.
- Ensure dynamically-loaded synced content uses the same responsive rules as regular page content.

### Description

- Added responsive content styles in `assets/scss/common/_custom.scss` to constrain images, SVGs, videos, iframes, tables and `pre` blocks and enable safe overflow scrolling for tables and code blocks.
- Applied a `.facodi-rich-content` helper and included it alongside existing `.content` so synced Markdown blocks render responsively in templates.
- Updated templates `layouts/course/single.html`, `layouts/uc/single.html` and `layouts/topic/single.html` to add the `facodi-rich-content` class to synced content containers and to use `col-12 col-sm-5` / `col-12 col-sm-7` grid classes for definition lists to stack on small screens.
- Updated `static/js/loaders.js` to emit the same responsive grid classes when populating course and UC detail `dl` elements so client-rendered content matches the templates.

### Testing

- Attempted to run the local site with `hugo server -D --bind 0.0.0.0 --port 1313`, but the command failed with `hugo: command not found`, so a local build/visual verification could not be performed in this environment.
- No automated unit or CI tests were executed as part of this change in the current run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f1b4edbc832288023fc75b2d1bd9)