### PR TITLE
refactor(frontend): centralize SPA route registry and round-trip parsing

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -14,6 +14,7 @@ import RequireAuth from './components/auth/RequireAuth';
 import PermissionDenied from './components/auth/PermissionDenied';
 import SEOHead from './components/SEOHead';
 import { getPostBySlug } from './data/blogPosts';
+import { fromPath, toPath, type View } from './app/router/routes';
 
 const Dashboard = React.lazy(() => import('./components/Dashboard'));
 const CourseDetail = React.lazy(() => import('./components/CourseDetail'));
@@ -39,38 +40,6 @@ const AdminContentDetailPage = React.lazy(() => import('./components/admin/Admin
 const AdminCuratorListPage = React.lazy(() => import('./components/admin/AdminCuratorListPage'));
 const BlogListPage = React.lazy(() => import('./components/blog/BlogListPage'));
 const BlogPostPage = React.lazy(() => import('./components/blog/BlogPostPage'));
-
-type View =
-  | 'home'
-  | 'not-found'
-  | 'courses'
-  | 'repository'
-  | 'paths'
-  | 'contributors'
-  | 'course-detail'
-  | 'lesson-detail'
-  | 'playlists'
-  | 'dashboard'
-  | 'institutional-page'
-  | 'videos'
-  | 'video-detail'
-  | 'profile'
-  | 'student-dashboard'
-  | 'student-my-courses'
-  | 'student-progress'
-  | 'student-history'
-  | 'curator-apply'
-  | 'curator-submit'
-  | 'curator-submissions'
-  | 'curator-channel-pipeline'
-  | 'curator-admin-review'
-  | 'curator-channel-curation'
-  | 'admin-dashboard'
-  | 'admin-contents'
-  | 'admin-content-detail'
-  | 'admin-curators'
-  | 'blog'
-  | 'blog-post';
 
 const App: React.FC = () => {
   const { user, profile } = useAuth();
@@ -105,184 +74,66 @@ const App: React.FC = () => {
   const t = useMemo(() => createTranslator(locale), [locale]);
 
   const updateRoute = (view: View, unitId?: string | null, lessonId?: string | null, videoId?: string | null, blogSlug?: string | null) => {
-    let path = '/';
-    if (view === 'courses') path = '/courses';
-    if (view === 'repository') path = '/courses/units';
-    if (view === 'course-detail' && unitId) path = `/courses/units/${unitId}`;
-    if (view === 'lesson-detail' && lessonId) path = `/lessons/${lessonId}`;
-    if (view === 'videos') path = '/videos';
-    if (view === 'video-detail' && videoId) path = `/videos/${videoId}`;
-    if (view === 'dashboard') path = '/dashboard';
-    if (view === 'playlists') path = '/playlists';
-    if (view === 'contributors') path = '/contributors';
-    if (view === 'profile') path = '/profile';
-    if (view === 'institutional-page' && unitId) path = `/${unitId}`;
-    if (view === 'student-dashboard') path = '/student/dashboard';
-    if (view === 'student-my-courses') path = '/student/my-courses';
-    if (view === 'student-progress') path = '/student/progress';
-    if (view === 'student-history') path = '/student/history';
-    if (view === 'curator-apply') path = '/curator/apply';
-    if (view === 'curator-submit') path = '/curator/submit';
-    if (view === 'curator-submissions') path = '/curator/submissions';
-    if (view === 'curator-channel-pipeline') path = '/curator/channel-pipeline';
-    if (view === 'curator-admin-review') path = '/curator/admin-review';
-    if (view === 'curator-channel-curation') path = '/curator/channel-curation';
-    if (view === 'admin-dashboard') path = '/admin';
-    if (view === 'admin-contents') path = '/admin/conteudos';
-    if (view === 'admin-content-detail' && unitId) path = `/admin/conteudos/${unitId}`;
-    if (view === 'admin-curators') path = '/admin/curadores';
-    if (view === 'blog') path = '/blog';
-    if (view === 'blog-post' && blogSlug) path = `/blog/${blogSlug}`;
-    window.history.pushState({}, '', path);
+    window.history.pushState({}, '', toPath(view, {
+      unitId,
+      lessonId,
+      videoId,
+      blogSlug,
+      pageSlug: unitId,
+      submissionId: unitId,
+    }));
   };
 
   const syncViewWithLocation = () => {
-    const path = window.location.pathname;
-    if (path.startsWith('/blog/')) {
-      const blogSlug = path.replace('/blog/', '').split('/')[0];
-      if (blogSlug) {
-        setSelectedBlogSlug(blogSlug);
-        setCurrentView('blog-post');
-        return;
-      }
-    }
-    if (path === '/blog') {
-      setCurrentView('blog');
+    const { view, params } = fromPath(window.location.pathname);
+
+    if (view === 'blog-post' && params?.blogSlug) {
+      setSelectedBlogSlug(params.blogSlug);
+      setCurrentView('blog-post');
       return;
     }
-    if (path.startsWith('/curator/')) {
-      if (path === '/curator/apply') {
-        setCurrentView('curator-apply');
-        return;
-      }
-      if (path === '/curator/submit') {
-        setCurrentView('curator-submit');
-        return;
-      }
-      if (path === '/curator/submissions') {
-        setCurrentView('curator-submissions');
-        return;
-      }
-      if (path === '/curator/channel-pipeline') {
-        setCurrentView('curator-channel-pipeline');
-        return;
-      }
-      if (path === '/curator/admin-review') {
-        setCurrentView('curator-admin-review');
-        return;
-      }
-      if (path === '/curator/channel-curation') {
-        setCurrentView('curator-channel-curation');
-        return;
-      }
-    }
-    if (path.startsWith('/admin')) {
-      if (path === '/admin') {
-        setCurrentView('admin-dashboard');
-        return;
-      }
-      if (path === '/admin/conteudos') {
-        setCurrentView('admin-contents');
-        return;
-      }
-      if (path.startsWith('/admin/conteudos/')) {
-        const submissionId = path.replace('/admin/conteudos/', '').split('/')[0];
-        if (submissionId) {
-          setSelectedAdminSubmissionId(submissionId);
-          setCurrentView('admin-content-detail');
-          return;
-        }
-      }
-      if (path === '/admin/curadores') {
-        setCurrentView('admin-curators');
-        return;
-      }
-    }
-    if (path.startsWith('/student/')) {
-      if (path === '/student/dashboard') {
-        setCurrentView('student-dashboard');
-        return;
-      }
-      if (path === '/student/my-courses') {
-        setCurrentView('student-my-courses');
-        return;
-      }
-      if (path === '/student/progress') {
-        setCurrentView('student-progress');
-        return;
-      }
-      if (path === '/student/history') {
-        setCurrentView('student-history');
-        return;
-      }
-    }
-    if (path.startsWith('/videos/')) {
-      const videoId = path.replace('/videos/', '').split('/')[0];
-      if (videoId) {
-        setSelectedVideoId(videoId);
-        setCurrentView('video-detail');
-        return;
-      }
-    }
-    if (path.startsWith('/videos')) {
-      setCurrentView('videos');
+
+    if (view === 'admin-content-detail' && params?.submissionId) {
+      setSelectedAdminSubmissionId(params.submissionId);
+      setCurrentView('admin-content-detail');
       return;
     }
-    if (path.startsWith('/lessons/')) {
-      const lessonId = path.replace('/lessons/', '').split('/')[0];
-      const lessonExists = units.some(unit => unit.id === lessonId);
+
+    if (view === 'video-detail' && params?.videoId) {
+      setSelectedVideoId(params.videoId);
+      setCurrentView('video-detail');
+      return;
+    }
+
+    if (view === 'lesson-detail' && params?.lessonId) {
+      const lessonExists = units.some(unit => unit.id === params.lessonId);
       if (lessonExists) {
-        setSelectedLessonId(lessonId);
+        setSelectedLessonId(params.lessonId);
         setCurrentView('lesson-detail');
         return;
       }
+      setCurrentView('not-found');
+      return;
     }
-    if (path.startsWith('/courses/units/')) {
-      const unitId = path.replace('/courses/units/', '').split('/')[0];
-      const unitExists = units.some(unit => unit.id === unitId);
+
+    if (view === 'course-detail' && params?.unitId) {
+      const unitExists = units.some(unit => unit.id === params.unitId);
       if (unitExists) {
-        setSelectedUnitId(unitId);
+        setSelectedUnitId(params.unitId);
         setCurrentView('course-detail');
         return;
       }
-    }
-    if (path.startsWith('/courses/units')) {
-      setCurrentView('repository');
+      setCurrentView('not-found');
       return;
     }
-    if (path.startsWith('/courses')) {
-      setCurrentView('courses');
-      return;
-    }
-    if (path.startsWith('/dashboard')) {
-      setCurrentView('dashboard');
-      return;
-    }
-    if (path.startsWith('/playlists')) {
-      setCurrentView('playlists');
-      return;
-    }
-    if (path.startsWith('/contributors')) {
-      setCurrentView('contributors');
-      return;
-    }
-    if (path === '/profile') {
-      setCurrentView('profile');
-      return;
-    }
-    // Institutional pages: /manifesto, /sobre, /comunidade, /roadmap, /infraestrutura, /como-contribuir
-    const INSTITUTIONAL_SLUGS = ['manifesto', 'sobre', 'comunidade', 'roadmap', 'infraestrutura', 'como-contribuir', 'sobre-marcelo', 'sobre-ualg', 'sobre-open2', 'modelo-academico'];
-    const slug = path.replace('/', '');
-    if (INSTITUTIONAL_SLUGS.includes(slug)) {
-      setSelectedPageSlug(slug);
+
+    if (view === 'institutional-page' && params?.pageSlug) {
+      setSelectedPageSlug(params.pageSlug);
       setCurrentView('institutional-page');
       return;
     }
-    if (path === '/' || path === '') {
-      setCurrentView('home');
-      return;
-    }
-    setCurrentView('not-found');
+
+    setCurrentView(view);
   };
 
   useEffect(() => {

--- a/frontend/app/router/routes.test.ts
+++ b/frontend/app/router/routes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { fromPath, ROUTES, toPath, type View } from './routes';
+
+const SAMPLE_PARAMS: Record<View, Record<string, string>> = {
+  'home': {}, 'not-found': {}, 'courses': {}, 'repository': {}, 'paths': {}, 'contributors': {},
+  'course-detail': { unitId: 'u1' }, 'lesson-detail': { lessonId: 'l1' }, 'playlists': {}, 'dashboard': {},
+  'institutional-page': { pageSlug: 'manifesto' }, 'videos': {}, 'video-detail': { videoId: 'v1' }, 'profile': {},
+  'student-dashboard': {}, 'student-my-courses': {}, 'student-progress': {}, 'student-history': {},
+  'curator-apply': {}, 'curator-submit': {}, 'curator-submissions': {}, 'curator-channel-pipeline': {},
+  'curator-admin-review': {}, 'curator-channel-curation': {}, 'admin-dashboard': {}, 'admin-contents': {},
+  'admin-content-detail': { submissionId: 's1' }, 'admin-curators': {}, 'blog': {}, 'blog-post': { blogSlug: 'hello' },
+};
+
+describe('routes registry round-trip', () => {
+  it('covers all defined routes with view -> path -> view consistency', () => {
+    for (const route of ROUTES) {
+      const path = toPath(route.view, SAMPLE_PARAMS[route.view]);
+      const parsed = fromPath(path);
+      expect(parsed.view).toBe(route.view);
+    }
+  });
+
+  it('resolves unknown routes to not-found', () => {
+    expect(fromPath('/definitely/unknown')).toEqual({ view: 'not-found' });
+  });
+});

--- a/frontend/app/router/routes.ts
+++ b/frontend/app/router/routes.ts
@@ -1,0 +1,97 @@
+export type View =
+  | 'home'
+  | 'not-found'
+  | 'courses'
+  | 'repository'
+  | 'paths'
+  | 'contributors'
+  | 'course-detail'
+  | 'lesson-detail'
+  | 'playlists'
+  | 'dashboard'
+  | 'institutional-page'
+  | 'videos'
+  | 'video-detail'
+  | 'profile'
+  | 'student-dashboard'
+  | 'student-my-courses'
+  | 'student-progress'
+  | 'student-history'
+  | 'curator-apply'
+  | 'curator-submit'
+  | 'curator-submissions'
+  | 'curator-channel-pipeline'
+  | 'curator-admin-review'
+  | 'curator-channel-curation'
+  | 'admin-dashboard'
+  | 'admin-contents'
+  | 'admin-content-detail'
+  | 'admin-curators'
+  | 'blog'
+  | 'blog-post';
+
+export type RouteAccess = 'public' | 'private' | 'editor' | 'admin';
+
+type RouteParams = {
+  unitId?: string | null;
+  lessonId?: string | null;
+  videoId?: string | null;
+  blogSlug?: string | null;
+  pageSlug?: string | null;
+  submissionId?: string | null;
+};
+
+type RouteMatch = { view: View; params?: RouteParams };
+
+type RouteDef = {
+  view: View;
+  template: string;
+  access: RouteAccess;
+  toPath: (params?: RouteParams) => string;
+  match: (path: string) => RouteMatch | null;
+};
+
+const INSTITUTIONAL_SLUGS = new Set(['manifesto', 'sobre', 'comunidade', 'roadmap', 'infraestrutura', 'como-contribuir', 'sobre-marcelo', 'sobre-ualg', 'sobre-open2', 'modelo-academico']);
+
+export const ROUTES: RouteDef[] = [
+  { view: 'home', template: '/', access: 'public', toPath: () => '/', match: (p) => p === '/' ? { view: 'home' } : null },
+  { view: 'courses', template: '/courses', access: 'public', toPath: () => '/courses', match: (p) => p === '/courses' ? { view: 'courses' } : null },
+  { view: 'repository', template: '/courses/units', access: 'public', toPath: () => '/courses/units', match: (p) => p === '/courses/units' ? { view: 'repository' } : null },
+  { view: 'course-detail', template: '/courses/units/:unitId', access: 'public', toPath: (x) => x?.unitId ? `/courses/units/${x.unitId}` : '/courses/units', match: (p) => p.startsWith('/courses/units/') ? ({ view: 'course-detail', params: { unitId: p.replace('/courses/units/', '').split('/')[0] } }) : null },
+  { view: 'lesson-detail', template: '/lessons/:lessonId', access: 'public', toPath: (x) => x?.lessonId ? `/lessons/${x.lessonId}` : '/courses/units', match: (p) => p.startsWith('/lessons/') ? ({ view: 'lesson-detail', params: { lessonId: p.replace('/lessons/', '').split('/')[0] } }) : null },
+  { view: 'videos', template: '/videos', access: 'public', toPath: () => '/videos', match: (p) => p === '/videos' ? { view: 'videos' } : null },
+  { view: 'video-detail', template: '/videos/:videoId', access: 'public', toPath: (x) => x?.videoId ? `/videos/${x.videoId}` : '/videos', match: (p) => p.startsWith('/videos/') ? ({ view: 'video-detail', params: { videoId: p.replace('/videos/', '').split('/')[0] } }) : null },
+  { view: 'dashboard', template: '/dashboard', access: 'private', toPath: () => '/dashboard', match: (p) => p === '/dashboard' ? { view: 'dashboard' } : null },
+  { view: 'playlists', template: '/playlists', access: 'public', toPath: () => '/playlists', match: (p) => p === '/playlists' ? { view: 'playlists' } : null },
+  { view: 'contributors', template: '/contributors', access: 'public', toPath: () => '/contributors', match: (p) => p === '/contributors' ? { view: 'contributors' } : null },
+  { view: 'profile', template: '/profile', access: 'private', toPath: () => '/profile', match: (p) => p === '/profile' ? { view: 'profile' } : null },
+  { view: 'institutional-page', template: '/:pageSlug', access: 'public', toPath: (x) => x?.pageSlug ? `/${x.pageSlug}` : '/', match: (p) => { const slug = p.replace('/', ''); return INSTITUTIONAL_SLUGS.has(slug) ? { view: 'institutional-page', params: { pageSlug: slug } } : null; } },
+  { view: 'student-dashboard', template: '/student/dashboard', access: 'private', toPath: () => '/student/dashboard', match: (p) => p === '/student/dashboard' ? { view: 'student-dashboard' } : null },
+  { view: 'student-my-courses', template: '/student/my-courses', access: 'private', toPath: () => '/student/my-courses', match: (p) => p === '/student/my-courses' ? { view: 'student-my-courses' } : null },
+  { view: 'student-progress', template: '/student/progress', access: 'private', toPath: () => '/student/progress', match: (p) => p === '/student/progress' ? { view: 'student-progress' } : null },
+  { view: 'student-history', template: '/student/history', access: 'private', toPath: () => '/student/history', match: (p) => p === '/student/history' ? { view: 'student-history' } : null },
+  { view: 'curator-apply', template: '/curator/apply', access: 'private', toPath: () => '/curator/apply', match: (p) => p === '/curator/apply' ? { view: 'curator-apply' } : null },
+  { view: 'curator-submit', template: '/curator/submit', access: 'editor', toPath: () => '/curator/submit', match: (p) => p === '/curator/submit' ? { view: 'curator-submit' } : null },
+  { view: 'curator-submissions', template: '/curator/submissions', access: 'private', toPath: () => '/curator/submissions', match: (p) => p === '/curator/submissions' ? { view: 'curator-submissions' } : null },
+  { view: 'curator-channel-pipeline', template: '/curator/channel-pipeline', access: 'private', toPath: () => '/curator/channel-pipeline', match: (p) => p === '/curator/channel-pipeline' ? { view: 'curator-channel-pipeline' } : null },
+  { view: 'curator-admin-review', template: '/curator/admin-review', access: 'admin', toPath: () => '/curator/admin-review', match: (p) => p === '/curator/admin-review' ? { view: 'curator-admin-review' } : null },
+  { view: 'curator-channel-curation', template: '/curator/channel-curation', access: 'admin', toPath: () => '/curator/channel-curation', match: (p) => p === '/curator/channel-curation' ? { view: 'curator-channel-curation' } : null },
+  { view: 'admin-dashboard', template: '/admin', access: 'admin', toPath: () => '/admin', match: (p) => p === '/admin' ? { view: 'admin-dashboard' } : null },
+  { view: 'admin-contents', template: '/admin/conteudos', access: 'admin', toPath: () => '/admin/conteudos', match: (p) => p === '/admin/conteudos' ? { view: 'admin-contents' } : null },
+  { view: 'admin-content-detail', template: '/admin/conteudos/:submissionId', access: 'admin', toPath: (x) => x?.submissionId ? `/admin/conteudos/${x.submissionId}` : '/admin/conteudos', match: (p) => p.startsWith('/admin/conteudos/') ? ({ view: 'admin-content-detail', params: { submissionId: p.replace('/admin/conteudos/', '').split('/')[0] } }) : null },
+  { view: 'admin-curators', template: '/admin/curadores', access: 'admin', toPath: () => '/admin/curadores', match: (p) => p === '/admin/curadores' ? { view: 'admin-curators' } : null },
+  { view: 'blog', template: '/blog', access: 'public', toPath: () => '/blog', match: (p) => p === '/blog' ? { view: 'blog' } : null },
+  { view: 'blog-post', template: '/blog/:blogSlug', access: 'public', toPath: (x) => x?.blogSlug ? `/blog/${x.blogSlug}` : '/blog', match: (p) => p.startsWith('/blog/') ? ({ view: 'blog-post', params: { blogSlug: p.replace('/blog/', '').split('/')[0] } }) : null },
+];
+
+export function toPath(view: View, params?: RouteParams): string {
+  return ROUTES.find((r) => r.view === view)?.toPath(params) ?? '/';
+}
+
+export function fromPath(pathname: string): RouteMatch {
+  for (const route of ROUTES) {
+    const matched = route.match(pathname);
+    if (matched) return matched;
+  }
+  return { view: 'not-found' };
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated route generation and parsing logic scattered in `App.tsx` by introducing a single source of truth for routes. 
- Make path generation and parsing deterministic and testable so `view -> path -> view` round-trips are reliable. 
- Preserve existing access policy intent (public/private/editor/admin) so role gating behavior remains enforceable centrally. 

### Description
- Added a centralized route registry at `frontend/app/router/routes.ts` exposing `ROUTES`, `toPath(view, params)`, and `fromPath(path)` with each route carrying `view`, `template`, `match` parser, and `access` metadata. 
- Replaced the ad-hoc if-chain `updateRoute` and `syncViewWithLocation` logic in `frontend/App.tsx` to delegate path construction and parsing to the new registry and kept unit/lesson existence checks for detail views. 
- Added comprehensive unit tests in `frontend/app/router/routes.test.ts` that assert round-trip consistency for every registered route and that unknown paths resolve to `not-found`. 

### Testing
- Ran unit tests with `cd frontend && pnpm test:unit` and observed all unit tests passing. 
- Built the frontend with `cd frontend && pnpm build` and the production build completed successfully. 
- Ran E2E suite with `cd frontend && pnpm test:e2e`; the Playwright run started but multiple E2E tests failed in this environment (not related to route registry unit tests) and require follow-up investigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006775432483229ea41edace5ea84d)