### PR TITLE
Make mobile offcanvas full-height and scrollable

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -78,6 +78,13 @@ a {
   padding: 1.25rem 0;
 }
 
+@include media-breakpoint-down(lg) {
+  .offcanvas-body {
+    overflow-y: auto;
+    max-height: 100vh;
+  }
+}
+
 .facodi-navbar__links {
   width: 100%;
 

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -31,7 +31,7 @@
     </button>
 
     <!-- Main navigation -->
-    <div class="offcanvas offcanvas-end h-auto" tabindex="-1" id="offcanvasNavMain" aria-labelledby="offcanvasNavMainLabel">
+    <div class="offcanvas offcanvas-end h-100" tabindex="-1" id="offcanvasNavMain" aria-labelledby="offcanvasNavMainLabel">
       {{ if site.Params.doks.headerBar -}}
         <div class="header-bar d-lg-none"></div>
       {{ end -}}
@@ -155,5 +155,4 @@
 {{ if site.Params.doks.flexSearch -}}
 {{ partial "header/search-modal" . }}
 {{ end -}}
-
 


### PR DESCRIPTION
### Motivation
- Ensure the mobile offcanvas uses the full viewport height and allows internal scrolling so menu items are reachable on small screens and Bootstrap offcanvas behavior applies.

### Description
- Replace `h-auto` with `h-100` on the offcanvas container in `layouts/_partials/header/header.html` and add a small-screen rule in `assets/scss/common/_custom.scss` (`@include media-breakpoint-down(lg) { .offcanvas-body { overflow-y: auto; max-height: 100vh; } }`).

### Testing
- Attempted to run `hugo server -D --bind 0.0.0.0 --port 1313`, which failed because the `hugo` binary is not available in the environment; no automated site build tests completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968063520b0832280e0cb25f30f6186)