### PR TITLE
Fix offcanvas menu height and scrolling

### DIFF
--- a/assets/css/facodi.css
+++ b/assets/css/facodi.css
@@ -158,6 +158,38 @@ body {
   padding: 1.25rem 0;
 }
 
+.facodi-navbar__offcanvas {
+  border: 0;
+  background: var(--facodi-surface-bg);
+  color: var(--facodi-heading-color);
+  box-shadow: var(--facodi-surface-shadow);
+  height: 100vh;
+}
+
+.facodi-navbar__offcanvas .offcanvas-header {
+  padding: 1.25rem 1.5rem 0.75rem;
+  border-bottom: 1px solid var(--facodi-surface-border);
+}
+
+.facodi-navbar__offcanvas .offcanvas-title {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.facodi-navbar__offcanvas .offcanvas-body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  overflow-y: auto;
+}
+
+.facodi-navbar__close {
+  filter: none;
+}
+
+html[data-theme="dark"] .facodi-navbar__close {
+  filter: invert(1);
+}
+
 .facodi-navbar__links .nav-link {
   display: inline-flex;
   align-items: center;
@@ -629,6 +661,26 @@ html[data-theme="dark"] .facodi-footer {
   background: rgba(106, 75, 255, 0.12);
   color: var(--facodi-primary);
   font-weight: 500;
+}
+
+@media (min-width: 992px) {
+  .facodi-navbar__offcanvas {
+    position: static;
+    visibility: visible;
+    transform: none;
+    background: transparent;
+    box-shadow: none;
+    height: auto;
+  }
+
+  .facodi-navbar__offcanvas .offcanvas-header {
+    display: none;
+  }
+
+  .facodi-navbar__offcanvas .offcanvas-body {
+    padding: 0;
+    overflow: visible;
+  }
 }
 
 @media (max-width: 991.98px) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -304,6 +304,10 @@
     "translation": "Select language"
   },
   {
+    "id": "nav.mainNavigation",
+    "translation": "Main navigation"
+  },
+  {
     "id": "nav.openMainMenu",
     "translation": "Open main menu"
   },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -304,6 +304,10 @@
     "translation": "Seleccionar idioma"
   },
   {
+    "id": "nav.mainNavigation",
+    "translation": "Navegación principal"
+  },
+  {
     "id": "nav.openMainMenu",
     "translation": "Abrir menú principal"
   },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -304,6 +304,10 @@
     "translation": "Sélectionner la langue"
   },
   {
+    "id": "nav.mainNavigation",
+    "translation": "Navigation principale"
+  },
+  {
     "id": "nav.openMainMenu",
     "translation": "Ouvrir le menu principal"
   },

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -304,6 +304,10 @@
     "translation": "Selecionar idioma"
   },
   {
+    "id": "nav.mainNavigation",
+    "translation": "Navegação principal"
+  },
+  {
     "id": "nav.openMainMenu",
     "translation": "Abrir menu principal"
   },

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -10,7 +10,7 @@
 <div class="header-bar"></div>
 {{ end -}}
 
-<header class="navbar navbar-expand-lg facodi-navbar">
+<header class="navbar navbar-expand-lg facodi-navbar" role="navigation" aria-label="{{ i18n "nav.mainNavigation" }}" data-i18n-attr-aria-label="nav.mainNavigation">
   {{ with site.Params.doks.containerBreakpoint -}}
     <div class="container-{{ . }} facodi-navbar__inner">
   {{ else -}}
@@ -21,7 +21,7 @@
     <a class="navbar-brand facodi-navbar__brand" href="{{ relLangURL "" }}">{{ .Site.Title }}</a>
 
     <!-- Main navigation button -->
-    <button class="facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}" data-i18n-attr-aria-label="nav.openMainMenu">
+    <button class="navbar-toggler facodi-navbar__toggle d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavMain" aria-controls="offcanvasNavMain" aria-label="{{ i18n "nav.openMainMenu" }}" data-i18n-attr-aria-label="nav.openMainMenu">
       <span class="visually-hidden" {{ partial "facodi/i18n-attrs.html" (dict "key" "nav.openMenu") }}>{{ i18n "nav.openMenu" }}</span>
       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -31,32 +31,14 @@
     </button>
 
     <!-- Main navigation -->
-    <div class="offcanvas offcanvas-end h-auto" tabindex="-1" id="offcanvasNavMain" aria-labelledby="offcanvasNavMainLabel">
+    <div class="offcanvas offcanvas-end offcanvas-lg facodi-navbar__offcanvas" tabindex="-1" id="offcanvasNavMain" aria-labelledby="offcanvasNavMainLabel">
       {{ if site.Params.doks.headerBar -}}
         <div class="header-bar d-lg-none"></div>
       {{ end -}}
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="offcanvasNavMainLabel">{{ site.Title }}</h5>
-        <button type="button" class="btn btn-link nav-link p-0 ms-auto" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}" data-i18n-attr-aria-label="nav.closeMenu">
-          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-            <path d="M18 6l-12 12"></path>
-            <path d="M6 6l12 12"></path>
-         </svg>
-        </button>
+        <button type="button" class="btn-close facodi-navbar__close" data-bs-dismiss="offcanvas" aria-label="{{ i18n "nav.closeMenu" }}" data-i18n-attr-aria-label="nav.closeMenu"></button>
       </div>
