### PR TITLE
Improve mobile responsiveness and content overflow handling

### DIFF
--- a/assets/css/facodi.css
+++ b/assets/css/facodi.css
@@ -38,6 +38,28 @@ body {
   flex-direction: column;
 }
 
+.content {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.content img,
+.content video,
+.content iframe {
+  max-width: 100%;
+  height: auto;
+}
+
+.content table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+}
+
+.content pre {
+  overflow-x: auto;
+}
+
 a {
   color: var(--facodi-primary);
   text-decoration-color: rgba(106, 75, 255, 0.35);
@@ -170,7 +192,14 @@ body {
 .facodi-navbar__actions {
   display: flex;
   gap: 1rem;
-  align-items: center;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+@media (min-width: 992px) {
+  .facodi-navbar__actions {
+    align-items: center;
+  }
 }
 
 .facodi-navbar__select {
@@ -603,6 +632,32 @@ html[data-theme="dark"] .facodi-footer {
   .facodi-navbar__actions {
     width: 100%;
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .facodi-navbar__links .nav-link {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .facodi-hero {
+    padding: 4rem 0 2.5rem;
+  }
+  .facodi-hero__card,
+  .facodi-section__body,
+  .facodi-manifesto,
+  .facodi-cta {
+    padding: 2rem;
+  }
+  .course-uc-card__meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .course-uc-card__details {
+    grid-template-columns: 1fr;
+  }
+  .course-uc-card__details dd {
+    text-align: left;
   }
 }
 .facodi-pill {

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -5,6 +5,28 @@ body {
   color: var(--facodi-body-color);
 }
 
+.content {
+  overflow-wrap: break-word;
+  word-break: break-word;
+
+  img,
+  video,
+  iframe {
+    max-width: 100%;
+    height: auto;
+  }
+
+  table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  pre {
+    overflow-x: auto;
+  }
+}
+
 a {
   color: $primary;
   text-decoration-color: rgba($primary, 0.35);
@@ -114,9 +136,12 @@ a {
 
 .facodi-navbar__actions {
   width: 100%;
+  flex-wrap: wrap;
+  align-items: stretch;
 
   @include media-breakpoint-up(lg) {
     width: auto;
+    align-items: center;
   }
 }
 
@@ -1006,5 +1031,36 @@ html[data-theme="dark"] .facodi-theme-icon--light {
 
   .facodi-navbar__actions {
     display: flex;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .facodi-navbar__links .nav-link {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .facodi-hero {
+    padding: 4rem 0 2.5rem;
+  }
+
+  .facodi-hero__card,
+  .facodi-section__body,
+  .facodi-manifesto,
+  .facodi-cta {
+    padding: 2rem;
+  }
+
+  .course-uc-card__meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .course-uc-card__details {
+    grid-template-columns: 1fr;
+  }
+
+  .course-uc-card__details dd {
+    text-align: left;
   }
 }


### PR DESCRIPTION
### Motivation
- Fix layout and readability issues on small screens by making content blocks (images, tables, code) responsive and preventing overflow. 
- Ensure navbar actions and course/UC card metadata wrap and align cleanly across breakpoints to improve usability on narrow viewports. 

### Description
- Added responsive-safe content rules (images, `video`, `iframe`, `table`, `pre`) under the `.content` selector to prevent overflow and ensure media scales to container width in `assets/scss/common/_custom.scss` and `assets/css/facodi.css`.
- Enabled wrapping and adjusted alignment for navbar actions via `flex-wrap` and breakpoint-specific `align-items` rules in `assets/scss/common/_custom.scss` and `assets/css/facodi.css`.
- Added mobile-specific adjustments (reduced hero spacing, reduced padding for hero/card/CTA sections, stacked course-UC metadata and single-column details) inside `@media (max-width: 575.98px)` in both stylesheet files.
- Added a desktop-specific alignment rule (`@media (min-width: 992px)`) to keep previous alignment on larger viewports while allowing the mobile-friendly wrapping behavior.

### Testing
- No automated tests were executed for these style changes in the environment. 
- An attempt to run the site with `hugo server -D --bind 0.0.0.0 --port 1313` failed because the `hugo` binary is not available in this environment, so visual verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f5a36af08322932d9bfed810e03b)