-      <!--
-        <div class="offcanvas-header">
-        <h5 class="offcanvas-title fw-bold" id="offcanvasNavMainLabel">{{ .Site.Params.Title }}</h5>
-        <button class="btn btn-link nav-link ms-auto" type="button" data-bs-dismiss="offcanvas" aria-label="Close menu">
-          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-            <path d="M18 6l-12 12"></path>
-            <path d="M6 6l12 12"></path>
-          </svg>
-        </button>
-      </div>
-      -->
       <div class="offcanvas-body facodi-navbar__body d-flex flex-column flex-lg-row align-items-lg-center gap-lg-4">
         <ul class="navbar-nav facodi-navbar__links flex-column flex-lg-row align-items-lg-center gap-2 gap-lg-4 mb-4 mb-lg-0">
           {{- $current := . -}}
@@ -87,9 +69,9 @@
                     {{- end -}}
                     {{- $childKey := .Params.i18nKey | default "" -}}
                     {{- if $childKey -}}
-                      <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="true"{{ end }} {{ partial "facodi/i18n-attrs.html" (dict "key" $childKey) }}>{{ i18n $childKey }}</a></li>
+                      <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="page"{{ end }} {{ partial "facodi/i18n-attrs.html" (dict "key" $childKey) }}>{{ i18n $childKey }}</a></li>
                     {{- else -}}
-                      <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
+                      <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ $childHref }}"{{ if $active }} aria-current="page"{{ end }}>{{ .Name }}</a></li>
                     {{- end -}}
                   {{ end -}}
                 </ul>
@@ -105,9 +87,9 @@
                 {{- end -}}
                 {{- $labelKey := .Params.i18nKey | default "" -}}
                 {{- if $labelKey -}}
-                  <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="true"{{ end }} {{ partial "facodi/i18n-attrs.html" (dict "key" $labelKey) }}>{{ i18n $labelKey }}</a>
+                  <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="page"{{ end }} {{ partial "facodi/i18n-attrs.html" (dict "key" $labelKey) }}>{{ i18n $labelKey }}</a>
                 {{- else -}}
-                  <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
+                  <a class="nav-link{{ if $active }} active{{ end }}" href="{{ $href }}"{{ if $active }} aria-current="page"{{ end }}>{{ .Name }}</a>
                 {{- end -}}
               </li>
             {{ end -}}
@@ -155,5 +137,3 @@
 {{ if site.Params.doks.flexSearch -}}
 {{ partial "header/search-modal" . }}
 {{ end -}}
-
-


### PR DESCRIPTION
### Motivation
- The offcanvas sidebar menu was only partially visible on small viewports and needed to fill the viewport and support scrolling so all links are accessible.
- Desktop layout must remain inline and unaffected by mobile offcanvas behavior.
- Ensure navigation markup follows accessible, responsive patterns (labeling and standard controls).

### Description
- Updated `assets/css/facodi.css` to set `.facodi-navbar__offcanvas { height: 100vh; }` and make `.offcanvas-body` `overflow-y: auto` so the menu fills the viewport and scrolls on smaller screens.
- Reset the offcanvas behavior at desktop breakpoints with an `@media (min-width: 992px)` rule that sets `.facodi-navbar__offcanvas { height: auto; }` and `.offcanvas-body { overflow: visible; }` to preserve the inline navbar layout.
- Adjusted header markup in `layouts/_partials/header/header.html` to improve accessibility and Bootstrap compliance by adding `role="navigation"` and an i18n `aria-label`, switching the toggle to `navbar-toggler`, adding `offcanvas-lg facodi-navbar__offcanvas`, replacing the custom SVG close button with a `btn-close facodi-navbar__close`, and normalizing active link attributes to `aria-current="page"`.
- Added the `nav.mainNavigation` i18n string to `i18n/en.json`, `i18n/pt.json`, `i18n/es.json`, and `i18n/fr.json`.

### Testing
- Ran `hugo server -D --bind 0.0.0.0 --port 1313` and the site built and served successfully.
- Executed a Playwright script that opened the homepage at a mobile viewport, triggered the menu via `.facodi-navbar__toggle`, and saved `artifacts/facodi-mobile-menu-fixed.png`, confirming the offcanvas menu opens and renders with scrolling (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680002a50483229cd72d856142dafd)